### PR TITLE
Fixed access issue on the workbench side.

### DIFF
--- a/embeddings/vector-search-quickstart.ipynb
+++ b/embeddings/vector-search-quickstart.ipynb
@@ -248,6 +248,21 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "id": "HPd9NaBxn7ho"
+   },
+   "source": [
+    "### Set IAM permissions\n",
+    "\n",
+    "Also, we need to add access permissions to the default service account for using those services.\n",
+    "\n",
+    "- Go to [the IAM page](https://console.cloud.google.com/iam-admin/) in the Console\n",
+    "- Look for the principal for default compute service account. It should look like: `<project-number>-compute@developer.gserviceaccount.com`\n",
+    "- Click the edit button at right and click `ADD ANOTHER ROLE` to add `Vertex AI User`, `Storage Admin` and `Service Usage Admin` roles to the account.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
     "id": "8hIbkmLEn2Z_"
    },
    "source": [
@@ -264,7 +279,7 @@
    },
    "outputs": [],
    "source": [
-    "! gcloud services enable compute.googleapis.com aiplatform.googleapis.com storage.googleapis.com --project {PROJECT_ID}"
+    "! gcloud services enable compute.googleapis.com aiplatform.googleapis.com storage.googleapis.com --project \"{PROJECT_ID}\""
    ]
   },
   {
@@ -273,21 +288,6 @@
     "id": "08ylzWapgKBw"
    },
    "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "HPd9NaBxn7ho"
-   },
-   "source": [
-    "### Set IAM permissions\n",
-    "\n",
-    "Also, we need to add access permissions to the default service account for using those services.\n",
-    "\n",
-    "- Go to [the IAM page](https://console.cloud.google.com/iam-admin/) in the Console\n",
-    "- Look for the principal for default compute service account. It should look like: `<project-number>-compute@developer.gserviceaccount.com`\n",
-    "- Click the edit button at right and click `ADD ANOTHER ROLE` to add `Vertex AI User` and `Storage Admin` roles to the account.\n"
-   ]
   },
   {
    "cell_type": "markdown",
@@ -345,8 +345,8 @@
    },
    "outputs": [],
    "source": [
-    "! gsutil mb -l $LOCATION -p $PROJECT_ID $BUCKET_URI\n",
-    "! gsutil cp \"gs://github-repo/data/vs-quickstart/product-embs.json\" $BUCKET_URI"
+    "! gsutil mb -l \"$LOCATION\" -p \"$PROJECT_ID\" \"$BUCKET_URI\"\n",
+    "! gsutil cp \"gs://github-repo/data/vs-quickstart/product-embs.json\" \"$BUCKET_URI\""
    ]
   },
   {
@@ -651,7 +651,7 @@
     "my_index.delete()\n",
     "\n",
     "# delete Cloud Storage bucket\n",
-    "! gsutil rm -r {BUCKET_URI}"
+    "! gsutil rm -r \"{BUCKET_URI}\""
    ]
   },
   {


### PR DESCRIPTION
(As requested after talking to Kaz Sato)

1. Switched `IAM` and `gcloud` command
2. Added 'Service Usage Admin' to the IAM permissions. This should unblock the `gcloud services enable ...` command.
3. Added some double quotes around variables in shell to make it safer to run these commands (impredictable behaviour if empty string).

Note this is needed in Workbench mode, since it runs as your compute Service Account. If it runs as you, you dont need any IAM powerup.