### PR TITLE
fix: Updated the intro_langchain_palm_api.ipynb notebook

### DIFF
--- a/language/orchestration/langchain/intro_langchain_palm_api.ipynb
+++ b/language/orchestration/langchain/intro_langchain_palm_api.ipynb
@@ -1573,7 +1573,7 @@
     "from langchain.text_splitter import RecursiveCharacterTextSplitter\n",
     "\n",
     "text_splitter = RecursiveCharacterTextSplitter(chunk_size=1500, chunk_overlap=0)\n",
-    "docs = text_splitter.split_documents(documents)\n",
+    "docs = text_splitter.split_documents(documents[40:60])\n",
     "print(f\"# of documents = {len(docs)}\")"
    ]
   },


### PR DESCRIPTION
- To address the Qwiklabs quota restrictions, we've updated the document to utilize document indices 40 to 60. This modification allows us to complete the lab without causing quota errors.
