### PR TITLE
fix: Specify project id in auth call in tracing notebook

### DIFF
--- a/gemini/reasoning-engine/tracing_agents_in_reasoning_engine.ipynb
+++ b/gemini/reasoning-engine/tracing_agents_in_reasoning_engine.ipynb
@@ -278,7 +278,7 @@
     "if \"google.colab\" in sys.modules:\n",
     "    from google.colab import auth\n",
     "\n",
-    "    auth.authenticate_user()"
+    "    auth.authenticate_user(project_id=PROJECT_ID)"
    ]
   },
   {


### PR DESCRIPTION
Cloud Trace reads project_id from a different source. In order to get the correct project_id, the call to auth.authenticate_user needs to specify the project_id.

Fixes #852