### PR TITLE
docs(gemini-streamlit-cloudrun): Remove separate build step

### DIFF
--- a/gemini/sample-apps/gemini-streamlit-cloudrun/README.md
+++ b/gemini/sample-apps/gemini-streamlit-cloudrun/README.md
@@ -82,31 +82,22 @@ To deploy the Streamlit Application in [Cloud Run](https://cloud.google.com/run/
    export GCP_REGION='us-central1'             # If you change this, make sure the region is supported.
    ```
 
-2. Now you can build the Docker image for the application and push it to Artifact Registry. To do this, you will need one environment variable set that will point to the Artifact Registry name. Included in the script below is a command that will create this Artifact Registry repository for you.
+2. Build and deploy the service to Cloud Run:
 
-   In Cloud Shell, execute the following commands:
+   In Cloud Shell, execute the following command to name the Cloud Run service:
 
    ```bash
-   export AR_REPO='<REPLACE_WITH_YOUR_AR_REPO_NAME>'  # Change this
    export SERVICE_NAME='gemini-streamlit-app' # This is the name of our Application and Cloud Run service. Change it if you'd like.
-
-   #make sure you are in the active directory for 'gemini-streamlit-cloudrun'
-   gcloud artifacts repositories create "$AR_REPO" --location="$GCP_REGION" --repository-format=Docker
-   gcloud auth configure-docker "$GCP_REGION-docker.pkg.dev"
-   gcloud builds submit --tag "$GCP_REGION-docker.pkg.dev/$GCP_PROJECT/$AR_REPO/$SERVICE_NAME"
    ```
-
-3. The final step is to deploy the service in Cloud Run with the image that we had built and had pushed to the Artifact Registry in the previous step:
 
    In Cloud Shell, execute the following command:
 
    ```bash
    gcloud run deploy "$SERVICE_NAME" \
      --port=8080 \
-     --image="$GCP_REGION-docker.pkg.dev/$GCP_PROJECT/$AR_REPO/$SERVICE_NAME" \
+     --source=. \
      --allow-unauthenticated \
      --region=$GCP_REGION \
-     --platform=managed  \
      --project=$GCP_PROJECT \
      --set-env-vars=GCP_PROJECT=$GCP_PROJECT,GCP_REGION=$GCP_REGION
    ```


### PR DESCRIPTION
# Description

This change removes the build step for the Cloud Run deployment instructions. Instead, the Cloud Run deploy uses a source deploy, where Cloud Run's CLI operation manages the steps to upload and build the container image for use.

This simplifies the instructions and accelerates folks to using the sample app more quickly.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
