### PR TITLE
fix: Update notebook from reasoning engine to agent engine

### DIFF
--- a/gemini/sample-apps/photo-discovery/ag-web/ag_setup_re.ipynb
+++ b/gemini/sample-apps/photo-discovery/ag-web/ag_setup_re.ipynb
@@ -29,9 +29,9 @@
         "id": "r11Gu7qNgx1p"
       },
       "source": [
-        "# Building a photo recognition agent: Reasoning Engine setup\n",
+        "# Building a photo recognition agent: Agent Engine setup\n",
         "\n",
-        "This notebook shows how to setup the Reasoning Engine for the photo recognition agent demo"
+        "This notebook shows how to setup the Agent Engine for the photo recognition agent demo"
       ]
     },
     {
@@ -42,7 +42,7 @@
       "source": [
         "### Install Vertex AI SDK for Python\n",
         "\n",
-        "Install the latest version of the Vertex AI SDK for Python as well as extra dependencies related to Reasoning Engine and LangChain:"
+        "Install the latest version of the Vertex AI SDK for Python as well as extra dependencies related to Agent Engine and LangChain:"
       ]
     },
     {
@@ -53,7 +53,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade --quiet google-cloud-aiplatform[langchain,reasoningengine]==1.55.0 google-cloud-discoveryengine==0.11.10"
+        "%pip install --upgrade --quiet google-cloud-aiplatform[langchain,agent_engines]==1.83.0 google-cloud-discoveryengine==0.11.10"
       ]
     },
     {
@@ -141,7 +141,7 @@
       },
       "source": [
         "## Wikipedia Tool\n",
-        "In this section, you'll define multiple Python functions that access the Wikipedia API. Later we'll use these Python functions as Tools in our Reasoning Engine agent."
+        "In this section, you'll define multiple Python functions that access the Wikipedia API. Later we'll use these Python functions as Tools in our Agent Engine agent."
       ]
     },
     {
@@ -275,6 +275,7 @@
       },
       "outputs": [],
       "source": [
+        "from vertexai import agent_engines\n",
         "from vertexai.preview import reasoning_engines\n",
         "\n",
         "GOOGLE_SHOP_VERTEXAI_SEARCH_URL = (\n",
@@ -316,7 +317,7 @@
       },
       "source": [
         "## Define and deploy the Agent\n",
-        "In this section, it creates an agent with the Wikipedia Tool and Search Tool, and deploy it to the Reasoning Engine runtime.\n",
+        "In this section, it creates an agent with the Wikipedia Tool and Search Tool, and deploy it to the Agent Engine runtime.\n",
         "\n",
         "### Define the agent"
       ]
@@ -422,7 +423,7 @@
         "id": "Gpz4arAz4LD2"
       },
       "source": [
-        "### Deploy the Agent to the Reasoning Engine runtime"
+        "### Deploy the Agent to the Agent Engine runtime"
       ]
     },
     {
@@ -436,24 +437,24 @@
           "name": "stdout",
           "output_type": "stream",
           "text": [
-            "Using bucket gcp-samples-ic0-ag\n",
-            "Writing to gs://gcp-samples-ic0-ag/reasoning_engine/reasoning_engine.pkl\n",
-            "Writing to gs://gcp-samples-ic0-ag/reasoning_engine/requirements.txt\n",
-            "Creating in-memory tarfile of extra_packages\n",
-            "Writing to gs://gcp-samples-ic0-ag/reasoning_engine/dependencies.tar.gz\n",
-            "Creating ReasoningEngine\n",
-            "Create ReasoningEngine backing LRO: projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056/operations/8418596355013869568\n",
-            "ReasoningEngine created. Resource name: projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056\n",
-            "To use this ReasoningEngine in another session:\n",
-            "reasoning_engine = vertexai.preview.reasoning_engines.ReasoningEngine('projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056')\n"
+            "INFO:vertexai.agent_engines:Using bucket gcp-samples-ic0-ag\n",
+            "INFO:vertexai.agent_engines:Writing to gs://gcp-samples-ic0-ag/agent_engine/agent_engine.pkl\n",
+            "INFO:vertexai.agent_engines:Writing to gs://gcp-samples-ic0-ag/agent_engine/requirements.txt\n",
+            "INFO:vertexai.agent_engines:Creating in-memory tarfile of extra_packages\n",
+            "INFO:vertexai.agent_engines:Writing to gs://gcp-samples-ic0-ag/agent_engine/dependencies.tar.gz\n",
+            "INFO:vertexai.agent_engines:Creating AgentEngine\n",
+            "INFO:vertexai.agent_engines:Create AgentEngine backing LRO: projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056/operations/8418596355013869568\n",
+            "INFO:vertexai.agent_engines:AgentEngine created. Resource name: projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056\n",
+            "INFO:vertexai.agent_engines:To use this AgentEngine in another session:\n",
+            "INFO:vertexai.agent_engines:agent_engine = vertexai.agent_engines.get('projects/761793285222/locations/us-central1/reasoningEngines/6978222069494317056')\n"
           ]
         }
       ],
       "source": [
-        "remote_agent = reasoning_engines.ReasoningEngine.create(\n",
+        "remote_agent = agent_engines.create(\n",
         "    agent,\n",
         "    requirements=[\n",
-        "        \"google-cloud-aiplatform[langchain,reasoningengine]\",\n",
+        "        \"google-cloud-aiplatform[langchain,agent_engines]\",\n",
         "        \"requests\",\n",
         "    ],\n",
         ")"


### PR DESCRIPTION
# Description

This PR is a followup to https://github.com/GoogleCloudPlatform/generative-ai/pull/1787 and https://github.com/GoogleCloudPlatform/generative-ai/pull/1794 that fixes imports in Agent Engine due to different namespaces in current Vertex AI SDK release

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)
