### PR TITLE
Fix: Update the path to the Google-10K 14 page pdf in multimodal_rag_langchain.ipynb

### DIFF
--- a/gemini/use-cases/retrieval-augmented-generation/multimodal_rag_langchain.ipynb
+++ b/gemini/use-cases/retrieval-augmented-generation/multimodal_rag_langchain.ipynb
@@ -388,7 +388,7 @@
       "outputs": [],
       "source": [
         "# Download documents and images used in this notebook\n",
-        "!gsutil -m rsync -r gs://github-repo/rag/intro_multimodal_rag/ .\n",
+        "!gsutil -m rsync -r gs://github-repo/rag/multimodal_rag_langchain/ .\n",
         "print(\"Download completed\")"
       ]
     },


### PR DESCRIPTION
The [google-10k-sample-14pages.pdf](https://storage.googleapis.com/github-repo/rag/multimodal_rag_langchain/google-10k-sample-14pages.pdf) needed for the gemini/use-cases/retrieval-augmented-generation/multimodal_rag_langchain.ipynb is present in gs://github-repo/rag/multimodal_rag_langchain/ instead of gs://github-repo/rag/intro_multimodal_rag/. This PR updates the path for downloading it in the rsync command.

Fixes #742 
