### PR TITLE
fix: Update model version to Gemini 1.5 Pro in SQL Talk app

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -11,6 +11,8 @@ bqml
 Boyz
 CHECKOV
 Chocolat
+codelab
+Codelab
 colab
 Colab
 codebase

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -76,7 +76,7 @@ sql_query_tool = Tool(
 )
 
 model = GenerativeModel(
-    "gemini-1.0-pro-001",
+    "gemini-1.5-pro-001",
     generation_config={"temperature": 0},
     tools=[sql_query_tool],
 )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -129,7 +129,7 @@ for message in st.session_state.messages:
         st.markdown(message["content"].replace("$", "\$"))  # noqa: W605, W1401
         try:
             with st.expander("Function calls, parameters, and responses"):
-                st.markdown(message["BACKEND_DETAILS"])
+                st.markdown(message["backend_details"])
         except KeyError:
             pass
 
@@ -140,7 +140,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
-        FULL_RESPONSE = ""
+        full_response = ""  #noqa C0103
         chat = model.start_chat()
         client = bigquery.Client()
 
@@ -157,7 +157,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         print(response)
 
         api_requests_and_responses = []
-        BACKEND_DETAILS = ""
+        backend_details = ""  #noqa C0103
 
         FUNCTION_CALLING_IN_PROCESS = True
         while FUNCTION_CALLING_IN_PROCESS:
@@ -239,43 +239,43 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                 )
                 response = response.candidates[0].content.parts[0]
 
