### PR TITLE
fix: change edit mode for product background editing

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -40,6 +40,7 @@ Bao
 Beckham
 Benno
 Bettes
+bgswap
 Biden
 Bigtable
 Bitcoin

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -40,7 +40,6 @@ Bao
 Beckham
 Benno
 Bettes
-bgswap
 Biden
 Bigtable
 Bitcoin
@@ -574,6 +573,7 @@ baxis
 bbc
 beir
 bff
+bgswap
 bigframes
 bigquery
 bitcoin

--- a/vision/getting-started/imagen3_editing.ipynb
+++ b/vision/getting-started/imagen3_editing.ipynb
@@ -543,11 +543,12 @@
         "id": "68909c926952"
       },
       "source": [
-        "### Product background editing\n",
+        "### Product background editing via bgswap mode\n",
         "\n",
-        "You can also use Imagen 3 for product image editing. By using a mask, you can maintain the product content while modifying other aspects of the image. \n",
         "\n",
-        "For this example, start with an image stored in a Google Cloud Storage bucket. Use automatic mask detection to identify the background of the image and provide a prompt describing the new background scene.  "
+        "You can also use Imagen 3 for product image editing. By setting `edit_mode` to \"bgswap\", you can maintain the product content while modifying the image background.\n",
+        "\n",
+        "For this example, start with an image stored in a Google Cloud Storage bucket, and provide a prompt describing the new background scene.  "
       ]
     },
     {
@@ -562,12 +563,12 @@
         "    gcs_uri=\"gs://cloud-samples-data/generative-ai/image/suitcase.png\"\n",
         ")\n",
         "raw_ref_image = RawReferenceImage(image=product_image, reference_id=0)\n",
-        "mask_ref_image = MaskReferenceImage(reference_id=1, image=None, mask_mode=\"background\")\n",
-        "prompt = \"a large window in an airport, airplanes taking off in the distance\"\n",
+        "prompt = \"a light blue suitcase[0] in front of a window in an airport, lots of bright, natural lighting coming in from the windows, planes taking off in the distance\"\n",
         "edited_image = edit_model.edit_image(\n",
         "    prompt=prompt,\n",
-        "    edit_mode=\"inpainting-insert\",\n",
-        "    reference_images=[raw_ref_image, mask_ref_image],\n",
+        "    edit_mode=\"bgswap\",\n",
+        "    reference_images=[raw_ref_image],\n",
+        "    seed=1,\n",
         "    number_of_images=1,\n",
         "    safety_filter_level=\"block_some\",\n",
         "    person_generation=\"allow_adult\",\n",


### PR DESCRIPTION
Correct the Imagen 3 editing example to use "bgswap" instead of "inpainting-insert"