### PR TITLE
Fix TypeError in `get_embeddings_wrapper` by Ensuring List Input

### DIFF
--- a/vector-search/intro-textemb-vectorsearch.ipynb
+++ b/vector-search/intro-textemb-vectorsearch.ipynb
@@ -632,7 +632,7 @@
    "outputs": [],
    "source": [
     "# get embeddings for the question titles and add them as \"embedding\" column\n",
-    "df = df.assign(embedding=get_embeddings_wrapper(df.title))\n",
+    "df = df.assign(embedding=get_embeddings_wrapper(df.title.tolist()))\n",
     "df.head()"
    ]
   },


### PR DESCRIPTION
This pull request addresses a TypeError encountered in the `get_embeddings_wrapper` function within the Vertex AI vector search notebook. The error was caused by passing a pandas Series (df.title) directly to the function, which expects a list of strings.

Changes Made:
* Modified the call to `get_embeddings_wrapper` by converting the Series df.title to a list of strings using `tolist()`.
* This change ensures compatibility with the expected input format of the `model.get_embeddings` method, preventing the TypeError.


Verified that the `get_embeddings_wrapper` function now correctly processes a list of strings without throwing a TypeError, and confirmed that the embeddings are successfully retrieved and added to the DataFrame.
