### PR TITLE
fix: Renamed the variable "model" to "llm"

### DIFF
--- a/gemini/evaluation/evaluating_langgraph_agent.ipynb
+++ b/gemini/evaluation/evaluating_langgraph_agent.ipynb
@@ -636,7 +636,7 @@
       },
       "outputs": [],
       "source": [
-        "model = \"gemini-1.5-pro\""
+        "llm = \"gemini-1.5-pro\""
       ]
     },
     {
@@ -662,7 +662,7 @@
       "source": [
         "def agent_parsed_outcome(input):\n",
         "\n",
-        "    model = ChatVertexAI(model=model)\n",
+        "    model = ChatVertexAI(model=llm)\n",
         "    builder = MessageGraph()\n",
         "\n",
         "    model_with_tools = model.bind_tools([get_product_details, get_product_price])\n",


### PR DESCRIPTION
The code tries to use the model variable as an argument to ChatVertexAI, but at this point, model has not been defined within the function's scope. It's attempting to use the global model variable you set earlier (model = "gemini-1.5-pro"), but since you're also assigning to model inside the function, Python treats it as a local variable, and it hasn't been assigned a value yet.