### PR TITLE
feat: add imagen editing example from local file

### DIFF
--- a/vision/getting-started/imagen3_editing.ipynb
+++ b/vision/getting-started/imagen3_editing.ipynb
@@ -499,6 +499,56 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "AnneP_O4vdL1"
+      },
+      "source": [
+        "Below you'll see another instance of inpainting insert. This time you'll use a local image and mask that have been downloaded from Google Cloud Stroage. When using your own mask, you'll specify \"MASK_MODE_USER_PROVIDED\" as the ```mask_mode```."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "87yClMcjsM_O"
+      },
+      "outputs": [],
+      "source": [
+        "! gsutil cp \"gs://cloud-samples-data/generative-ai/image/image-dog.png\" .\n",
+        "! gsutil cp \"gs://cloud-samples-data/generative-ai/image/image-dog-mask.png\" .\n",
+        "initial_image = Image.from_file(location=\"image-dog.png\")\n",
+        "initial_image_mask = Image.from_file(location=\"image-dog-mask.png\")\n",
+        "\n",
+        "edit_prompt = \"a Persian cat sitting in a white cat bed\"\n",
+        "raw_ref_image = RawReferenceImage(reference_image=initial_image, reference_id=0)\n",
+        "mask_ref_image = MaskReferenceImage(\n",
+        "    reference_id=1,\n",
+        "    reference_image=initial_image_mask,\n",
+        "    config=MaskReferenceConfig(\n",
+        "        mask_mode=\"MASK_MODE_USER_PROVIDED\",\n",
+        "        mask_dilation=0.1,\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "edited_image = client.models.edit_image(\n",
+        "    model=edit_model,\n",
+        "    prompt=edit_prompt,\n",
+        "    reference_images=[raw_ref_image, mask_ref_image],\n",
+        "    config=EditImageConfig(\n",
+        "        edit_mode=\"EDIT_MODE_INPAINT_INSERTION\",\n",
+        "        number_of_images=1,\n",
+        "        safety_filter_level=\"BLOCK_MEDIUM_AND_ABOVE\",\n",
+        "        person_generation=\"ALLOW_ADULT\",\n",
+        "    ),\n",
+        ")\n",
+        "\n",
+        "display_images(\n",
+        "    initial_image._pil_image, edited_image.generated_images[0].image._pil_image\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "6ad62258e803"
       },
       "source": [
@@ -506,7 +556,7 @@
         "\n",
         "Inpainting remove allows you to use a mask area to remove image content.\n",
         "\n",
-        "In this next example, you'll take the edited image from the previous cell and create a mask over detected mirror instances. You'll then remove these objects by setting the edit mode to \"EDIT_MODE_INPAINT_REMOVAL.\" For these types of requests the prompt can be an empty string."
+        "In this next example, you'll take an image in Google Cloud Storage of a wall with a mirror and some photos and create a mask over detected mirror instances. You'll then remove this object by setting the edit mode to \"EDIT_MODE_INPAINT_REMOVAL.\" For these types of requests the prompt can be an empty string."
       ]
     },
     {
@@ -517,9 +567,8 @@
       },
       "outputs": [],
       "source": [
-        "raw_ref_image = RawReferenceImage(\n",
-        "    reference_image=edited_image.generated_images[0].image, reference_id=0\n",
-        ")\n",
+        "starting_image = Image(gcs_uri=\"gs://cloud-samples-data/generative-ai/image/mirror.png\")\n",
+        "raw_ref_image = RawReferenceImage(reference_image=starting_image, reference_id=0)\n",
         "mask_ref_image = MaskReferenceImage(\n",
         "    reference_id=1,\n",
         "    reference_image=None,\n",
@@ -540,8 +589,14 @@
         "    ),\n",
         ")\n",
         "\n",
+        "starting_image_show = PIL_Image.open(\n",
+        "    urllib.request.urlopen(\n",
+        "        \"https://storage.googleapis.com/cloud-samples-data/generative-ai/image/mirror.png\"\n",
+        "    )\n",
+        ")\n",
+        "\n",
         "display_images(\n",
-        "    edited_image.generated_images[0].image._pil_image,\n",
+        "    starting_image_show,\n",
         "    remove_image.generated_images[0].image._pil_image,\n",
         ")"
       ]


### PR DESCRIPTION
# Description
Add an example showing Imagen 3 editing with a local image file and a user provided mask. Update inpainting removal example to use a different starting image, rather than the one from the previous cell. 




