### PR TITLE
fix: Add a "session crash" warning

### DIFF
--- a/notebook_template.ipynb
+++ b/notebook_template.ipynb
@@ -356,7 +356,7 @@
       },
       "source": [
         "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
+        "<b>⚠️ The kernel is going to restart. In Colab or Colab Enterprise, you might see an error message that says \"Your session crashed for an unknown reason.\" This is expected. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
         "</div>\n"
       ]
     },


### PR DESCRIPTION
I've seen an engineer got stuck with the "session crash" message with our notebooks. I shared this with @polong-lin and he suggested me to create a PR for a fix to the template.

