### PR TITLE
feat: Improve error catching in the SQL Talk app (Gemini Function Calling)

### DIFF
--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -1,7 +1,6 @@
 import time
-
-from google.cloud import bigquery
 import streamlit as st
+from google.cloud import bigquery
 from vertexai.generative_models import FunctionDeclaration, GenerativeModel, Part, Tool
 
 BIGQUERY_DATASET_ID = "thelook_ecommerce"
@@ -140,131 +139,161 @@ if prompt := st.chat_input("Ask me about information in the database..."):
             from BigQuery, do not make up information.
             """
 
-        response = chat.send_message(prompt)
-        response = response.candidates[0].content.parts[0]
+        try:
+            response = chat.send_message(prompt)
+            response = response.candidates[0].content.parts[0]
 
-        print(response)
+            print(response)
 
-        api_requests_and_responses = []
-        backend_details = ""
+            api_requests_and_responses = []
+            backend_details = ""
 
-        function_calling_in_process = True
-        while function_calling_in_process:
-            try:
-                params = {}
-                for key, value in response.function_call.args.items():
-                    params[key] = value
+            function_calling_in_process = True
+            while function_calling_in_process:
+                try:
+                    params = {}
+                    for key, value in response.function_call.args.items():
+                        params[key] = value
 
-                print(response.function_call.name)
-                print(params)
+                    print(response.function_call.name)
+                    print(params)
 
-                if response.function_call.name == "list_datasets":
-                    api_response = client.list_datasets()
-                    api_response = BIGQUERY_DATASET_ID
-                    api_requests_and_responses.append(
-                        [response.function_call.name, params, api_response]
-                    )
+                    if response.function_call.name == "list_datasets":
+                        api_response = client.list_datasets()
+                        api_response = BIGQUERY_DATASET_ID
+                        api_requests_and_responses.append(
+                            [response.function_call.name, params, api_response]
+                        )
 
-                if response.function_call.name == "list_tables":
-                    api_response = client.list_tables(params["dataset_id"])
-                    api_response = str([table.table_id for table in api_response])
-                    api_requests_and_responses.append(
-                        [response.function_call.name, params, api_response]
-                    )
+                    if response.function_call.name == "list_tables":
+                        api_response = client.list_tables(params["dataset_id"])
+                        api_response = str([table.table_id for table in api_response])
+                        api_requests_and_responses.append(
+                            [response.function_call.name, params, api_response]
+                        )
 
-                if response.function_call.name == "get_table":
-                    api_response = client.get_table(params["table_id"])
-                    api_response = api_response.to_api_repr()
-                    api_requests_and_responses.append(
-                        [
-                            response.function_call.name,
-                            params,
+                    if response.function_call.name == "get_table":
+                        api_response = client.get_table(params["table_id"])
+                        api_response = api_response.to_api_repr()
+                        api_requests_and_responses.append(
                             [
-                                str(api_response.get("description", "")),
-                                str(
-                                    [
-                                        column["name"]
-                                        for column in api_response["schema"]["fields"]
-                                    ]
-                                ),
-                            ],
-                        ]
+                                response.function_call.name,
+                                params,
+                                [
+                                    str(api_response.get("description", "")),
+                                    str(
+                                        [
+                                            column["name"]
+                                            for column in api_response["schema"]["fields"]
+                                        ]
+                                    ),
+                                ],
+                            ]
+                        )
+                        api_response = str(api_response)
+
+                    if response.function_call.name == "sql_query":
+                        job_config = bigquery.QueryJobConfig(
+                            maximum_bytes_billed=100000000
+                        )  # Data limit per query job
+                        try:
+                            cleaned_query = (
+                                params["query"]
+                                .replace("\\n", " ")
+                                .replace("\n", "")
+                                .replace("\\", "")
+                            )
+                            query_job = client.query(cleaned_query, job_config=job_config)
+                            api_response = query_job.result()
+                            api_response = str([dict(row) for row in api_response])
+                            api_response = api_response.replace("\\", "").replace("\n", "")
+                            api_requests_and_responses.append(
+                                [response.function_call.name, params, api_response]
+                            )
+                        except Exception as e:
+                            error_message = f"""
+                            We're having trouble running this SQL query. This
+                            could be due to an invalid query or the structure of
+                            the data. Try rephrasing your question to help the
+                            model generate a valid query. Details:
+
+                            {str(e)}"""
+                            st.error(error_message)
+                            api_response = error_message
+                            api_requests_and_responses.append(
+                                [response.function_call.name, params, api_response]
+                            )
+                            st.session_state.messages.append(
+                                {
+                                    "role": "assistant",
+                                    "content": error_message,
+                                }
+                            )
+
+                    print(api_response)
+
+                    response = chat.send_message(
+                        Part.from_function_response(
+                            name=response.function_call.name,
+                            response={
+                                "content": api_response,
+                            },
+                        ),
                     )
-                    api_response = str(api_response)
+                    response = response.candidates[0].content.parts[0]
 
-                if response.function_call.name == "sql_query":
-                    job_config = bigquery.QueryJobConfig(
-                        maximum_bytes_billed=100000000
-                    )  # Data limit per query job
-                    try:
-                        cleaned_query = (
-                            params["query"]
-                            .replace("\\n", " ")
-                            .replace("\n", "")
-                            .replace("\\", "")
-                        )
-                        query_job = client.query(cleaned_query, job_config=job_config)
-                        api_response = query_job.result()
-                        api_response = str([dict(row) for row in api_response])
-                        api_response = api_response.replace("\\", "").replace("\n", "")
-                        api_requests_and_responses.append(
-                            [response.function_call.name, params, api_response]
-                        )
-                    except Exception as e:
-                        api_response = f"{str(e)}"
-                        api_requests_and_responses.append(
-                            [response.function_call.name, params, api_response]
-                        )
+                    backend_details += "- Function call:\n"
+                    backend_details += (
+                        "   - Function name: ```"
+                        + str(api_requests_and_responses[-1][0])
+                        + "```"
+                    )
+                    backend_details += "\n\n"
+                    backend_details += (
+                        "   - Function parameters: ```"
+                        + str(api_requests_and_responses[-1][1])
+                        + "```"
+                    )
+                    backend_details += "\n\n"
+                    backend_details += (
+                        "   - API response: ```"
+                        + str(api_requests_and_responses[-1][2])
+                        + "```"
+                    )
+                    backend_details += "\n\n"
+                    with message_placeholder.container():
+                        st.markdown(backend_details)
 
-                print(api_response)
+                except AttributeError:
+                    function_calling_in_process = False
 
-                response = chat.send_message(
-                    Part.from_function_response(
-                        name=response.function_call.name,
-                        response={
-                            "content": api_response,
-                        },
-                    ),
-                )
-                response = response.candidates[0].content.parts[0]
+            time.sleep(3)
 
-                backend_details += "- Function call:\n"
-                backend_details += (
-                    "   - Function name: ```"
-                    + str(api_requests_and_responses[-1][0])
-                    + "```"
-                )
-                backend_details += "\n\n"
-                backend_details += (
-                    "   - Function parameters: ```"
-                    + str(api_requests_and_responses[-1][1])
-                    + "```"
-                )
-                backend_details += "\n\n"
-                backend_details += (
-                    "   - API response: ```"
-                    + str(api_requests_and_responses[-1][2])
-                    + "```"
-                )
-                backend_details += "\n\n"
-                with message_placeholder.container():
+            full_response = response.text
+            with message_placeholder.container():
+                st.markdown(full_response.replace("$", r"\$"))  # noqa: W605
+                with st.expander("Function calls, parameters, and responses:"):
                     st.markdown(backend_details)
 
-            except AttributeError:
-                function_calling_in_process = False
+            st.session_state.messages.append(
+                {
+                    "role": "assistant",
+                    "content": full_response,
+                    "backend_details": backend_details,
+                }
+            )
+        except Exception as e:
+            print(e)
+            error_message = f"""
+                Something went wrong! We encountered an unexpected error while
+                trying to process your request. Please try rephrasing your
+                question. Details:
 
