### PR TITLE
fix: question_answering.ipynb with a working fuzzywuzzy lib location

### DIFF
--- a/gemini/prompts/examples/question_answering.ipynb
+++ b/gemini/prompts/examples/question_answering.ipynb
@@ -134,7 +134,7 @@
     "\n",
     "# Install the package `fuzzywuzzy` and `python-Levenshtein`\n",
     "!pip install -q python-Levenshtein --upgrade --user\n",
-    "!pip install -q fuzzywuzzy --upgrade --user"
+    "!pip install -q git+git://github.com/seatgeek/fuzzywuzzy.git@0.18.0#egg=fuzzywuzzy --upgrade --user"
    ]
   },
   {


### PR DESCRIPTION
# Description

Fixing FuzzyWuzzy source library availability. 
QwickLabs were failing.  

This is the latest (2020) stable library that is available at the official github repo

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file. N/A
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)

Fixes #NA 🦕
