### PR TITLE
docs: update contributing flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,7 @@ body:
         Thanks for stopping by to let us know something could be better!
         **PLEASE READ**:
         - This repository is for [Generative AI with Vertex AI on Google Cloud](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview), not the [Google AI Gemini/PaLM APIs](https://ai.google.dev/)
-          - For issues with the Google AI Gemini API, refer to one of [these repositories](https://github.com/orgs/google/repositories?q=generative-ai) or the [Google Developers Community Discord `#gemini-api` channel](https://ai.google.dev/docs/discord).
+          - For issues with the Google AI Gemini API, refer to one of [these repositories](https://github.com/orgs/google/repositories?q=generative-ai) or the [Google Developers Community Discourse](https://discuss.ai.google.dev/).
         - If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
   - type: input
     id: file-name

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -10,7 +10,7 @@ body:
         Thanks for stopping by to let us know something could be better!
         **PLEASE READ**:
         - This repository is for [Generative AI with Vertex AI on Google Cloud](https://cloud.google.com/vertex-ai/docs/generative-ai/learn/overview), not the [Google AI Gemini/PaLM APIs](https://ai.google.dev/)
-          - For issues with the Google AI Gemini API, refer to one of [these repositories](https://github.com/orgs/google/repositories?q=generative-ai) or the [Google Developers Community Discord `#gemini-api` channel](https://ai.google.dev/docs/discord).
+          - For issues with the Google AI Gemini API, refer to one of [these repositories](https://github.com/orgs/google/repositories?q=generative-ai) or the [Google Developers Community Discourse](https://discuss.ai.google.dev/).
         - If you have a support contract with Google, please create an issue in the [support console](https://cloud.google.com/support/) instead of filing on GitHub. This will ensure a timely response.
   - type: textarea
     id: problem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,12 +74,10 @@ You may follow these steps to contribute:
 
 1. **Fork the official repository.** This will create a copy of the official repository in your own account.
 2. **Sync the branches.** This will ensure that your copy of the repository is up-to-date with the latest changes from the official repository.
-3. **Work on your forked repository's dev branch.** This is where you will make your changes to the code.
-4. **Commit your updates on your forked repository's dev branch.** This will save your changes to your copy of the repository.
+3. **Work on your forked repository's feature branch.** This is where you will make your changes to the code.
+4. **Commit your updates on your forked repository's feature branch.** This will save your changes to your copy of the repository.
 5. **Submit a pull request to the official repository's main branch.** This will request that your changes be merged into the official repository.
 6. **Resolve any lint errors.** This will ensure that your changes are formatted correctly.
-
-![image](https://storage.googleapis.com/github-repo/img/contributing/contributor-guide-diagram.jpg)
 
 Here are some additional things to keep in mind during the process:
 


### PR DESCRIPTION
# Description

* #383 said that the graphic should be updated -- for now, I think just deleting the reference to the graphic is a strict improvement.
* while looking for references to `dev`, I found two links to `discord` that somewhat confusingly redirect to discourse, so update the links and descriptions

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
