### PR TITLE
fix: textembedding gecko 003 change from latest

### DIFF
--- a/gemini/use-cases/retrieval-augmented-generation/utils/intro_multimodal_rag_utils.py
+++ b/gemini/use-cases/retrieval-augmented-generation/utils/intro_multimodal_rag_utils.py
@@ -20,7 +20,7 @@ from vertexai.language_models import TextEmbeddingModel
 from vertexai.vision_models import Image as vision_model_Image
 from vertexai.vision_models import MultiModalEmbeddingModel
 
-text_embedding_model = TextEmbeddingModel.from_pretrained("textembedding-gecko@latest")
+text_embedding_model = TextEmbeddingModel.from_pretrained("textembedding-gecko@003")
 multimodal_embedding_model = MultiModalEmbeddingModel.from_pretrained(
     "multimodalembedding@001"
 )


### PR DESCRIPTION
# Description

As described in the issue [1571](https://github.com/GoogleCloudPlatform/generative-ai/issues/1571) the gecko version can't load if it's specified as the latest, it's also not recommended by the documentation, I've changed it to the version 003.

Fixes ##1571 🦕
