### PR TITLE
fix:  getting_started notebook starter pack eval prompt template

### DIFF
--- a/gemini/sample-apps/e2e-gen-ai-app-starter-pack/notebooks/getting_started.ipynb
+++ b/gemini/sample-apps/e2e-gen-ai-app-starter-pack/notebooks/getting_started.ipynb
@@ -1036,7 +1036,7 @@
         "************\n",
         "Written content: {instance[\"response\"]}\n",
         "************\n",
-        "Original source data: {instance[\"response\"]}\n",
+        "Original source data: {instance[\"reference\"]}\n",
         "\n",
         "Examine the text and determine whether the text is faithful or not.\n",
         "Faithfulness refers to how accurately a generated summary reflects the essential information and key concepts present in the original source document.\n",


### PR DESCRIPTION
Fix the prompt template being used for evaluation in the starter pack getting_started notebook.