### PR TITLE
Update intro_palm_api.ipynb

### DIFF
--- a/language/intro_palm_api.ipynb
+++ b/language/intro_palm_api.ipynb
@@ -199,7 +199,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install google-cloud-aiplatform --upgrade --user"
+    "!pip install google-cloud-aiplatform --upgrade "shapely<2.0.0"
    ]
   },
   {


### PR DESCRIPTION
Fix the following 2 errors when importing vertex ai.
1) https://github.com/GoogleCloudPlatform/generative-ai/issues/107
2) ContextualVersionConflict: (shapely 2.0.1 ([/usr/local/lib/python3](https://colab.sandbox.google.com/drive/1TYlx3F_n95LXrHBRVsoyUW9yWoZYQ4NF?resourcekey=0-Buu1roWyVuyvLNf6dbN-QQ#).10/dist-packages), Requirement.parse('shapely<2.0.0'), {'google-cloud-aiplatform'})