-        time.sleep(3)
-
-        full_response = response.text
-        with message_placeholder.container():
-            st.markdown(full_response.replace("$", r"\$"))  # noqa: W605
-            with st.expander("Function calls, parameters, and responses:"):
-                st.markdown(backend_details)
-
-        st.session_state.messages.append(
-            {
-                "role": "assistant",
-                "content": full_response,
-                "backend_details": backend_details,
-            }
-        )
+                {str(e)}"""
+            st.error(error_message)
+            st.session_state.messages.append(
+                {
+                    "role": "assistant",
+                    "content": error_message,
+                }
+            )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -184,7 +184,9 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                                     str(
                                         [
                                             column["name"]
-                                            for column in api_response["schema"]["fields"]
+                                            for column in api_response["schema"][
+                                                "fields"
+                                            ]
                                         ]
                                     ),
                                 ],
@@ -203,10 +205,14 @@ if prompt := st.chat_input("Ask me about information in the database..."):
                                 .replace("\n", "")
                                 .replace("\\", "")
                             )
-                            query_job = client.query(cleaned_query, job_config=job_config)
+                            query_job = client.query(
+                                cleaned_query, job_config=job_config
+                            )
                             api_response = query_job.result()
                             api_response = str([dict(row) for row in api_response])
-                            api_response = api_response.replace("\\", "").replace("\n", "")
+                            api_response = api_response.replace("\\", "").replace(
+                                "\n", ""
+                            )
                             api_requests_and_responses.append(
                                 [response.function_call.name, params, api_response]
                             )

--- a/gemini/function-calling/sql-talk-app/app.py
+++ b/gemini/function-calling/sql-talk-app/app.py
@@ -1,6 +1,7 @@
 import time
-import streamlit as st
+
 from google.cloud import bigquery
+import streamlit as st
 from vertexai.generative_models import FunctionDeclaration, GenerativeModel, Part, Tool
 
 BIGQUERY_DATASET_ID = "thelook_ecommerce"


### PR DESCRIPTION
# Description

This PR adds improved error catching to the SQL Talk app. Currently, if an error is encountered due to a malformed generated SQL query or an error executing the tools / functions, then a full stack trace will appear in the app. With this PR, errors are caught at the SQL execution level and top-level application and rendered in the app (and persisted in the message history) without a full stack trace.

Special thanks to @mona19 for suggesting this change and providing a sample implementation! 🙏 

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)

How friendlier errors will appear now instead of a full stack trace:

---

![Screenshot 2024-09-18 at 6 21 37 PM](https://github.com/user-attachments/assets/44c45e96-095e-4373-ab23-a6fde871b6e0)

---

![Screenshot 2024-09-18 at 6 22 11 PM](https://github.com/user-attachments/assets/b47cba62-6ee2-4ddf-8832-9f4e4643d0df)