### PR TITLE
refactor: Update the batch prediction API namespace

### DIFF
--- a/gemini/batch-prediction/intro_batch_prediction.ipynb
+++ b/gemini/batch-prediction/intro_batch_prediction.ipynb
@@ -253,7 +253,7 @@
         "\n",
         "from google.cloud import storage\n",
         "from vertexai.generative_models import GenerativeModel\n",
-        "from vertexai.preview.batch_prediction import BatchPredictionJob"
+        "from vertexai.batch_prediction import BatchPredictionJob"
       ]
     },
     {

--- a/gemini/batch-prediction/intro_batch_prediction_using_bigquery_input.ipynb
+++ b/gemini/batch-prediction/intro_batch_prediction_using_bigquery_input.ipynb
@@ -247,8 +247,8 @@
         "\n",
         "from google.cloud import bigquery\n",
         "import vertexai\n",
-        "from vertexai.generative_models import GenerativeModel\n",
-        "from vertexai.preview.batch_prediction import BatchPredictionJob"
+        "from vertexai.batch_prediction import BatchPredictionJob\n",
+        "from vertexai.generative_models import GenerativeModel"
       ]
     },
     {


### PR DESCRIPTION
# Description

Update the batch prediction API namespace. 
The new API is available in Vertex AI SDK for Python 1.71.0.