### PR TITLE
fix:  Fix `intro to langgraph` notebook.

### DIFF
--- a/gemini/agent-engine/tutorial_langgraph.ipynb
+++ b/gemini/agent-engine/tutorial_langgraph.ipynb
@@ -87,7 +87,7 @@
       "source": [
         "| | |\n",
         "|-|-|\n",
-        "| Author(s) | [Kristopher Overholt](https://github.com/koverholt) |"
+        "| Author(s) | [Kristopher Overholt](https://github.com/koverholt), [Shawn Yang](https://github.com/shawn-yang-google) |"
       ]
     },
     {
@@ -146,7 +146,7 @@
         "%pip install --upgrade --user --quiet \\\n",
         "    \"google-cloud-aiplatform[agent_engines,langchain]\" \\\n",
         "    cloudpickle==3.0.0 \\\n",
-        "    \"pydantic>=2.10\" \\\n",
+        "    \"pydantic==2.11.2\" \\\n",
         "    langgraph \\\n",
         "    httpx"
       ]
@@ -307,7 +307,6 @@
       },
       "outputs": [],
       "source": [
-        "@tool\n",
         "def get_product_details(product_name: str):\n",
         "    \"\"\"Gathers basic details about a product.\"\"\"\n",
         "    details = {\n",
@@ -564,7 +563,7 @@
         "    requirements=[\n",
         "        \"google-cloud-aiplatform[agent_engines,langchain]\",\n",
         "        \"cloudpickle==3.0.0\",\n",
-        "        \"pydantic>=2.10\",\n",
+        "        \"pydantic==2.11.2\",\n",
         "        \"langgraph\",\n",
         "        \"httpx\",\n",
         "    ],\n",


### PR DESCRIPTION
Currently there are two issues in `intro to langgraph` notebook:
1. When deploy the agent, there is an error in the pickle file: AttributeError: 'FieldInfo' object has no attribute '_qualifiers'

2. When send a query to remote agent, there is an error in response: 'Error: TypeError("get_product_details() missing 1 required keyword-only argument: \'product_name\'")\n Please fix your mistakes.'

The first error can be fixed by adding a fixed version for pydantic (i.e., "pydantic==2.11.2").

The 2nd error can be fixed by removing the `@tool` decorator

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)

Fixes 409381713 🦕
