### PR TITLE
fix: Search Web App - Change Image Search to allow text queries

### DIFF
--- a/search/web-app/README.md
+++ b/search/web-app/README.md
@@ -78,8 +78,8 @@ Additional features include how to search the public Cloud Knowledge Graph using
 
 4. Configure Image Search
 
-   - Follow the instructions in the documentation to [enable image search](https://cloud.google.com/generative-ai-app-builder/docs/image-search#enable-advanced) for a search engine.
-   - This feature is in early access and requires separate allowlisting from the rest of Vertex AI Search in order to use.
+   - Follow the instructions in the documentation to [enable image search](https://cloud.google.com/generative-ai-app-builder/docs/image-search#enable-advanced) for a website search engine.
+      - NOTE: You must enable [Advanced Website Indexing](https://cloud.google.com/generative-ai-app-builder/docs/about-advanced-features#advanced-website-indexing) which requires [domain verification](https://cloud.google.com/generative-ai-app-builder/docs/domain-verification).
    - Add the datastore id for your search engine to `IMAGE_SEARCH_DATASTORE_IDs` in `consts.py`.
 
 5. Deploy the Cloud Run app in your project.

--- a/search/web-app/templates/image-search.html
+++ b/search/web-app/templates/image-search.html
@@ -53,8 +53,8 @@
       <h3></h3>
       <p>
         Search the
-        <a href="https://shop.googlemerchandisestore.com/">Google Merchandise Store</a> by providing
-        an image URL or file to find similar matches.
+        <a href="https://shop.googlemerchandisestore.com/">Google Merchandise Store</a> by providing a text query,
+        an image URL, or image file to find similar matches.
       </p>
     </section>
     <main id="active-area">
@@ -69,7 +69,7 @@
           <div class="mdc-notched-outline">
             <div class="mdc-notched-outline__leading"></div>
             <div class="mdc-notched-outline__notch">
-              <label for="query-input" class="mdc-floating-label">Search by Image URL</label>
+              <label for="query-input" class="mdc-floating-label">Search by Text Query or Image URL</label>
             </div>
             <div class="mdc-notched-outline__trailing"></div>
           </div>


### PR DESCRIPTION
- This was supported before, but the description didn't say so. And a user got confused.
- Updated: https://vertex-ai-search.web.app/image-search