### PR TITLE
fixed broken link - codey_rag

### DIFF
--- a/language/code/code_retrieval_augmented_generation.ipynb
+++ b/language/code/code_retrieval_augmented_generation.ipynb
@@ -24,6 +24,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "XNPE46X8mJj4"
@@ -34,18 +35,18 @@
     "<table align=\"left\">\n",
     "\n",
     "  <td>\n",
-    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/generative-ai/blob/main/language/code/code-retrieval-augmented-generation.ipynb\">\n",
+    "    <a href=\"https://colab.research.google.com/github/GoogleCloudPlatform/generative-ai/blob/main/language/code/code_retrieval_augmented_generation.ipynb\">\n",
     "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
     "    </a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://github.com/GoogleCloudPlatform/generative-ai/blob/main/language/code/code-retrieval-augmented-generation.ipynb\">\n",
+    "    <a href=\"https://github.com/GoogleCloudPlatform/generative-ai/blob/main/language/code/code_retrieval_augmented_generation.ipynb\">\n",
     "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
     "      View on GitHub\n",
     "    </a>\n",
     "  </td>\n",
     "  <td>\n",
-    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/generative-ai/blob/main/language/code/code-retrieval-augmented-generation.ipynb\">\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/GoogleCloudPlatform/generative-ai/blob/main/language/code/code_retrieval_augmented_generation.ipynb\">\n",
     "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
     "      Open in Vertex AI Workbench\n",
     "    </a>\n",


### PR DESCRIPTION
url's were fixed for colab, github and workspace for codey RAG notebook.