### PR TITLE
fix: Correct issue with package installation in Vertex AI SDK in AI agents workshop notebook

### DIFF
--- a/workshops/ai-agents/ai_agents_for_engineers.ipynb
+++ b/workshops/ai-agents/ai_agents_for_engineers.ipynb
@@ -93,7 +93,7 @@
         "    langgraph \\\n",
         "    langchain \\\n",
         "    langchain-google-genai \\\n",
-        "    # langchain-google-vertexai \\\n",
+        "    langchain-google-vertexai \\\n",
         "    langchain-community \\\n",
         "    tavily-python \\\n",
         "    pydantic"


### PR DESCRIPTION
# Description

This PR fixes an issue in the AI agents workshop notebook. The commented out library was causing the packages after it (e.g., `langchain-community`) to not get installed.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)
