### PR TITLE
Update intro_prompt_design.ipynb to be compatible with Colab runtime

### DIFF
--- a/language/intro_prompt_design.ipynb
+++ b/language/intro_prompt_design.ipynb
@@ -164,7 +164,14 @@
    "outputs": [],
    "source": [
     "# from google.colab import auth\n",
-    "# auth.authenticate_user()"
+    "# auth.authenticate_user()",
+    "\n",
+    "# auth.authenticate_user()\n",
+    "\n",
+    "# PROJECT = 'gcp-project-id'\n",
+    "# LOCATION = 'us-central1'\n",
+    "\n",
+    "# vertexai.init(project=PROJECT, location=LOCATION)"
    ]
   },
   {


### PR DESCRIPTION
I tried this notebook in Colab, and it is missing the step of setting up the GCP Project ID. This is one technique that could be used, but you might have another preferred method. Let me know what you think!