### PR TITLE
fix: starter pack tracing utils gcs export

### DIFF
--- a/gemini/sample-apps/e2e-gen-ai-app-starter-pack/tests/unit/test_utils/test_tracing_exporter.py
+++ b/gemini/sample-apps/e2e-gen-ai-app-starter-pack/tests/unit/test_utils/test_tracing_exporter.py
@@ -75,7 +75,6 @@ def exporter(
         storage_client=mock_storage_client,
         bucket_name="test-bucket",
     )
-    exporter._ensure_bucket_exists = Mock()  # type: ignore[method-assign]
     return exporter
 
 


### PR DESCRIPTION
Avoid to create a GCS bucket from Python as non transparent for the user. This might also cause errors with Terraform IaC.
