### PR TITLE
[Gemini function calling] Fix exception handling in app frontend code

### DIFF
--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -119,7 +119,7 @@ for message in st.session_state.messages:
         try:
             with st.expander("Function calls, parameters, and responses"):
                 st.markdown(message["backend_details"])
-        except ValueError:
+        except KeyError:
             pass
 
 if prompt := st.chat_input("Ask me about information in the database..."):


### PR DESCRIPTION
A tiny followup PR to #385 that uses the appropriate exception handling to check if intermediate function calling outputs exist for a given conversation turn. Fixes an uncaught exception when doing 2 or more conversation turns.

Updated app version is deployed at https://sql-talk-r5gdynozbq-uc.a.run.app/