### PR TITLE
fix: Update imports in Agent Engine notebooks when using LangChain & LangGraph pre-built templates

### DIFF
--- a/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
+++ b/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
@@ -142,7 +142,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade --user --quiet \"google-cloud-aiplatform[evaluation, langchain, agent_engines]\" \\\n",
+        "%pip install --upgrade --user --quiet \"google-cloud-aiplatform[agent_engines,evaluation,langchain]\" \\\n",
         "    \"langchain_google_vertexai\" \\\n",
         "    \"cloudpickle==3.0.0\" \\\n",
         "    \"pydantic>=2.10\" \\\n",
@@ -296,6 +296,7 @@
         "import pandas as pd\n",
         "import plotly.graph_objects as go\n",
         "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent\n",
         "\n",
         "# Evaluate agent\n",
         "from vertexai.preview.evaluation import EvalTask\n",
@@ -576,7 +577,7 @@
       },
       "outputs": [],
       "source": [
-        "local_1p_agent = agent_engines.LangchainAgent(\n",
+        "local_1p_agent = LangchainAgent(\n",
         "    model=model,\n",
         "    tools=[get_product_details, get_product_price],\n",
         "    agent_executor_kwargs={\"return_intermediate_steps\": True},\n",

--- a/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
+++ b/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
@@ -296,7 +296,6 @@
         "import pandas as pd\n",
         "import plotly.graph_objects as go\n",
         "from vertexai import agent_engines\n",
-        "from vertexai.preview.reasoning_engines import LangchainAgent\n",
         "\n",
         "# Evaluate agent\n",
         "from vertexai.preview.evaluation import EvalTask\n",
@@ -304,7 +303,8 @@
         "    PointwiseMetric,\n",
         "    PointwiseMetricPromptTemplate,\n",
         "    TrajectorySingleToolUse,\n",
-        ")"
+        ")\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {

--- a/gemini/agent-engine/intro_agent_engine.ipynb
+++ b/gemini/agent-engine/intro_agent_engine.ipynb
@@ -310,7 +310,8 @@
       },
       "outputs": [],
       "source": [
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -440,7 +441,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    model=model,\n",
         "    tools=[get_exchange_rate],\n",
         "    agent_executor_kwargs={\"return_intermediate_steps\": True},\n",
@@ -648,7 +649,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    model=model,\n",
         "    tools=[get_exchange_rate],\n",
         ")"

--- a/gemini/agent-engine/langgraph_human_in_the_loop.ipynb
+++ b/gemini/agent-engine/langgraph_human_in_the_loop.ipynb
@@ -273,7 +273,8 @@
       "source": [
         "from langchain.load import load as langchain_load\n",
         "import requests\n",
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -382,7 +383,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LanggraphAgent(\n",
+        "agent = LanggraphAgent(\n",
         "    model=\"gemini-1.5-pro\",\n",
         "    tools=[get_exchange_rate],\n",
         "    model_kwargs={\"temperature\": 0, \"max_retries\": 6},\n",
@@ -859,7 +860,7 @@
       "outputs": [],
       "source": [
         "remote_agent = agent_engines.create(\n",
-        "    agent_engines.LanggraphAgent(\n",
+        "    LanggraphAgent(\n",
         "        model=\"gemini-1.5-pro\",\n",
         "        tools=[get_exchange_rate],\n",
         "        model_kwargs={\"temperature\": 0, \"max_retries\": 6},\n",

--- a/gemini/agent-engine/langgraph_human_in_the_loop.ipynb
+++ b/gemini/agent-engine/langgraph_human_in_the_loop.ipynb
@@ -273,8 +273,7 @@
       "source": [
         "from langchain.load import load as langchain_load\n",
         "import requests\n",
-        "from vertexai import agent_engines\n",
-        "from vertexai.preview.reasoning_engines import LangchainAgent"
+        "from vertexai import agent_engines"
       ]
     },
     {

--- a/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
+++ b/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
@@ -206,7 +206,7 @@
       "outputs": [],
       "source": [
         "%pip install --upgrade --user --quiet \\\n",
-        "    \"google-cloud-aiplatform[agent_engines,langchain,]\" \\\n",
+        "    \"google-cloud-aiplatform[agent_engines,langchain]\" \\\n",
         "    cloudpickle==3.0.0 \\\n",
         "    \"pydantic>=2.10\" \\\n",
         "    google-cloud-trace"
@@ -342,6 +342,7 @@
         "from google.cloud import trace_v1 as trace\n",
         "import pandas as pd\n",
         "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent\n",
         "from vertexai.agent_engines._agent_engines import _utils"
       ]
     },
@@ -435,7 +436,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    model=\"gemini-1.5-pro\",\n",
         "    model_kwargs={\"temperature\": 0},\n",
         "    tools=[classify_ticket, search_knowledge_base, escalate_to_human],\n",

--- a/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
+++ b/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
@@ -342,8 +342,8 @@
         "from google.cloud import trace_v1 as trace\n",
         "import pandas as pd\n",
         "from vertexai import agent_engines\n",
-        "from vertexai.preview.reasoning_engines import LangchainAgent\n",
-        "from vertexai.agent_engines._agent_engines import _utils"
+        "from vertexai.agent_engines._agent_engines import _utils\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {

--- a/gemini/agent-engine/tutorial_alloydb_rag_agent.ipynb
+++ b/gemini/agent-engine/tutorial_alloydb_rag_agent.ipynb
@@ -171,7 +171,8 @@
         "from langchain_google_vertexai import VertexAIEmbeddings\n",
         "from sqlalchemy import text  # noqa: F401\n",
         "import vertexai\n",
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -679,7 +680,7 @@
         "vertexai.init(project=PROJECT_ID, location=\"us-central1\", staging_bucket=STAGING_BUCKET)\n",
         "\n",
         "remote_app = agent_engines.create(\n",
-        "    agent_engines.LangchainAgent(\n",
+        "    LangchainAgent(\n",
         "        model=\"gemini-pro\",\n",
         "        tools=[similarity_search],\n",
         "        model_kwargs={\n",
@@ -687,7 +688,7 @@
         "        },\n",
         "    ),\n",
         "    requirements=[\n",
-        "        \"google-cloud-aiplatform[agent_engines,langchain]==1.68.0\",\n",
+        "        \"google-cloud-aiplatform[agent_engines,langchain]\",\n",
         "        \"langchain-google-alloydb-pg==0.7.0\",\n",
         "        \"langchain-google-vertexai==1.0.4\",\n",
         "    ],\n",

--- a/gemini/agent-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
+++ b/gemini/agent-engine/tutorial_cloud_sql_pg_rag_agent.ipynb
@@ -171,7 +171,8 @@
         "from langchain_google_vertexai import VertexAIEmbeddings\n",
         "from sqlalchemy import text  # noqa: F401\n",
         "import vertexai\n",
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -622,7 +623,7 @@
         "vertexai.init(project=PROJECT_ID, location=\"us-central1\", staging_bucket=STAGING_BUCKET)\n",
         "\n",
         "remote_app = agent_engines.create(\n",
-        "    agent_engines.LangchainAgent(\n",
+        "    LangchainAgent(\n",
         "        model=\"gemini-pro\",\n",
         "        tools=[similarity_search],\n",
         "        model_kwargs={\n",
@@ -630,7 +631,7 @@
         "        },\n",
         "    ),\n",
         "    requirements=[\n",
-        "        \"google-cloud-aiplatform[agent_engines,langchain]==1.68.0\",\n",
+        "        \"google-cloud-aiplatform[agent_engines,langchain]\",\n",
         "        \"langchain-google-cloud-sql-pg==0.10.0\",\n",
         "        \"langchain-google-vertexai==1.0.10\",\n",
         "    ],\n",

--- a/gemini/agent-engine/tutorial_google_maps_agent.ipynb
+++ b/gemini/agent-engine/tutorial_google_maps_agent.ipynb
@@ -328,7 +328,8 @@
         "from google.cloud import resourcemanager_v3, storage\n",
         "import matplotlib.pyplot as plt\n",
         "from rasterio.io import MemoryFile\n",
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -644,7 +645,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    model=model,\n",
         "    model_kwargs={\"temperature\": 0},\n",
         "    tools=[\n",
@@ -718,7 +719,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    model=model,\n",
         "    model_kwargs={\"temperature\": 0},\n",
         "    tools=[\n",

--- a/gemini/agent-engine/tutorial_vertex_ai_search_rag_agent.ipynb
+++ b/gemini/agent-engine/tutorial_vertex_ai_search_rag_agent.ipynb
@@ -306,7 +306,8 @@
         "from langchain.agents.format_scratchpad.tools import format_to_tool_messages\n",
         "from langchain.memory import ChatMessageHistory\n",
         "from langchain_core import prompts\n",
-        "from vertexai import agent_engines"
+        "from vertexai import agent_engines\n",
+        "from vertexai.preview.reasoning_engines import LangchainAgent"
       ]
     },
     {
@@ -516,7 +517,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    prompt=prompt,\n",
         "    model=model,\n",
         "    chat_history=get_session_history,\n",
@@ -594,7 +595,7 @@
       },
       "outputs": [],
       "source": [
-        "agent = agent_engines.LangchainAgent(\n",
+        "agent = LangchainAgent(\n",
         "    prompt=prompt,\n",
         "    model=model,\n",
         "    chat_history=get_session_history,\n",


### PR DESCRIPTION
# Description

This PR is a followup to #1787 that fixes imports in Agent Engine due to different namespaces in current Vertex AI SDK release. Where we use pre-built templates, we need to use the `from vertexai.preview.reasoning_engines import [Langgraph|Langchain|AG2]Agent` namespace. Where we perform CRUD operations on agents, we need to use the `from vertexai import agent_engines` namespace.


- [X] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [X] You are listed as the author in your notebook or README file.
  - [X] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [X] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [X] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [X] Appropriate docs were updated (if necessary)
