### PR TITLE
docs: Add additional info on how to use the remote reasoning engine de…

### DIFF
--- a/gemini/reasoning-engine/intro_reasoning_engine.ipynb
+++ b/gemini/reasoning-engine/intro_reasoning_engine.ipynb
@@ -575,7 +575,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " Afterwards you can use it by uncommenting and adapting the following code:"
+    "Afterwards you can use it by uncommenting and adapting the following code:"
    ]
   },
   {

--- a/gemini/reasoning-engine/intro_reasoning_engine.ipynb
+++ b/gemini/reasoning-engine/intro_reasoning_engine.ipynb
@@ -559,7 +559,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can now import and use the remotely deployed Reasoning Engine in this notebook session or in a different notebook or Python script by uncommenting and adapting the following code:"
+    "You can now import and use the remotely deployed Reasoning Engine in this notebook session or in a different notebook or Python script. First you need to get its resource_name by calling:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_agent.resource_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " Afterwards you can use it by uncommenting and adapting the following code:"
    ]
   },
   {
@@ -570,11 +586,9 @@
    "source": [
     "# from vertexai.preview import reasoning_engines\n",
     "\n",
-    "# PROJECT_ID = \"YOUR_PROJECT_ID\"\n",
-    "# LOCATION = \"YOUR_LOCATION\"\n",
-    "# REASONING_ENGINE_ID = \"YOUR_REASONING_ENGINE_ID\"\n",
+    "# REASONING_ENGINE_RESOURCE_NAME = \"YOUR_REASONING_ENGINE_RESOURCE_NAME\"\n",
     "\n",
-    "# remote_agent = reasoning_engines.ReasoningEngine(f\"projects/{PROJECT_ID}/locations/{LOCATION}/reasoningEngines/{REASONING_ENGINE_ID}\")\n",
+    "# remote_agent = reasoning_engines.ReasoningEngine(REASONING_ENGINE_RESOURCE_NAME)\n",
     "# response = remote_agent.query(input=query)"
    ]
   },


### PR DESCRIPTION
# Description

Adding additional info on how to use the remote reasoning engine deployed on VertexAI. It seems the `resource_name` already contains the full string needed to call it, so there is no need for the f-string.

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [ ] Appropriate docs were updated (if necessary)