### PR TITLE
corrected CONTRIBUTING.md link in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You will need a Google Cloud project to use this project.
 Please see the README in the [setup-env/](https://github.com/GoogleCloudPlatform/generative-ai/setup-env) folder for information on using Colab notebooks and Vertex AI Workbench.
 
 ## Contributing
-Contributions welcome! See the [Contributing Guide](https://github.com/GoogleCloudPlatform/generative-ai/CONTRIBUTING.md).
+Contributions welcome! See the [Contributing Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
 
 ## Getting help
 Please use the [issues page](https://github.com/GoogleCloudPlatform/generative-ai/issues) to provide feedback or submit a bug report.


### PR DESCRIPTION
Reference to CONTRIBUTING.md file has wrong url in README.md, have corrected with correct URL. 
Original URL: https://github.com/GoogleCloudPlatform/generative-ai/CONTRIBUTING.md
Correct URL: https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md