### PR TITLE
fix: ev_agent error in extract entities

### DIFF
--- a/gemini/agents/research-multi-agents/ev_agent/agent_handler/agent_03_QueryAnalysisAgent.py
+++ b/gemini/agents/research-multi-agents/ev_agent/agent_handler/agent_03_QueryAnalysisAgent.py
@@ -177,20 +177,6 @@ class QueryAnalysisAgent:
                 debug=self.debug,
             )
 
-            function_response_part = types.Part.from_function_response(
-                name=function_call.name, response={"result": result}
-            )
-
-            # Final generation with context
-            final_response = self.client.models.generate_content(
-                model=self.model_name,
-                contents=[
-                    types.Part.from_text(query),
-                    response.candidates[0].content.parts[0],
-                    function_response_part,
-                ],
-            )
-
             return QueryEntities(**result)
 
         except Exception as e:


### PR DESCRIPTION
# Description
Colab Building a Research Multi Agent System - a Design Pattern Overview with Gemini 2.0
https://colab.research.google.com/github/GoogleCloudPlatform/generative-ai/blob/main/gemini/agents/research-multi-agents/intro_research_multi_agents_gemini_2_0.ipynb

has a bug when run 
# Execute the analysis
results = await agent.execute(
    "Show EV charging coverage in Chicago"
)

error:
💥 Error in execution: 'entities'
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
[/content/ev_agent/agent_handler/agent_01_ExecutionAgent.py](https://localhost:8080/#) in execute(self, query)
     81             self._debug_print(results, "green")
---> 82             self.output_type = str(results["query_analysis"]["entities"]["output_type"])
     83 

KeyError: 'entities'

After some debug, i figure out the redundant code make this a bug, so i delete it
'Could not extract required entities from query. Details: from_text() takes 1 positional argument but 2 were given'