### PR TITLE
fix: Update web app config for conversation/chat-app related to static site generation

### DIFF
--- a/conversation/chat-app/.prettierrc
+++ b/conversation/chat-app/.prettierrc
@@ -4,5 +4,6 @@
   "printWidth": 100,
   "bracketSameLine": true,
   "pluginSearchDirs": ["."],
+  "plugins": ["prettier-plugin-svelte"],
   "overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }

--- a/conversation/chat-app/src/routes/+page.svelte
+++ b/conversation/chat-app/src/routes/+page.svelte
@@ -4,8 +4,8 @@
   import { Heading } from "flowbite-svelte";
   import { onMount } from "svelte";
 
-  var text = ""
-  var time = 0
+  var text = "";
+  var time = 0;
 
   function send_input(text, time) {
     setTimeout(function () {
@@ -21,7 +21,8 @@
         .querySelector("df-messenger")
         .querySelector("df-messenger-chat")
         .shadowRoot.querySelector("df-messenger-user-input")
-        .shadowRoot.querySelector("textarea").dispatchEvent(new Event("input"));
+        .shadowRoot.querySelector("textarea")
+        .dispatchEvent(new Event("input"));
     }, time + 100);
 
     setTimeout(function () {
@@ -36,9 +37,9 @@
 
   onMount(() => {
     // Write and send sample questions to chatbot
-    send_input("Hello", 2000)
-    send_input("Does the Pixel 7 Pro support fast charging?", 6000)
-    send_input("Which colors is the Pixel Watch available in?", 11000)
+    send_input("Hello", 2000);
+    send_input("Does the Pixel 7 Pro support fast charging?", 6000);
+    send_input("Which colors is the Pixel Watch available in?", 11000);
   });
 </script>
 
@@ -107,7 +108,7 @@
           language-code="en"
           storage-option="none"
           class="drop-shadow-lg"
-          max-query-length=-1>
+          max-query-length="-1">
           <df-messenger-chat
             chat-title="Google Store - Vertex AI Conversation"
             bot-writing-text="..."

--- a/conversation/chat-app/svelte.config.js
+++ b/conversation/chat-app/svelte.config.js
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-import preprocess from "svelte-preprocess";
 import adapter from "@sveltejs/adapter-static";
-import { vitePreprocess } from "@sveltejs/kit/vite";
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://kit.svelte.dev/docs/integrations#preprocessors
-  // for more information about preprocessors
-  preprocess: [
-    vitePreprocess(),
-    preprocess({
-      postcss: true,
-    }),
-  ],
-
   kit: {
     adapter: adapter({
       // default options are shown. On some platforms

--- a/conversation/chat-app/svelte.config.js
+++ b/conversation/chat-app/svelte.config.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import adapter from "@sveltejs/adapter-static";
+import adapter from '@sveltejs/adapter-static'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -22,13 +22,13 @@ const config = {
     adapter: adapter({
       // default options are shown. On some platforms
       // these options are set automatically — see below
-      pages: "build",
-      assets: "build",
+      pages: 'build',
+      assets: 'build',
       fallback: undefined,
       precompress: false,
-      strict: true,
-    }),
-  },
-};
+      strict: true
+    })
+  }
+}
 
-export default config;
+export default config


### PR DESCRIPTION
# Description

This PR is a followup to the version bumps in #1006 from dependabot, as it updates the config for the conversation/chat-app  to avoid this error at build time:

```
$ npm run build

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'svelte-preprocess'
imported from generative-ai/conversation/chat-app/svelte.config.js
```

The fix is to remove references to `svelte-preprocess` from `svelte.config.js` since its no longer needed per the [Svelte static site adapter docs](https://kit.svelte.dev/docs/adapter-static).

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [X] You are listed as the author in your notebook or README file.
  - [X] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [X] Appropriate docs were updated (if necessary)
