### PR TITLE
Updated the model named 'text-bison' with 'gemini-pro' for the notebook 'intro_langchain_plam_api'

### DIFF
--- a/language/orchestration/langchain/intro_langchain_palm_api.ipynb
+++ b/language/orchestration/langchain/intro_langchain_palm_api.ipynb
@@ -29,7 +29,7 @@
     "id": "359697d5"
    },
    "source": [
-    "# Getting Started with LangChain 🦜️🔗 + Vertex AI PaLM API\n",
+    "# Getting Started with LangChain 🦜️🔗 + Vertex AI\n",
     "\n",
     "<table align=\"left\">\n",
     "  <td style=\"text-align: center\">\n",

--- a/language/orchestration/langchain/intro_langchain_palm_api.ipynb
+++ b/language/orchestration/langchain/intro_langchain_palm_api.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "# LLM model\n",
     "llm = VertexAI(\n",
-    "    model_name=\"text-bison\",\n",
+    "    model=\"gemini-pro\",\n",
     "    max_output_tokens=256,\n",
     "    temperature=0.1,\n",
     "    top_p=0.8,\n",


### PR DESCRIPTION
- The model named "text-bison" has been updated with "gemini-pro" as the model "text-bison" will be deprecated soon.
