### PR TITLE
fix: Update README.md to add missing application-default login step

### DIFF
--- a/gemini/sample-apps/e2e-gen-ai-app-starter-pack/README.md
+++ b/gemini/sample-apps/e2e-gen-ai-app-starter-pack/README.md
@@ -117,6 +117,7 @@ export PROJECT_ID="YOUR_PROJECT_ID"
 export REGION="YOUR_REGION"
 gcloud config set project $PROJECT_ID
 gcloud config set region $REGION
+gcloud auth application-default login
 gcloud auth application-default set-quota-project $PROJECT_ID
 ```
 


### PR DESCRIPTION
Add gcloud auth application-default login command before running gcloud auth application-default set-quota-project $PROJECT_ID (otherwise the latter will fail)

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [X] Appropriate docs were updated (if necessary)

