### PR TITLE
Update intro-grounding.ipynb

### DIFF
--- a/language/grounding/intro-grounding.ipynb
+++ b/language/grounding/intro-grounding.ipynb
@@ -734,7 +734,7 @@
     "print(response.grounding_metadata)\n",
     "\n",
     "response = chat.send_message(\n",
-    "    PROMPT,\n",
+    "    PROMPT_FOLLOWUP,\n",
     "    grounding_source=grounding_source,\n",
     ")\n",
     "print(response.text)\n",


### PR DESCRIPTION
The "Chat session grounded in Vertex AI Search results" section used PROMPT twice instead of PROMPT and PROMPT_FOLLOWUP.