### PR TITLE
fix: add missing sqlalchemy text import in cloud sql tutorial

### DIFF
--- a/gemini/reasoning-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
+++ b/gemini/reasoning-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
@@ -145,9 +145,9 @@
         "from langchain_core.documents import Document\n",
         "from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore\n",
         "from langchain_google_vertexai import VertexAIEmbeddings\n",
+        "from sqlalchemy import text  # noqa: F401\n",
         "import vertexai\n",
-        "from vertexai.preview import reasoning_engines\n",
-        "from sqlalchemy import text"
+        "from vertexai.preview import reasoning_engines"
       ]
     },
     {

--- a/gemini/reasoning-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
+++ b/gemini/reasoning-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
@@ -146,7 +146,8 @@
         "from langchain_google_cloud_sql_pg import PostgresEngine, PostgresVectorStore\n",
         "from langchain_google_vertexai import VertexAIEmbeddings\n",
         "import vertexai\n",
-        "from vertexai.preview import reasoning_engines"
+        "from vertexai.preview import reasoning_engines\n",
+        "from sqlalchemy import text"
       ]
     },
     {


### PR DESCRIPTION
Add missing sqlalchemy import in cloud sql tutorial.

Affected lines:

https://github.com/GoogleCloudPlatform/generative-ai/blob/aff5724b3ebb8b7e6292cba8027ec2e4d24a95b9/gemini/reasoning-engine/tutorial_cloud_sql_pg_rag_agent.ipynb#L348-L350

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
