### PR TITLE
Include full GCS path for gsutil command

### DIFF
--- a/language/examples/document-qa/question_answering_documents_langchain_matching_engine.ipynb
+++ b/language/examples/document-qa/question_answering_documents_langchain_matching_engine.ipynb
@@ -457,7 +457,7 @@
    "source": [
     "ME_REGION = \"us-central1\"\n",
     "ME_INDEX_NAME = f\"{PROJECT_ID}-me-index\"  # @param {type:\"string\"}\n",
-    "ME_EMBEDDING_DIR = f\"{PROJECT_ID}-me-bucket\"  # @param {type:\"string\"}\n",
+    "ME_EMBEDDING_DIR = f\"gs://{PROJECT_ID}-me-bucket\"  # @param {type:\"string\"}\n",
     "ME_DIMENSIONS = 768  # when using Vertex PaLM Embedding"
    ]
   },


### PR DESCRIPTION
Including ""gs://" syntax. Else it throws the following error..

_CommandException: "mb" command does not support "file://" URLs. Did you mean to use a gs:// URL?_