### PR TITLE
fix: Modify prompt related to geocoding address in `intro_function_calling` notebook

### DIFF
--- a/gemini/function-calling/intro_function_calling.ipynb
+++ b/gemini/function-calling/intro_function_calling.ipynb
@@ -910,7 +910,7 @@
    ],
    "source": [
     "prompt = \"\"\"\n",
-    "I want to get the lat/lon coordinates for the following address:\n",
+    "I want to get the coordinates for the following address:\n",
     "1600 Amphitheatre Pkwy, Mountain View, CA 94043, US\n",
     "\"\"\"\n",
     "\n",


### PR DESCRIPTION
# Description

Modify the prompt in Intro to Function Calling notebook to avoid safety filters when geocoding address.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)