### PR TITLE
fix: Change Thinking mode to model in markdown

### DIFF
--- a/gemini/getting-started/intro_gemini_2_0_flash_thinking_mode.ipynb
+++ b/gemini/getting-started/intro_gemini_2_0_flash_thinking_mode.ipynb
@@ -29,7 +29,7 @@
         "id": "VyPmicX9RlZX"
       },
       "source": [
-        "# Getting Started with Gemini 2.0 Flash Thinking Mode\n",
+        "# Getting Started with Gemini 2.0 Flash Thinking Model\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td style=\"text-align: center\">\n",
@@ -103,9 +103,9 @@
       "source": [
         "## Overview\n",
         "\n",
-        "[Gemini 2.0 Flash Thinking mode](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking-mode) is an experimental model that's trained to generate the \"thinking process\" the model goes through as part of its response. As a result, the Flash Thinking model is capable of stronger reasoning capabilities in its responses than the Gemini 2.0 Flash model.\n",
+        "[Gemini 2.0 Flash Thinking](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking-mode) is an experimental model that's trained to generate the \"thinking process\" the model goes through as part of its response. As a result, the Flash Thinking model is capable of stronger reasoning capabilities in its responses than the Gemini 2.0 Flash model.\n",
         "\n",
-        "This tutorial demonstrates how to access the Gemini 2.0 Flash Thinking mode and use the model to solve the following complex tasks that require multiple rounds of strategizing and iteratively solving.\n",
+        "This tutorial demonstrates how to access the Gemini 2.0 Flash Thinking model and use the model to solve the following complex tasks that require multiple rounds of strategizing and iteratively solving.\n",
         "\n",
         "- Example 1: Code simplification\n",
         "- Example 2: Geometry problem (with image)\n",
@@ -250,7 +250,7 @@
         "id": "w0u6hYSleE0H"
       },
       "source": [
-        "## Use Gemini 2.0 Flash Thinking Mode\n"
+        "## Use Gemini 2.0 Flash Thinking Model\n"
       ]
     },
     {
@@ -395,7 +395,7 @@
         "id": "IrRBg9UGC9nn"
       },
       "source": [
-        "## Thinking Mode examples\n",
+        "## Thinking Model examples\n",
         "\n",
         "The following examples are some complex tasks that require multiple rounds of strategizing and iteratively solving.\n",
         "\n",


### PR DESCRIPTION
Change the Thinking model to Thinking model in notebook markdown. 
No code changes.
(Keep the filename as it is for now)