### PR TITLE
Updated Retriever class to support new API response fields

### DIFF
--- a/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
+++ b/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
@@ -2,13 +2,13 @@
 # pylint: disable=no-self-argument
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from google.cloud import discoveryengine_v1beta
 from google.cloud.discoveryengine_v1beta.services.search_service import pagers
 from langchain.schema import BaseRetriever, Document
 from langchain.utils import get_from_dict_or_env
-from pydantic import BaseModel, Extra, root_validator, Field
+from pydantic import BaseModel, Extra, Field, root_validator
 
 
 class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
@@ -20,7 +20,7 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
     search_engine_id: str
     serving_config_id: str = "default_config"
     location_id: str = "global"
-    filter: str = None
+    filter: Optional[str] = None
     get_extractive_answers: bool = False
     max_documents: int = Field(default=5, ge=1, le=100)
     max_extractive_answer_count: int = Field(default=1, ge=1, le=5)
@@ -41,7 +41,7 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
         try:
-            from google.cloud import discoveryengine_v1beta
+            from google.cloud import discoveryengine_v1beta  # noqa: F401
         except ImportError:
             raise ImportError(
                 "google.cloud.discoveryengine is not installed. "
@@ -89,9 +89,11 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
                     else:
                         metadata["source"] = f"{doc_data.get('link', '')}"
                     metadata["id"] = result.document.id
-                    documents.append(Document(
-                        page_content=chunk.get("content", ""), metadata=metadata
-                    ))
+                    documents.append(
+                        Document(
+                            page_content=chunk.get("content", ""), metadata=metadata
+                        )
+                    )
 
         return documents
 

--- a/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
+++ b/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
@@ -8,20 +8,24 @@ from google.cloud import discoveryengine_v1beta
 from google.cloud.discoveryengine_v1beta.services.search_service import pagers
 from langchain.schema import BaseRetriever, Document
 from langchain.utils import get_from_dict_or_env
-from pydantic import BaseModel, Extra, root_validator
+from pydantic import BaseModel, Extra, root_validator, Field
 
 
 class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
-    """Wrapper around Google Cloud Enterprise Search."""
+    """Wrapper around Google Cloud Enterprise Search Service API."""
 
-    client: Any = None  #: :meta private:
-    serving_config: Any = None  #: :meta private:Any
-    content_search_spec: Any = None  #: :meta private:Any
-    project_id: str = ""
-    search_engine_id: str = ""
+    _client: Any
+    _serving_config: Any
+    project_id: str
+    search_engine_id: str
     serving_config_id: str = "default_config"
     location_id: str = "global"
-    max_snippet_count: int = 3
+    filter: str = None
+    get_extractive_answers: bool = False
+    max_documents: int = Field(default=5, ge=1, le=100)
+    max_extractive_answer_count: int = Field(default=1, ge=1, le=5)
+    max_extractive_segment_count: int = Field(default=1, ge=1, le=1)
+    query_expansion_condition: int = Field(default=1, ge=0, le=2)
     credentials: Any = None
     "The default custom credentials (google.auth.credentials.Credentials) to use "
     "when making API calls. If not provided, credentials will be ascertained from "
@@ -32,6 +36,7 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
 
         extra = Extra.forbid
         arbitrary_types_allowed = True
+        underscore_attrs_are_private = True
 
     @root_validator()
     def validate_environment(cls, values: Dict) -> Dict:
@@ -43,40 +48,24 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
                 "Please install it with pip install google-cloud-discoveryengine"
             )
 
