### PR TITLE
fix: Add voice config example for live API

### DIFF
--- a/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb
+++ b/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb
@@ -175,7 +175,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 36,
+      "execution_count": null,
       "metadata": {
         "id": "xBCH3hnAX9Bh"
       },
@@ -185,7 +185,12 @@
         "\n",
         "from IPython.display import Audio, Markdown, display\n",
         "from google import genai\n",
-        "from google.genai.types import LiveConnectConfig\n",
+        "from google.genai.types import (\n",
+        "    LiveConnectConfig,\n",
+        "    PrebuiltVoiceConfig,\n",
+        "    SpeechConfig,\n",
+        "    VoiceConfig,\n",
+        ")\n",
         "import numpy as np"
       ]
     },
@@ -339,6 +344,13 @@
       "source": [
         "config = LiveConnectConfig(\n",
         "    response_modalities=[\"AUDIO\"],\n",
+        "    speech_config=SpeechConfig(\n",
+        "        voice_config=VoiceConfig(\n",
+        "            prebuilt_voice_config=PrebuiltVoiceConfig(\n",
+        "                voice_name=\"Aoede\",\n",
+        "            )\n",
+        "        )\n",
+        "    ),\n",
         ")\n",
         "\n",
         "async with client.aio.live.connect(\n",


### PR DESCRIPTION
# Description

Add back the voice config example for multimodal live API notebook after the SDK update (b/384020181).