### PR TITLE
Added authentication for other development environments in jupyter notebooks

### DIFF
--- a/language/getting-started/intro_palm_api.ipynb
+++ b/language/getting-started/intro_palm_api.ipynb
@@ -189,7 +189,7 @@
     "id": "j7UyNVSiyQ96"
    },
    "source": [
-    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+    "**Colab only:** Run the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
    ]
   },
   {
@@ -200,11 +200,11 @@
    },
    "outputs": [],
    "source": [
-    "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "import IPython\n",
     "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
    ]
   },
   {
@@ -214,8 +214,9 @@
    },
    "source": [
     "### Authenticating your notebook environment\n",
-    "* If you are using **Colab** to run this notebook, uncomment the cell below and continue.\n",
-    "* If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
+    "\n",
+    "- If you are using **Colab** to run this notebook, run the cell below and continue.\n",
+    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
    ]
   },
   {
@@ -226,17 +227,25 @@
    },
    "outputs": [],
    "source": [
-    "# from google.colab import auth\n",
-    "# auth.authenticate_user()"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "GckO4EysV5BT"
-   },
+   "metadata": {},
    "source": [
-    "## Vertex AI PaLM API models"
+    "- If you are running this notebook in a local development environment:\n",
+    "  - Install the [Google Cloud SDK](https://cloud.google.com/sdk).\n",
+    "  - Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):\n",
+    "\n",
+    "    ```bash\n",
+    "    gcloud auth application-default login\n",
+    "    ```"
    ]
   },
   {
@@ -245,6 +254,8 @@
     "id": "BDYqwDmTLgEy"
    },
    "source": [
+    "## Vertex AI PaLM API models\n",
+    "\n",
     "The Vertex AI PaLM API enables you to test, customize, and deploy instances of Google’s large language models (LLM) called as PaLM,  so that you can leverage the capabilities of PaLM in your applications.\n",
     "\n",
     "### Model naming scheme\n",
@@ -289,7 +300,7 @@
     "id": "Vnq2kIV8yQ97"
    },
    "source": [
-    "**Colab only:** Uncomment the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this.  "
+    "**Colab only:** Run the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this."
    ]
   },
   {
@@ -300,10 +311,13 @@
    },
    "outputs": [],
    "source": [
-    "# import vertexai\n",
+    "import vertexai\n",
     "\n",
-    "# PROJECT_ID = \"\"  # @param {type:\"string\"}\n",
-    "# vertexai.init(project=PROJECT_ID, location=\"us-central1\")"
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Initialize Vertex AI SDK\n",
+    "vertexai.init(project=PROJECT_ID, location=REGION)"
    ]
   },
   {

--- a/language/orchestration/langchain/intro_langchain_palm_api.ipynb
+++ b/language/orchestration/langchain/intro_langchain_palm_api.ipynb
@@ -176,7 +176,7 @@
     "id": "d3fd2805"
    },
    "source": [
-    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top.\n"
+    "**Colab only:** Run the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top.\n"
    ]
   },
   {
@@ -187,11 +187,11 @@
    },
    "outputs": [],
    "source": [
-    "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "import IPython\n",
     "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
    ]
   },
   {
@@ -202,8 +202,8 @@
    "source": [
     "### Authenticating your notebook environment\n",
     "\n",
-    "- If you are using **Colab** to run this notebook, uncomment the cell below and continue.\n",
-    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env).\n"
+    "- If you are using **Colab** to run this notebook, run the cell below and continue.\n",
+    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
    ]
   },
   {
@@ -214,8 +214,25 @@
    },
    "outputs": [],
    "source": [
-    "# from google.colab import auth as google_auth\n",
-    "# google_auth.authenticate_user()"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- If you are running this notebook in a local development environment:\n",
+    "  - Install the [Google Cloud SDK](https://cloud.google.com/sdk).\n",
+    "  - Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):\n",
+    "\n",
+    "    ```bash\n",
+    "    gcloud auth application-default login\n",
+    "    ```"
    ]
   },
   {
@@ -229,25 +246,24 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "89d2e5b70afd"
-   },
+   "metadata": {},
    "source": [
-    "**Colab only:** Uncomment the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this.\n"
+    "**Colab only:** Run the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "e62a5503"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# import vertexai\n",
+    "import vertexai\n",
     "\n",
-    "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "# vertexai.init(project=PROJECT_ID, location=\"us-central1\")"
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
+    "\n",
+    "# Initialize Vertex AI SDK\n",
+    "vertexai.init(project=PROJECT_ID, location=REGION)"
    ]
   },
   {

--- a/language/prompts/intro_prompt_design.ipynb
+++ b/language/prompts/intro_prompt_design.ipynb
@@ -124,7 +124,7 @@
     "id": "cebd6983cbad"
    },
    "source": [
-    "**Colab only:** Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+    "**Colab only:** Run the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
    ]
   },
   {
@@ -149,8 +149,9 @@
    },
    "source": [
     "### Authenticating your notebook environment\n",
-    "* If you are using **Colab** to run this notebook, uncomment the cell below and continue.\n",
-    "* If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
+    "\n",
+    "- If you are using **Colab** to run this notebook, run the cell below and continue.\n",
+    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
    ]
   },
   {
@@ -161,9 +162,25 @@
    },
    "outputs": [],
    "source": [
-    "from google.colab import auth\n",
+    "import sys\n",
     "\n",
-    "auth.authenticate_user()"
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- If you are running this notebook in a local development environment:\n",
+    "  - Install the [Google Cloud SDK](https://cloud.google.com/sdk).\n",
+    "  - Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):\n",
+    "\n",
+    "    ```bash\n",
+    "    gcloud auth application-default login\n",
+    "    ```"
    ]
   },
   {
@@ -181,7 +198,7 @@
     "id": "ue7q-YO3Scpp"
    },
    "source": [
-    "**Colab only:** Uncomment the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this.  "
+    "**Colab only:** Run the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this."
    ]
   },
   {
@@ -194,8 +211,10 @@
    "source": [
     "import vertexai\n",
     "\n",
-    "PROJECT_ID = \"<PROJECT-ID>\"  # @param {type:\"string\"}\n",
-    "vertexai.init(project=PROJECT_ID, location=\"us-central1\")"
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
+    "\n",
+    "vertexai.init(project=PROJECT_ID, location=REGION)"
    ]
   },
   {

--- a/language/use-cases/document-qa/question_answering_documents_langchain.ipynb
+++ b/language/use-cases/document-qa/question_answering_documents_langchain.ipynb
@@ -179,7 +179,7 @@
     "id": "yStiAHorWE3Q"
    },
    "source": [
-    "***Colab only***: Uncomment the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+    "***Colab only***: Run the following cell to restart the kernel or use the button to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
    ]
   },
   {
@@ -191,10 +191,10 @@
    "outputs": [],
    "source": [
     "# Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
+    "import IPython\n",
     "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
    ]
   },
   {
@@ -204,8 +204,9 @@
    },
    "source": [
     "### Authenticating your notebook environment\n",
-    "* If you are using **Colab** to run this notebook, uncomment the cell below and continue.\n",
-    "* If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
+    "\n",
+    "- If you are using **Colab** to run this notebook, run the cell below and continue.\n",
+    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
    ]
   },
   {
@@ -216,9 +217,41 @@
    },
    "outputs": [],
    "source": [
-    "# from google.colab import auth\n",
+    "import sys\n",
     "\n",
-    "# auth.authenticate_user()"
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- If you are running this notebook in a local development environment:\n",
+    "  - Install the [Google Cloud SDK](https://cloud.google.com/sdk).\n",
+    "  - Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):\n",
+    "\n",
+    "    ```bash\n",
+    "    gcloud auth application-default login\n",
+    "    ```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "960505627ddf"
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Colab only:** Run the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this."
    ]
   },
   {
@@ -229,21 +262,12 @@
    },
    "outputs": [],
    "source": [
-    "# PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "# REGION = \"us-central1\"\n",
+    "import vertexai\n",
     "\n",
-    "# import vertexai\n",
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"\n",
     "\n",
-    "# vertexai.init(project=PROJECT_ID, location=REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "960505627ddf"
-   },
-   "source": [
-    "### Import libraries"
+    "vertexai.init(project=PROJECT_ID, location=REGION)"
    ]
   },
   {
@@ -269,7 +293,7 @@
     "from langchain.vectorstores import Chroma\n",
     "\n",
     "warnings.filterwarnings(\"ignore\")\n",
-    "# restart python kernal if issues with langchain import."
+    "# restart python kernel if issues with langchain import."
    ]
   },
   {

--- a/language/use-cases/document-qa/question_answering_documents_langchain_matching_engine.ipynb
+++ b/language/use-cases/document-qa/question_answering_documents_langchain_matching_engine.ipynb
@@ -253,9 +253,22 @@
     "import sys\n",
     "\n",
     "if \"google.colab\" in sys.modules:\n",
-    "    from google.colab import auth as google_auth\n",
+    "    from google.colab import auth\n",
     "\n",
-    "    google_auth.authenticate_user()"
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "- If you are running this notebook in a local development environment:\n",
+    "  - Install the [Google Cloud SDK](https://cloud.google.com/sdk).\n",
+    "  - Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):\n",
+    "\n",
+    "    ```bash\n",
+    "    gcloud auth application-default login\n",
+    "    ```"
    ]
   },
   {

--- a/language/use-cases/document-summarization/summarization_large_documents_langchain.ipynb
+++ b/language/use-cases/document-summarization/summarization_large_documents_langchain.ipynb
@@ -150,7 +150,7 @@
     "id": "jWwtjLV5TY6H"
    },
    "source": [
-    "**Colab only**: Uncomment the following cell to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
+    "**Colab only**: Run the following cell to restart the kernel. For Vertex AI Workbench you can restart the terminal using the button on top."
    ]
   },
   {
@@ -161,11 +161,11 @@
    },
    "outputs": [],
    "source": [
-    "# # Automatically restart kernel after installs so that your environment can access the new packages\n",
-    "# import IPython\n",
+    "# Automatically restart kernel after installs so that your environment can access the new packages\n",
+    "import IPython\n",
     "\n",
-    "# app = IPython.Application.instance()\n",
-    "# app.kernel.do_shutdown(True)"
+    "app = IPython.Application.instance()\n",
+    "app.kernel.do_shutdown(True)"
    ]
   },
   {
@@ -175,8 +175,9 @@
    },
    "source": [
     "### Authenticating your notebook environment\n",
-    "* If you are using **Colab** to run this notebook, uncomment the cell below and continue.\n",
-    "* If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
+    "\n",
+    "- If you are using **Colab** to run this notebook, run the cell below and continue.\n",
+    "- If you are using **Vertex AI Workbench**, check out the setup instructions [here](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/setup-env)."
    ]
   },
   {
@@ -187,8 +188,28 @@
    },
    "outputs": [],
    "source": [
-    "# from google.colab import auth\n",
-    "# auth.authenticate_user()"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    from google.colab import auth\n",
+    "\n",
+    "    auth.authenticate_user()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "n5fXfvzhTkYN"
+   },
+   "source": [
+    "### Import libraries"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Colab only:** Run the following cell to initialize the Vertex AI SDK. For Vertex AI Workbench, you don't need to run this."
    ]
   },
   {
@@ -199,21 +220,12 @@
    },
    "outputs": [],
    "source": [
-    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
-    "REGION = \"us-central1\"\n",
-    "\n",
     "import vertexai\n",
     "\n",
+    "PROJECT_ID = \"[your-project-id]\"  # @param {type:\"string\"}\n",
+    "REGION = \"us-central1\"  # @param {type:\"string\"}\n",
+    "\n",
     "vertexai.init(project=PROJECT_ID, location=REGION)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "n5fXfvzhTkYN"
-   },
-   "source": [
-    "### Import libraries"
    ]
   },
   {

--- a/setup-env/README.md
+++ b/setup-env/README.md
@@ -58,6 +58,16 @@ After launching the notebook instance, you can clone this repository in your Jup
 git clone https://github.com/GoogleCloudPlatform/generative-ai.git
 ```
 
+#### Local development
+
+- Install the [Google Cloud SDK](https://cloud.google.com/sdk).
+
+- Obtain authentication credentials. Create local credentials by running the following command and following the oauth2 flow (read more about the command [here](https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login)):
+
+  ```bash
+  gcloud auth application-default login
+  ```
+
 ## Python library
 
 Install the latest Python SDK:


### PR DESCRIPTION
In Jupiter notebooks tutorial examples [https://cloud.google.com/vertex-ai/docs/generative-ai/learn-resources](https://cloud.google.com/vertex-ai/docs/generative-ai/learn-resources) I was not able to authenticate in my local development environment. 
Current option was only for colab and workbench.

Found solution using google.oauth2 and service_account.

So I added commented authentication option for "other development environments" to jupyter notebooks tutorials.