### PR TITLE
fix: updated pinecone client and resolved `client` name conflicts in rag pinecone colab

### DIFF
--- a/gemini/rag-engine/rag_engine_pinecone.ipynb
+++ b/gemini/rag-engine/rag_engine_pinecone.ipynb
@@ -131,7 +131,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade --quiet google-cloud-aiplatform google-cloud-secret-manager \"pinecone-client[grpc]\" google-genai"
+        "%pip install --upgrade --quiet google-cloud-aiplatform google-cloud-secret-manager \"pinecone[grpc]\" google-genai"
       ]
     },
     {
@@ -425,11 +425,11 @@
       "source": [
         "from google.cloud import secretmanager\n",
         "\n",
-        "client = secretmanager.SecretManagerServiceClient()\n",
+        "secretmanager_client = secretmanager.SecretManagerServiceClient()\n",
         "\n",
         "# Create the secret.\n",
-        "secret = client.create_secret(\n",
-        "    parent=client.common_project_path(PROJECT_ID),\n",
+        "secret = secretmanager_client.create_secret(\n",
+        "    parent=secretmanager_client.common_project_path(PROJECT_ID),\n",
         "    secret_id=SECRET_ID,\n",
         "    secret=secretmanager.Secret(\n",
         "        replication=secretmanager.Replication(\n",
@@ -439,7 +439,7 @@
         ")\n",
         "\n",
         "# Add API key to the secret payload.\n",
-        "secret_version = client.add_secret_version(\n",
+        "secret_version = secretmanager_client.add_secret_version(\n",
         "    parent=secret.name,\n",
         "    payload=secretmanager.SecretPayload(data=PINECONE_API_KEY.encode(\"UTF-8\")),\n",
         ")\n",


### PR DESCRIPTION
# Description

Update Pinecone client import and disambiguate client references in rag pinecone colab

- Replace deprecated `pinecone-client` with `pinecone`
- Rename `client` references in Colab to avoid reference conflict between Secret Manager and GenAI object.