-                BACKEND_DETAILS += "- Function call:\n"
-                BACKEND_DETAILS += (
+                backend_details += "- Function call:\n"
+                backend_details += (
                     "   - Function name: ```"
                     + str(api_requests_and_responses[-1][0])
                     + "```"
                 )
-                BACKEND_DETAILS += "\n\n"
-                BACKEND_DETAILS += (
+                backend_details += "\n\n"
+                backend_details += (
                     "   - Function parameters: ```"
                     + str(api_requests_and_responses[-1][1])
                     + "```"
                 )
-                BACKEND_DETAILS += "\n\n"
-                BACKEND_DETAILS += (
+                backend_details += "\n\n"
+                backend_details += (
                     "   - API response: ```"
                     + str(api_requests_and_responses[-1][2])
                     + "```"
                 )
-                BACKEND_DETAILS += "\n\n"
+                backend_details += "\n\n"
                 with message_placeholder.container():
-                    st.markdown(BACKEND_DETAILS)
+                    st.markdown(backend_details)
 
             except AttributeError:
                 FUNCTION_CALLING_IN_PROCESS = False
 
         time.sleep(3)
 
-        FULL_RESPONSE = response.text
+        full_response = response.text
         with message_placeholder.container():
-            st.markdown(FULL_RESPONSE.replace("$", "\$"))  # noqa: W605, W1401
+            st.markdown(full_response.replace("$", "\$"))  # noqa: W605, W1401
             with st.expander("Function calls, parameters, and responses:"):
-                st.markdown(BACKEND_DETAILS)
+                st.markdown(backend_details)
 
         st.session_state.messages.append(
             {
                 "role": "assistant",
-                "content": FULL_RESPONSE,
-                "BACKEND_DETAILS": BACKEND_DETAILS,
+                "content": full_response,
+                "backend_details": backend_details,
             }
         )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -182,38 +182,38 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                 print(params)
 
                 if response.function_call.name == "list_datasets":
-                    API_RESPONSE = client.list_datasets()
-                    API_RESPONSE = BIGQUERY_DATASET_ID
+                    api_response = client.list_datasets()
+                    api_response = BIGQUERY_DATASET_ID
                     api_requests_and_responses.append(
-                        [response.function_call.name, params, API_RESPONSE]
+                        [response.function_call.name, params, api_response]
                     )
 
                 if response.function_call.name == "list_tables":
-                    API_RESPONSE = client.list_tables(params["dataset_id"])
-                    API_RESPONSE = str([table.table_id for table in API_RESPONSE])
+                    api_response = client.list_tables(params["dataset_id"])
+                    api_response = str([table.table_id for table in api_response])
                     api_requests_and_responses.append(
-                        [response.function_call.name, params, API_RESPONSE]
+                        [response.function_call.name, params, api_response]
                     )
 
                 if response.function_call.name == "get_table":
-                    API_RESPONSE = client.get_table(params["table_id"])
-                    API_RESPONSE = API_RESPONSE.to_api_repr()
+                    api_response = client.get_table(params["table_id"])
+                    api_response = api_response.to_api_repr()
                     api_requests_and_responses.append(
                         [
                             response.function_call.name,
                             params,
                             [
-                                str(API_RESPONSE.get("description", "")),
+                                str(api_response.get("description", "")),
                                 str(
                                     [
                                         column["name"]
-                                        for column in API_RESPONSE["schema"]["fields"]
+                                        for column in api_response["schema"]["fields"]
                                     ]
                                 ),
                             ],
                         ]
                     )
-                    API_RESPONSE = str(API_RESPONSE)
+                    api_response = str(api_response)
 
                 if response.function_call.name == "sql_query":
                     job_config = bigquery.QueryJobConfig(
@@ -227,25 +227,25 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                             .replace("\\", "")
                         )
                         query_job = client.query(cleaned_query, job_config=job_config)
-                        API_RESPONSE = query_job.result()
-                        API_RESPONSE = str([dict(row) for row in API_RESPONSE])
-                        API_RESPONSE = API_RESPONSE.replace("\\", "").replace("\n", "")
+                        api_response = query_job.result()
+                        api_response = str([dict(row) for row in api_response])
+                        api_response = api_response.replace("\\", "").replace("\n", "")
                         api_requests_and_responses.append(
-                            [response.function_call.name, params, API_RESPONSE]
+                            [response.function_call.name, params, api_response]
                         )
                     except Exception as e:  # pylint: disable=broad-exception-caught
-                        API_RESPONSE = f"{str(e)}"
+                        api_response = f"{str(e)}"
                         api_requests_and_responses.append(
-                            [response.function_call.name, params, API_RESPONSE]
+                            [response.function_call.name, params, api_response]
                         )
 
-                print(API_RESPONSE)
+                print(api_response)
 
                 response = chat.send_message(
                     Part.from_function_response(
                         name=response.function_call.name,
                         response={
-                            "content": API_RESPONSE,
+                            "content": api_response,
                         },
                     ),
                 )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -100,6 +100,7 @@ with col2:
 
 st.subheader("Powered by Function Calling in Gemini")
 
+# pylint: disable=line-too-long
 st.markdown(
     """[Source Code](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/function-calling/sql-talk-app/)
     •
@@ -108,7 +109,9 @@ st.markdown(
     [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
     •
     [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
-)  # pylint: disable=C0301
+)
+
+TEST_STRING = "Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines."
 
 with st.expander("Sample prompts", expanded=True):
     st.write(
@@ -140,7 +143,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
-        full_response = ""  # pylint: disable=C0103
+        full_response = ""  # pylint: disable=invalid-name
         chat = model.start_chat()
         client = bigquery.Client()
 
@@ -157,7 +160,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         print(response)
 
         api_requests_and_responses = []
-        backend_details = ""  # pylint: disable=C0103
+        backend_details = ""  # pylint: disable=invalid-name
 
         FUNCTION_CALLING_IN_PROCESS = True
         while FUNCTION_CALLING_IN_PROCESS:

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -34,7 +34,9 @@ list_tables_func = FunctionDeclaration(
 
 get_table_func = FunctionDeclaration(
     name="get_table",
-    description="Get information about a table, including the description, schema, and number of rows that will help answer the user's question. Always use the fully qualified dataset and table names.",
+    description="""Get information about a table, including the description,
+    schema, and number of rows that will help answer the user's question. Always
+    use the fully qualified dataset and table names.""",
     parameters={
         "type": "object",
         "properties": {
@@ -57,7 +59,10 @@ sql_query_func = FunctionDeclaration(
         "properties": {
             "query": {
                 "type": "string",
-                "description": "SQL query on a single line that will help give quantitative answers to the user's question when run on a BigQuery dataset and table. In the SQL query, always use the fully qualified dataset and table names.",
+                "description": """SQL query on a single line that will help give
+                quantitative answers to the user's question when run on a
+                BigQuery dataset and table. In the SQL query, always use the
+                fully qualified dataset and table names.""",
             }
         },
         "required": [
@@ -96,7 +101,13 @@ with col2:
 st.subheader("Powered by Function Calling in Gemini")
 
 st.markdown(
-    "[Source Code](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/function-calling/sql-talk-app/)   •   [Documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/function-calling)   •   [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)   •   [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"
+    """[Source Code](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/function-calling/sql-talk-app/)
+    •
+    [Documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/function-calling)
+    •
+    [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
+    •
+    [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
 )
 
 with st.expander("Sample prompts", expanded=True):
@@ -118,7 +129,7 @@ for message in st.session_state.messages:
         st.markdown(message["content"].replace("$", "\$"))  # noqa: W605
         try:
             with st.expander("Function calls, parameters, and responses"):
-                st.markdown(message["backend_details"])
+                st.markdown(message["BACKEND_DETAILS"])
         except KeyError:
             pass
 
@@ -129,7 +140,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
-        full_response = ""
+        FULL_RESPONSE = ""
         chat = model.start_chat()
         client = bigquery.Client()
 
@@ -146,10 +157,10 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         print(response)
 
         api_requests_and_responses = []
-        backend_details = ""
+        BACKEND_DETAILS = ""
 
-        function_calling_in_process = True
-        while function_calling_in_process:
+        FUNCTION_CALLING_IN_PROCESS = True
+        while FUNCTION_CALLING_IN_PROCESS:
             try:
                 params = {}
                 for key, value in response.function_call.args.items():
@@ -159,38 +170,38 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                 print(params)
 
                 if response.function_call.name == "list_datasets":
-                    api_response = client.list_datasets()
-                    api_response = BIGQUERY_DATASET_ID
+                    API_RESPONSE = client.list_datasets()
+                    API_RESPONSE = BIGQUERY_DATASET_ID
                     api_requests_and_responses.append(
-                        [response.function_call.name, params, api_response]
+                        [response.function_call.name, params, API_RESPONSE]
                     )
 
                 if response.function_call.name == "list_tables":
-                    api_response = client.list_tables(params["dataset_id"])
-                    api_response = str([table.table_id for table in api_response])
+                    API_RESPONSE = client.list_tables(params["dataset_id"])
+                    API_RESPONSE = str([table.table_id for table in API_RESPONSE])
                     api_requests_and_responses.append(
-                        [response.function_call.name, params, api_response]
+                        [response.function_call.name, params, API_RESPONSE]
                     )
 
                 if response.function_call.name == "get_table":
-                    api_response = client.get_table(params["table_id"])
-                    api_response = api_response.to_api_repr()
+                    API_RESPONSE = client.get_table(params["table_id"])
+                    API_RESPONSE = API_RESPONSE.to_api_repr()
                     api_requests_and_responses.append(
                         [
                             response.function_call.name,
                             params,
                             [
-                                str(api_response.get("description", "")),
+                                str(API_RESPONSE.get("description", "")),
                                 str(
                                     [
                                         column["name"]
-                                        for column in api_response["schema"]["fields"]
+                                        for column in API_RESPONSE["schema"]["fields"]
                                     ]
                                 ),
                             ],
                         ]
                     )
-                    api_response = str(api_response)
+                    API_RESPONSE = str(API_RESPONSE)
 
                 if response.function_call.name == "sql_query":
                     job_config = bigquery.QueryJobConfig(
@@ -204,67 +215,67 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                             .replace("\\", "")
                         )
                         query_job = client.query(cleaned_query, job_config=job_config)
-                        api_response = query_job.result()
-                        api_response = str([dict(row) for row in api_response])
-                        api_response = api_response.replace("\\", "").replace("\n", "")
+                        API_RESPONSE = query_job.result()
+                        API_RESPONSE = str([dict(row) for row in API_RESPONSE])
+                        API_RESPONSE = API_RESPONSE.replace("\\", "").replace("\n", "")
                         api_requests_and_responses.append(
-                            [response.function_call.name, params, api_response]
+                            [response.function_call.name, params, API_RESPONSE]
                         )
                     except Exception as e:
-                        api_response = f"{str(e)}"
+                        API_RESPONSE = f"{str(e)}"
                         api_requests_and_responses.append(
-                            [response.function_call.name, params, api_response]
+                            [response.function_call.name, params, API_RESPONSE]
                         )
 
-                print(api_response)
+                print(API_RESPONSE)
 
                 response = chat.send_message(
                     Part.from_function_response(
                         name=response.function_call.name,
                         response={
-                            "content": api_response,
+                            "content": API_RESPONSE,
                         },
                     ),
                 )
                 response = response.candidates[0].content.parts[0]
 
-                backend_details += "- Function call:\n"
-                backend_details += (
+                BACKEND_DETAILS += "- Function call:\n"
+                BACKEND_DETAILS += (
                     "   - Function name: ```"
                     + str(api_requests_and_responses[-1][0])
                     + "```"
                 )
-                backend_details += "\n\n"
-                backend_details += (
+                BACKEND_DETAILS += "\n\n"
+                BACKEND_DETAILS += (
                     "   - Function parameters: ```"
                     + str(api_requests_and_responses[-1][1])
                     + "```"
                 )
-                backend_details += "\n\n"
-                backend_details += (
+                BACKEND_DETAILS += "\n\n"
+                BACKEND_DETAILS += (
                     "   - API response: ```"
                     + str(api_requests_and_responses[-1][2])
                     + "```"
                 )
-                backend_details += "\n\n"
+                BACKEND_DETAILS += "\n\n"
                 with message_placeholder.container():
-                    st.markdown(backend_details)
+                    st.markdown(BACKEND_DETAILS)
 
             except AttributeError:
-                function_calling_in_process = False
+                FUNCTION_CALLING_IN_PROCESS = False
 
         time.sleep(3)
 
-        full_response = response.text
+        FULL_RESPONSE = response.text
         with message_placeholder.container():
-            st.markdown(full_response.replace("$", "\$"))  # noqa: W605
+            st.markdown(FULL_RESPONSE.replace("$", "\$"))  # noqa: W605
             with st.expander("Function calls, parameters, and responses:"):
-                st.markdown(backend_details)
+                st.markdown(BACKEND_DETAILS)
 
         st.session_state.messages.append(
             {
                 "role": "assistant",
-                "content": full_response,
-                "backend_details": backend_details,
+                "content": FULL_RESPONSE,
+                "BACKEND_DETAILS": BACKEND_DETAILS,
             }
         )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -4,12 +4,6 @@ from google.cloud import bigquery
 import streamlit as st
 from vertexai.generative_models import FunctionDeclaration, GenerativeModel, Part, Tool
 
-"""
-This demo app uses Function Calling in Gemini to answer questions about a
-BigQuery dataset. It provides a chat interface for users to ask questions and
-interacts with BigQuery to retrieve relevant data and generate responses.
-"""
-
 BIGQUERY_DATASET_ID = "thelook_ecommerce"
 
 list_datasets_func = FunctionDeclaration(
@@ -40,9 +34,7 @@ list_tables_func = FunctionDeclaration(
 
 get_table_func = FunctionDeclaration(
     name="get_table",
-    description="""Get information about a table, including the description,
-    schema, and number of rows that will help answer the user's question. Always
-    use the fully qualified dataset and table names.""",
+    description="Get information about a table, including the description, schema, and number of rows that will help answer the user's question. Always use the fully qualified dataset and table names.",
     parameters={
         "type": "object",
         "properties": {
@@ -65,10 +57,7 @@ sql_query_func = FunctionDeclaration(
         "properties": {
             "query": {
                 "type": "string",
-                "description": """SQL query on a single line that will help give
-                quantitative answers to the user's question when run on a
-                BigQuery dataset and table. In the SQL query, always use the
-                fully qualified dataset and table names.""",
+                "description": "SQL query on a single line that will help give quantitative answers to the user's question when run on a BigQuery dataset and table. In the SQL query, always use the fully qualified dataset and table names.",
             }
         },
         "required": [
@@ -106,19 +95,9 @@ with col2:
 
 st.subheader("Powered by Function Calling in Gemini")
 
-# pylint: disable=line-too-long
 st.markdown(
-    """[Source Code](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/function-calling/sql-talk-app/)
-    •
-    [Documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/function-calling)
-    •
-    [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
-    •
-    [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
+    "[Source Code](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/function-calling/sql-talk-app/)   •   [Documentation](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/function-calling)   •   [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)   •   [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"
 )
-# pylint: enable=line-too-long
-
-TEST_STRING = "Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines."
 
 with st.expander("Sample prompts", expanded=True):
     st.write(
@@ -136,9 +115,7 @@ if "messages" not in st.session_state:
 
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
-        st.markdown(
-            message["content"].replace("$", "\$")
-        )  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
+        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605
         try:
             with st.expander("Function calls, parameters, and responses"):
                 st.markdown(message["backend_details"])
@@ -152,7 +129,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
-        full_response = ""  # pylint: disable=invalid-name
+        full_response = ""
         chat = model.start_chat()
         client = bigquery.Client()
 
@@ -169,10 +146,10 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         print(response)
 
         api_requests_and_responses = []
-        backend_details = ""  # pylint: disable=invalid-name
+        backend_details = ""
 
-        function_calling_in_progress = True
-        while function_calling_in_progress:
+        function_calling_in_process = True
+        while function_calling_in_process:
             try:
                 params = {}
                 for key, value in response.function_call.args.items():
@@ -233,7 +210,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                         api_requests_and_responses.append(
                             [response.function_call.name, params, api_response]
                         )
-                    except Exception as e:  # pylint: disable=broad-exception-caught
+                    except Exception as e:
                         api_response = f"{str(e)}"
                         api_requests_and_responses.append(
                             [response.function_call.name, params, api_response]
@@ -274,15 +251,13 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                     st.markdown(backend_details)
 
             except AttributeError:
-                function_calling_in_progress = False
+                function_calling_in_process = False
 
         time.sleep(3)
 
         full_response = response.text
         with message_placeholder.container():
-            st.markdown(
-                full_response.replace("$", "\$")
-            )  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
+            st.markdown(full_response.replace("$", "\$"))  # noqa: W605
             with st.expander("Function calls, parameters, and responses:"):
                 st.markdown(backend_details)
 

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -171,8 +171,8 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         api_requests_and_responses = []
         backend_details = ""  # pylint: disable=invalid-name
 
-        FUNCTION_CALLING_IN_PROCESS = True
-        while FUNCTION_CALLING_IN_PROCESS:
+        function_calling_in_progress = True
+        while function_calling_in_progress:
             try:
                 params = {}
                 for key, value in response.function_call.args.items():
@@ -274,7 +274,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                     st.markdown(backend_details)
 
             except AttributeError:
-                FUNCTION_CALLING_IN_PROCESS = False
+                function_calling_in_progress = False
 
         time.sleep(3)
 

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -136,7 +136,9 @@ if "messages" not in st.session_state:
 
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
-        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
+        st.markdown(
+            message["content"].replace("$", "\$")
+        )  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
         try:
             with st.expander("Function calls, parameters, and responses"):
                 st.markdown(message["backend_details"])
@@ -278,7 +280,9 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
         full_response = response.text
         with message_placeholder.container():
-            st.markdown(full_response.replace("$", "\$"))  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
+            st.markdown(
+                full_response.replace("$", "\$")
+            )  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
             with st.expander("Function calls, parameters, and responses:"):
                 st.markdown(backend_details)
 

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -108,7 +108,7 @@ st.markdown(
     [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
     •
     [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
-)
+) # noqa: C0301
 
 with st.expander("Sample prompts", expanded=True):
     st.write(
@@ -126,7 +126,7 @@ if "messages" not in st.session_state:
 
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
-        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605
+        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605, W1401
         try:
             with st.expander("Function calls, parameters, and responses"):
                 st.markdown(message["BACKEND_DETAILS"])
@@ -268,7 +268,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
         FULL_RESPONSE = response.text
         with message_placeholder.container():
-            st.markdown(FULL_RESPONSE.replace("$", "\$"))  # noqa: W605
+            st.markdown(FULL_RESPONSE.replace("$", "\$"))  # noqa: W605, W1401
             with st.expander("Function calls, parameters, and responses:"):
                 st.markdown(BACKEND_DETAILS)
 

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -108,7 +108,7 @@ st.markdown(
     [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
     •
     [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
-)  # noqa: C0301
+)  # pylint: disable=C0301
 
 with st.expander("Sample prompts", expanded=True):
     st.write(
@@ -140,7 +140,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
     with st.chat_message("assistant"):
         message_placeholder = st.empty()
-        full_response = ""  #noqa C0103
+        full_response = ""  # pylint: disable=C0103
         chat = model.start_chat()
         client = bigquery.Client()
 
@@ -157,7 +157,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
         print(response)
 
         api_requests_and_responses = []
-        backend_details = ""  #noqa C0103
+        backend_details = ""  # pylint: disable=C0103
 
         FUNCTION_CALLING_IN_PROCESS = True
         while FUNCTION_CALLING_IN_PROCESS:

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -4,6 +4,12 @@ from google.cloud import bigquery
 import streamlit as st
 from vertexai.generative_models import FunctionDeclaration, GenerativeModel, Part, Tool
 
+"""
+This demo app uses Function Calling in Gemini to answer questions about a
+BigQuery dataset. It provides a chat interface for users to ask questions and
+interacts with BigQuery to retrieve relevant data and generate responses.
+"""
+
 BIGQUERY_DATASET_ID = "thelook_ecommerce"
 
 list_datasets_func = FunctionDeclaration(
@@ -110,6 +116,7 @@ st.markdown(
     •
     [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
 )
+# pylint: enable=line-too-long
 
 TEST_STRING = "Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines. Testing long lines."
 
@@ -129,7 +136,7 @@ if "messages" not in st.session_state:
 
 for message in st.session_state.messages:
     with st.chat_message(message["role"]):
-        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605, W1401
+        st.markdown(message["content"].replace("$", "\$"))  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
         try:
             with st.expander("Function calls, parameters, and responses"):
                 st.markdown(message["backend_details"])
@@ -224,7 +231,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                         api_requests_and_responses.append(
                             [response.function_call.name, params, API_RESPONSE]
                         )
-                    except Exception as e:
+                    except Exception as e:  # pylint: disable=broad-exception-caught
                         API_RESPONSE = f"{str(e)}"
                         api_requests_and_responses.append(
                             [response.function_call.name, params, API_RESPONSE]
@@ -271,7 +278,7 @@ if prompt := st.chat_input("Ask me about information in the database..."):
 
         full_response = response.text
         with message_placeholder.container():
-            st.markdown(full_response.replace("$", "\$"))  # noqa: W605, W1401
+            st.markdown(full_response.replace("$", "\$"))  # noqa: W605, W1401 # pylint: disable=anomalous-backslash-in-string
             with st.expander("Function calls, parameters, and responses:"):
                 st.markdown(backend_details)
 

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -108,7 +108,7 @@ st.markdown(
     [Codelab](https://codelabs.developers.google.com/codelabs/gemini-function-calling)
     •
     [Sample Notebook](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/function-calling/intro_function_calling.ipynb)"""
-) # noqa: C0301
+)  # noqa: C0301
 
 with st.expander("Sample prompts", expanded=True):
     st.write(


### PR DESCRIPTION
# Description

This PR bumps the version of the Gemini model used in the SQL Talk sample app for Function Calling in Gemini from `gemini-1.0-pro-001` to `gemini-1.5-pro-001`.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)