### PR TITLE
fix: prevent SSLCertVerificationError when creating websocket to server

### DIFF
--- a/gemini/multimodal-live-api/websocket-demo-app/main.py
+++ b/gemini/multimodal-live-api/websocket-demo-app/main.py
@@ -8,9 +8,6 @@ from websockets.legacy.server import WebSocketServerProtocol
 import ssl
 import certifi
 
-ssl_context = ssl.create_default_context()
-ssl_context.load_verify_locations(certifi.where())
-
 HOST = "us-central1-aiplatform.googleapis.com"
 SERVICE_URL = f"wss://{HOST}/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent"
 
@@ -55,6 +52,9 @@ async def create_proxy(
         "Content-Type": "application/json",
         "Authorization": f"Bearer {bearer_token}",
     }
+
+    ssl_context = ssl.create_default_context()
+    ssl_context.load_verify_locations(certifi.where())
 
     async with websockets.connect(
         SERVICE_URL, additional_headers=headers, ssl=ssl_context

--- a/gemini/multimodal-live-api/websocket-demo-app/main.py
+++ b/gemini/multimodal-live-api/websocket-demo-app/main.py
@@ -5,6 +5,12 @@ import websockets
 from websockets.legacy.protocol import WebSocketCommonProtocol
 from websockets.legacy.server import WebSocketServerProtocol
 
+import ssl
+import certifi
+
+ssl_context = ssl.create_default_context()
+ssl_context.load_verify_locations(certifi.where())
+
 HOST = "us-central1-aiplatform.googleapis.com"
 SERVICE_URL = f"wss://{HOST}/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent"
 
@@ -51,7 +57,7 @@ async def create_proxy(
     }
 
     async with websockets.connect(
-        SERVICE_URL, additional_headers=headers
+        SERVICE_URL, additional_headers=headers, ssl=ssl_context
     ) as server_websocket:
         client_to_server_task = asyncio.create_task(
             proxy_task(client_websocket, server_websocket)

--- a/gemini/multimodal-live-api/websocket-demo-app/requirements.txt
+++ b/gemini/multimodal-live-api/websocket-demo-app/requirements.txt
@@ -1,2 +1,3 @@
 websockets==14.1
 asyncio==3.4.3
+certifi==2024.8.30


### PR DESCRIPTION
# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [X ] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [ ] Appropriate docs were updated (if necessary)

The Fix:

The following error was encountered when "Connect" was pressed:

`ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)`

The fix is to use certifi and make sure ssl_context using certifi is passed into the websocket creation.