-        project_id = get_from_dict_or_env(values, "project_id", "PROJECT_ID")
-        values["project_id"] = project_id
-        search_engine_id = get_from_dict_or_env(
+        values["project_id"] = get_from_dict_or_env(values, "project_id", "PROJECT_ID")
+        values["search_engine_id"] = get_from_dict_or_env(
             values, "search_engine_id", "SEARCH_ENGINE_ID"
         )
-        values["search_engine_id"] = search_engine_id
-        location_id = get_from_dict_or_env(values, "location_id", "LOCATION_ID")
-        values["location_id"] = location_id
-        max_snippet_count = get_from_dict_or_env(
-            values, "max_snippet_count", "MAX_SNIPPET_COUNT"
-        )
-        values["max_snippet_count"] = max_snippet_count
-
-        client = discoveryengine_v1beta.SearchServiceClient(
-            credentials=values["credentials"]
-        )
-        values["client"] = client
-
-        serving_config = client.serving_config_path(
-            project=project_id,
-            location=location_id,
-            data_store=search_engine_id,
-            serving_config=values["serving_config_id"],
-        )
-        values["serving_config"] = serving_config
-
-        content_search_spec = {
-            "snippet_spec": {
-                "max_snippet_count": max_snippet_count,
-            }
-        }
-        values["content_search_spec"] = content_search_spec
 
         return values
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._client = discoveryengine_v1beta.SearchServiceClient(
+            credentials=self.credentials
+        )
+        self._serving_config = self._client.serving_config_path(
+            project=self.project_id,
+            location=self.location_id,
+            data_store=self.search_engine_id,
+            serving_config=self.serving_config_id,
+        )
 
     def _convert_search_response(
         self, search_results: pagers.SearchPager
@@ -85,27 +74,69 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
         documents = []
         for result in search_results:
             if hasattr(result.document, "derived_struct_data"):
+                if hasattr(result.document, "struct_data"):
+                    metadata = result.document.struct_data
+                else:
+                    metadata = {}
                 doc_data = result.document.derived_struct_data
-                for snippet in doc_data.get("snippets", []):
-                    documents.append(
-                        Document(
-                            page_content=snippet.get("snippet", ""),
-                            metadata={
-                                "source": f"{doc_data.get('link', '')}:{snippet.get('pageNumber', '')}",
-                                "id": result.document.id,
-                            },
-                        )
+                chunk_type = (
+                    "extractive_answers"
+                    if self.get_extractive_answers
+                    else "extractive_segments"
+                )
+                for chunk in doc_data.get(chunk_type, []):
+                    if chunk_type == "extractive_answers":
+                        metadata[
+                            "source"
+                        ] = f"{doc_data.get('link', '')}:{chunk.get('pageNumber', '')}"
+                    else:
+                        metadata["source"] = f"{doc_data.get('link', '')}"
+                    metadata["id"] = result.document.id
+                    document = Document(
+                        page_content=chunk.get("content", ""), metadata=metadata
                     )
+                    documents.append(document)
+
         return documents
+
+    def _create_search_request(
+        self, query: str
+    ) -> discoveryengine_v1beta.SearchRequest:
+        """Prepares a SearchRequest object."""
+
+        if self.get_extractive_answers:
+            content_search_spec = {
+                "extractive_content_spec": {
+                    "max_extractive_answer_count": self.max_extractive_answer_count,
+                }
+            }
+        else:
+            content_search_spec = {
+                "extractive_content_spec": {
+                    "max_extractive_segment_count": self.max_extractive_segment_count,
+                }
+            }
+
+        query_expansion_spec = {
+            "condition": self.query_expansion_condition,
+        }
+
+        request = discoveryengine_v1beta.SearchRequest(
+            query=query,
+            filter=self.filter,
+            serving_config=self._serving_config,
+            page_size=self.max_documents,
+            content_search_spec=content_search_spec,
+            query_expansion_spec=query_expansion_spec,
+        )
+
+        return request
 
     def get_relevant_documents(self, query: str) -> List[Document]:
         """Get documents relevant for a query."""
-        request = discoveryengine_v1beta.SearchRequest(
-            query=query,
-            serving_config=self.serving_config,
-            content_search_spec=self.content_search_spec,
-        )
-        response = self.client.search(request)
+
+        request = self._create_search_request(query)
+        response = self._client.search(request)
         documents = self._convert_search_response(response.results)
 
         return documents

--- a/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
+++ b/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
@@ -89,10 +89,9 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
                     else:
                         metadata["source"] = f"{doc_data.get('link', '')}"
                     metadata["id"] = result.document.id
-                    document = Document(
+                    documents.append(Document(
                         page_content=chunk.get("content", ""), metadata=metadata
-                    )
-                    documents.append(document)
+                    ))
 
         return documents
 

--- a/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
+++ b/gen-app-builder/retrieval-augmented-generation/utils/retriever.py
@@ -74,10 +74,7 @@ class EnterpriseSearchRetriever(BaseRetriever, BaseModel):
         documents = []
         for result in search_results:
             if hasattr(result.document, "derived_struct_data"):
-                if hasattr(result.document, "struct_data"):
-                    metadata = result.document.struct_data
-                else:
-                    metadata = {}
+                metadata = getattr(result.document, "struct_data", {})
                 doc_data = result.document.derived_struct_data
                 chunk_type = (
                     "extractive_answers"


### PR DESCRIPTION
We recently updated our Enterprise Search response class to replace the `snippets` field with `extractive_segments` and `extractive_answers` which are specifically designed for consumption by LLMs. This was a breaking change, fixed by this PR