### PR TITLE
fix: Pin model version to `gemini-1.0-pro-001` for function calling notebooks

### DIFF
--- a/gemini/function-calling/function_calling_data_structures.ipynb
+++ b/gemini/function-calling/function_calling_data_structures.ipynb
@@ -267,7 +267,7 @@
       "outputs": [],
       "source": [
         "model = GenerativeModel(\n",
-        "    \"gemini-1.0-pro\", generation_config=GenerationConfig(temperature=0)\n",
+        "    \"gemini-1.0-pro-001\", generation_config=GenerationConfig(temperature=0)\n",
         ")"
       ]
     },

--- a/gemini/function-calling/intro_function_calling.ipynb
+++ b/gemini/function-calling/intro_function_calling.ipynb
@@ -390,7 +390,7 @@
    "outputs": [],
    "source": [
     "model = GenerativeModel(\n",
-    "    \"gemini-1.0-pro\",\n",
+    "    \"gemini-1.0-pro-001\",\n",
     "    generation_config=GenerationConfig(temperature=0),\n",
     "    tools=[retail_tool],\n",
     ")\n",

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -76,7 +76,7 @@ sql_query_tool = Tool(
 )
 
 model = GenerativeModel(
-    "gemini-1.0-pro",
+    "gemini-1.0-pro-001",
     generation_config={"temperature": 0},
     tools=[sql_query_tool],
 )


### PR DESCRIPTION
# Description

Updates Gemini Function Calling notebooks to pin `gemini-1.0-pro-001` for consistent model behavior.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)
