### PR TITLE
refactor: remove runtime reboot

### DIFF
--- a/gemini/evaluation/evaluate_models_in_vertex_ai_studio_and_model_garden.ipynb
+++ b/gemini/evaluation/evaluate_models_in_vertex_ai_studio_and_model_garden.ipynb
@@ -202,43 +202,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "Pe2lLnYuOvFp"
-      },
-      "source": [
-        "### Restart runtime\n",
-        "To use the newly installed packages in this Jupyter runtime, you must restart the runtime. You can do this by running the cell below, which restarts the current kernel.\n",
-        "\n",
-        "The restart might take a minute or longer. After it's restarted, continue to the next step."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "B3FDZs3qOvFp"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "LqDc-oyiOvFp"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Wait until it's finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "x1oLkh17OvFp"
       },
       "source": [

--- a/gemini/prompts/examples/chain_of_thought_react.ipynb
+++ b/gemini/prompts/examples/chain_of_thought_react.ipynb
@@ -227,7 +227,6 @@
       },
       "outputs": [],
       "source": [
-        "import IPython\n",
         "from IPython.display import Markdown, display\n",
         "from langchain_google_vertexai import VertexAI"
       ]

--- a/gemini/prompts/examples/chain_of_thought_react.ipynb
+++ b/gemini/prompts/examples/chain_of_thought_react.ipynb
@@ -155,45 +155,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "UXmrQ2Q4KOJi"
-      },
-      "source": [
-        "### Restart runtime\n",
-        "\n",
-        "To use the newly installed packages in this Jupyter runtime, you must restart the runtime. You can do this by running the cell below, which restarts the current kernel.\n",
-        "\n",
-        "The restart might take a minute or longer. After its restarted, continue to the next step.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "zF-SsQAfZWhJ"
-      },
-      "outputs": [],
-      "source": [
-        "# Restart kernel after installs so that your environment can access the new packages\n",
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Q5pJHyT-ZWhK"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
-        "</div>\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "I5VhU_S5ZWhK"
       },
       "source": [

--- a/gemini/prompts/examples/question_answering.ipynb
+++ b/gemini/prompts/examples/question_answering.ipynb
@@ -164,44 +164,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "7c1YgXj17Qyb"
-      },
-      "source": [
-        "### Restart runtime\n",
-        "\n",
-        "To use the newly installed packages in this Jupyter runtime, you must restart the runtime. You can do this by running the cell below, which restarts the current kernel.\n",
-        "\n",
-        "The restart might take a minute or longer. After its restarted, continue to the next step.\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "_Hsqwn4hkLKE"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "VRWao-yanACn"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "Xe7OuYuGkLKF"
       },
       "source": [

--- a/gemini/use-cases/marketing/creative_content_generation.ipynb
+++ b/gemini/use-cases/marketing/creative_content_generation.ipynb
@@ -190,40 +190,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "58707a750154"
-      },
-      "source": [
-        "Restart the kernel after installing packages:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "f200f10a1da3"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "m_5hx_2aDsBX"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "sBCra4QMA2wR"
       },
       "source": [

--- a/vision/getting-started/image_generation.ipynb
+++ b/vision/getting-started/image_generation.ipynb
@@ -177,53 +177,6 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "R5Xep4W9lq-Z"
-      },
-      "source": [
-        "### Restart current runtime\n",
-        "\n",
-        "To use the newly installed packages in this Jupyter runtime, it is recommended to restart the runtime. Run the following cell to restart the current kernel.\n",
-        "\n",
-        "The restart process might take a minute or so."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XRvKdaPDTznN"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "YIvVfyyhTPKi"
-      },
-      "source": [
-        "After the restart is complete, continue to the next step.\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SbmM4z7FOBpM"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. Please wait until it is finished before continuing to the next step. ⚠️</b>\n",
-        "</div>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
         "id": "opUxT_k5TdgP"
       },
       "source": [


### PR DESCRIPTION
Remove runtime reboot to support automated tests.

We're using %pip install to install libraries on the current runtime.
