### PR TITLE
docs(tutorial_langgraph.ipynb): fix duplicate description in LangGraph tools section

### DIFF
--- a/gemini/reasoning-engine/tutorial_langgraph.ipynb
+++ b/gemini/reasoning-engine/tutorial_langgraph.ipynb
@@ -107,7 +107,7 @@
         "This notebook covers the following steps:\n",
         "\n",
         "- **Define Tools**: Create custom Python functions to act as tools your AI application can use.\n",
-        "- **Define Router**: Create custom Python functions to act as tools your AI application can use.\n",
+        "- **Define Router**: Set up routing logic to control conversation flow and tool selection.\n",
         "- **Build a LangGraph Application**: Structure your application using LangGraph, including the Gemini model and custom tools that you define.\n",
         "- **Local Testing**: Test your LangGraph application locally to ensure functionality.\n",
         "- **Deploying to Vertex AI**: Seamlessly deploy your LangGraph application to Reasoning Engine for scalable execution.\n",


### PR DESCRIPTION
- Remove duplicate description "Create custom Python functions to act as tools your AI application can use"

- Replace router description with more specific text about routing logic and tool selection