### PR TITLE
[Gemini function calling] Simplify prompt in chat session to avoid multiple function calls

### DIFF
--- a/gemini/function-calling/intro_function_calling.ipynb
+++ b/gemini/function-calling/intro_function_calling.ipynb
@@ -909,7 +909,7 @@
    ],
    "source": [
     "prompt = \"\"\"\n",
-    "Where can I buy one near Mountain View, CA?\n",
+    "Is there a store in Mountain View, CA that I can visit to try it out?\n",
     "\"\"\"\n",
     "\n",
     "response = chat.send_message(prompt)\n",
@@ -954,7 +954,7 @@
     {
      "data": {
       "text/plain": [
-       "text: \" There is a store located at 1600 Amphitheatre Pkwy, Mountain View, CA 94043, US.\""
+       "text: \" Yes, there is a store in Mountain View, CA that you can visit to try out the Pixel 8 Pro. It is located at 1600 Amphitheatre Pkwy, Mountain View, CA 94043, US.\""
       ]
      },
      "execution_count": 17,
@@ -1112,9 +1112,9 @@
    "uri": "gcr.io/deeplearning-platform-release/workbench-notebooks:m113"
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel) (Local)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "conda-root-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1126,7 +1126,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Gemini will sometimes now return two or more subsequent function calls after a function response so that it can gather more information in a single conversation turn with the end user. This broke the simple example in the Gemini function calling notebook since (for the sake of simplicity) it assumes one function call per conversation turn.

```python
>>> response = chat.send_message(
>>>    Part.from_function_response(
>>>        name="place_order",
>>>        response={
>>>            "content": api_response,
>>>        },
>>>    ),
>>>)
>>>
>>>response.candidates[0].content.parts[0]

InvalidArgument: 400 Please ensure that function response turn comes immediately after a function call turn.
```

This PR simplifies one of the prompts to keep the conversation flow in the notebook on track and error-free for this walkthrough.