### PR TITLE
adding a API with function as a tool along with search

### DIFF
--- a/gemini/agent-engine/tutorial_vertex_ai_search_rag_agent.ipynb
+++ b/gemini/agent-engine/tutorial_vertex_ai_search_rag_agent.ipynb
@@ -404,7 +404,33 @@
         "    )\n",
         "\n",
         "    result = str(retriever.invoke(query))\n",
-        "    return result"
+        "    return result\n",
+        "\n",
+        "def get_exchange_rate(currency_from: str, currency_to: str, currency_date: str = \"latest\"):\n",
+        "    \"\"\"\n",
+        "    Fetches the exchange rate from the Frankfurter API.\n",
+        "    Do all the calculation if asked.\n",
+        "    \n",
+        "    Args:\n",
+        "        currency_from (str): The base currency (e.g., \"USD\").\n",
+        "        currency_to (str): The target currency (e.g., \"INR\").\n",
+        "        currency_date (str): The date for the exchange rate (e.g., \"latest\" or \"YYYY-MM-DD\").\n",
+        "    \n",
+        "    Returns:\n",
+        "        float or str: The exchange rate if successful, otherwise an error message.\n",
+        "    \"\"\"\n",
+        "    url = f\"https://api.frankfurter.app/{currency_date}\"\n",
+        "    params = {\n",
+        "        \"from\": currency_from,\n",
+        "        \"to\": currency_to\n",
+        "    }\n",
+        "    response = requests.get(url, params=params)\n",
+        "    \n",
+        "    if response.status_code == 200:\n",
+        "        data = response.json()\n",
+        "        return data.get(\"rates\", {}).get(currency_to, \"No rate found.\")\n",
+        "    else:\n",
+        "        return f\"Error: Unable to fetch data.\""
       ]
     },
     {
@@ -436,6 +462,15 @@
       ],
       "source": [
         "search_kaggle_movies(\"Harry Potter\")"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "get_exchange_rate(\"USD\", \"INR\")"
       ]
     },
     {
@@ -522,7 +557,7 @@
         "    model=model,\n",
         "    chat_history=get_session_history,\n",
         "    model_kwargs={\"temperature\": 0},\n",
-        "    tools=[search_kaggle_movies],\n",
+        "    tools=[search_kaggle_movies, get_exchange_rate],\n",
         "    agent_executor_kwargs={\"return_intermediate_steps\": True},\n",
         ")"
       ]
@@ -575,6 +610,20 @@
       ]
     },
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "response = agent.query(\n",
+        "    input=\"How much is us dollar to euro today\",\n",
+        "    config={\"configurable\": {\"session_id\": \"demo\"}},\n",
+        ")\n",
+        "\n",
+        "Markdown(response[\"output\"])"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "9abc4a214f3c"
@@ -600,7 +649,7 @@
         "    model=model,\n",
         "    chat_history=get_session_history,\n",
         "    model_kwargs={\"temperature\": 0},\n",
-        "    tools=[search_kaggle_movies],\n",
+        "    tools=[search_kaggle_movies, get_exchange_rate],\n",
         "    agent_executor_kwargs={\"return_intermediate_steps\": True},\n",
         ")"
       ]


### PR DESCRIPTION
# Description

This PR introduces the get_exchange_rate function, enabling real-time and historical currency conversion by fetching exchange rates from an external API. It allows specifying a base currency, target currency, and an optional date while handling API requests dynamically and managing errors gracefully.

Additionally, get_exchange_rate is integrated as a tool in the tools list, enhancing the agent’s capability to retrieve exchange rates not only from the datastore but also from an external API when needed.