### PR TITLE
Revert "GSP1209 - Notebook updates"

### DIFF
--- a/gemini/getting-started/intro_gemini_python.ipynb
+++ b/gemini/getting-started/intro_gemini_python.ipynb
@@ -148,18 +148,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "tFy3H3aPgx12",
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "! pip install protobuf==3.20.0"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "id": "R5Xep4W9lq-Z"


### PR DESCRIPTION
Reverts GoogleCloudPlatform/generative-ai#365

Based on @polong-lin 's comment in b/issues/322748639#comment6

> Actually pip install protobuf does not address the root cause, which I had fixed on Sunday: https://github.com/CloudVLab/terraform-lab-foundation/pull/353
>
> The User Managed Notebook Instance deployed in Qwiklabs was using an old VM image, which caused Python dependency conflicts with the latest version of Vertex AI. The notebook instance is deployed based on the terraform script here: https://github.com/CloudVLab/terraform-lab-foundation/tree/main/solutions/generative-ai/stable
>
> If a user uses a newer version of a User Managed Notebook instance or even a Workbench Instance, then users actually have no issue.
>
> Since the issue is limited to Qwiklabs due to the old image, I updated it as part of this PR: https://github.com/CloudVLab/terraform-lab-foundation/pull/353 so that the VM image for User-Managed Notebooks would be updated. This fix resolved the dependency issue, and this has since resolved the Qwiklab problem.
>
> My suggestion is that we retain the notebooks as they were (w/o installing protobuf), and that we revert this PR, which adds unnecessarily complexity and may break in the future: https://github.com/GoogleCloudPlatform/generative-ai/pull/365