### PR TITLE
Switch to different Data Store Agent in sample chat app

### DIFF
--- a/conversation/chat-app/src/routes/+page.svelte
+++ b/conversation/chat-app/src/routes/+page.svelte
@@ -121,7 +121,7 @@
           src="https://www.gstatic.com/dialogflow-console/fast/df-messenger/prod/v1/df-messenger.js"></script>
         <df-messenger
           project-id="your-project-id"
-          agent-id="b42e8b15-64ef-45be-bdaf-cbf78541873b"
+          agent-id="001c3b48-8bc8-481b-adb1-cfa2e604d367"
           language-code="en"
           storage-option="none"
           class="drop-shadow-lg">


### PR DESCRIPTION
Fixes #263 by switching to a different Data Store Agent indexed on Google Store.

Fixed version of the app is deployed to https://vertex-ai-conversation.web.app/.