### PR TITLE
feat: Add thinking example in chat completions API

### DIFF
--- a/gemini/chat-completions/intro_chat_completions_api.ipynb
+++ b/gemini/chat-completions/intro_chat_completions_api.ipynb
@@ -103,18 +103,20 @@
       "source": [
         "## Overview\n",
         "\n",
-        "Developers already working with OpenAI's libraries can easily tap into the power of Gemini by leveraging the Gemini Chat Completions API. The Gemini Chat Completions API offers a streamlined way to experiment with and incorporate Gemini's capabilities into your existing AI applications.\n",
+        "Developers already working with OpenAI's libraries can easily tap into the power of Gemini by leveraging the Chat Completions API. The Chat Completions API offers a streamlined way to experiment with and incorporate Gemini's capabilities into your existing AI applications.\n",
         "\n",
-        "Learn more about [calling Gemini by using the OpenAI library](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library).\n",
+        "If you are not already using the OpenAI libraries, we recommend using the Google Gen AI SDK. Learn more about [calling Vertex AI models by using the OpenAI library](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library).\n",
         "\n",
-        "In this tutorial, you learn how to call Gemini using the OpenAI library. You will complete the following tasks:\n",
+        "In this tutorial, you learn to call Gemini using the OpenAI library. You will complete the following tasks:\n",
         "\n",
-        "- Configure OpenAI SDK for the Gemini Chat Completions API\n",
+        "- Configure OpenAI SDK for the Chat Completions API\n",
         "- Send a chat completions request\n",
         "- Stream chat completions response\n",
         "- Send a multimodal request\n",
         "- Send a function calling request\n",
-        "- Send a function calling request with the `tool_choice` parameter\n"
+        "- Send a function calling request with the `tool_choice` parameter\n",
+        "- Use controlled generation\n",
+        "- Control thinking budget\n"
       ]
     },
     {
@@ -144,42 +146,6 @@
       "outputs": [],
       "source": [
         "%pip install --upgrade --quiet openai google-auth requests"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "R5Xep4W9lq-Z"
-      },
-      "source": [
-        "### Restart runtime\n",
-        "\n",
-        "To use the newly installed packages in this Jupyter runtime, you must restart the runtime. You can do this by running the cell below, which restarts the current kernel."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "XRvKdaPDTznN"
-      },
-      "outputs": [],
-      "source": [
-        "import IPython\n",
-        "\n",
-        "app = IPython.Application.instance()\n",
-        "app.kernel.do_shutdown(True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "SbmM4z7FOBpM"
-      },
-      "source": [
-        "<div class=\"alert alert-block alert-warning\">\n",
-        "<b>⚠️ The kernel is going to restart. The restart might take a minute or longer. After it's restarted, continue to the next step. ⚠️</b>\n",
-        "</div>\n"
       ]
     },
     {
@@ -236,7 +202,7 @@
         "if not PROJECT_ID or PROJECT_ID == \"[your-project-id]\":\n",
         "    PROJECT_ID = str(os.environ.get(\"GOOGLE_CLOUD_PROJECT\"))\n",
         "\n",
-        "LOCATION = os.environ.get(\"GOOGLE_CLOUD_REGION\", \"us-central1\")\n",
+        "LOCATION = os.environ.get(\"GOOGLE_CLOUD_REGION\", \"global\")\n",
         "\n",
         "print(f\"Using Vertex AI with project: {PROJECT_ID} in location: {LOCATION}\")"
       ]
@@ -256,7 +222,7 @@
         "id": "vHwJCyNF6u0O"
       },
       "source": [
-        "### Configure OpenAI SDK for the Gemini Chat Completions API\n",
+        "### Configure OpenAI SDK for the Chat Completions API\n",
         "\n",
         "#### Import libraries\n",
         "\n",
@@ -307,7 +273,7 @@
         "id": "Q04wJmA0HT6X"
       },
       "source": [
-        "Then configure the OpenAI SDK to point to the Gemini Chat Completions API endpoint."
+        "Then configure the OpenAI SDK to point to the Chat Completions API endpoint."
       ]
     },
     {
@@ -318,8 +284,12 @@
       },
       "outputs": [],
       "source": [
+        "api_host = \"aiplatform.googleapis.com\"\n",
+        "if LOCATION != \"global\":\n",
+        "    api_host = f\"{LOCATION}-aiplatform.googleapis.com\"\n",
+        "\n",
         "client = openai.OpenAI(\n",
-        "    base_url=f\"https://{LOCATION}-aiplatform.googleapis.com/v1beta1/projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/openapi\",\n",
+        "    base_url=f\"https://{api_host}/v1/projects/{PROJECT_ID}/locations/{LOCATION}/endpoints/openapi\",\n",
         "    api_key=credentials.token,\n",
         ")"
       ]
@@ -330,13 +300,9 @@
         "id": "UGokrtdiIHrX"
       },
       "source": [
-        "### Gemini models\n",
+        "### Supported models\n",
         "\n",
-        "You can experiment with [various supported Gemini models](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-gemini-using-openai-library#supported_models).\n",
-        "\n",
-        "If you are not sure which model to use, then try `gemini-2.0-flash-001`.\n",
-        "\n",
-        "`gemini-2.0-flash-001` is optimized for multimodal use cases where speed and cost are important."
+        "The Chat Completions API supports both Gemini models and select self-deployed models from Model Garden. Learn more about [supported models](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/call-vertex-using-openai-library#supported_models)."
       ]
     },
     {
@@ -356,7 +322,7 @@
         "id": "uiWrF7U4Q5-E"
       },
       "source": [
-        "### [Example] Send a chat completions request\n",
+        "### **Example**: Send a chat completions request\n",
         "\n",
         "The Chat Completions API takes a list of messages as input and returns a generated message as output. Although the message format is designed to make multi-turn conversations easy, it's just as useful for single-turn tasks without any conversation.\n",
         "\n",
@@ -442,7 +408,7 @@
         "id": "DpHc6sC6PIcI"
       },
       "source": [
-        "### [Example] Stream chat completions response\n",
+        "### **Example**: Stream chat completions response\n",
         "\n",
         "By default, the model returns a response after completing the entire generation process. You can also stream the response as it is being generated, and the model will return chunks of the response as soon as they are generated."
       ]
@@ -471,7 +437,7 @@
         "id": "kqNdZLK8VLaf"
       },
       "source": [
-        "### [Example] Send a multimodal request\n",
+        "### **Example**: Send a multimodal request\n",
         "You can send a multimodal prompt in a request to Gemini and get a text output.\n",
         "\n",
         "In this example, you ask the model to create a blog post for [this image](https://storage.googleapis.com/cloud-samples-data/generative-ai/image/meal.png) stored in a Cloud Storage bucket.\n"
@@ -513,7 +479,7 @@
         "id": "JPJot5D_dE6G"
       },
       "source": [
-        "### [Example] Send a function calling request\n",
+        "### **Example**: Send a function calling request\n",
         "\n",
         "You can use the Chat Completions API for function calling with the Gemini models. The `tools` parameter in the API is used to provide function specifications. This is to enable models to generate function arguments which adhere to the provided specifications.\n",
         "\n",
@@ -573,7 +539,7 @@
         "id": "B82QRs9Oc1HL"
       },
       "source": [
-        "### [Example] Send a function calling request with the `tool_choice` parameter\n",
+        "### **Example**: Send a function calling request with the `tool_choice` parameter\n",
         "\n",
         "Using the `tools` parameter, if the functions parameter is provided then by default the model will decide when it is appropriate to use one of the functions.\n",
         "\n",
@@ -624,6 +590,88 @@
         ")\n",
         "\n",
         "print(response.choices[0].message.tool_calls)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "0706c915f870"
+      },
+      "source": [
+        "### **Example**: Use controlled generation\n",
+        "\n",
+        "The Gemini models allow you to define a response schema to specify the structure of a model's output, the field names, and the expected data type for each field. The response schema is specified in the `response_format` parameter, and the model output will strictly follow that schema."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "735d2eafeb2c"
+      },
+      "outputs": [],
+      "source": [
+        "from pydantic import BaseModel\n",
+        "\n",
+        "\n",
+        "class Recipe(BaseModel):\n",
+        "    name: str\n",
+        "    description: str\n",
+        "    ingredients: list[str]\n",
+        "\n",
+        "\n",
+        "response = client.beta.chat.completions.parse(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=[\n",
+        "        {\n",
+        "            \"role\": \"user\",\n",
+        "            \"content\": \"List a few popular cookie recipes and their ingredients.\",\n",
+        "        }\n",
+        "    ],\n",
+        "    response_format=Recipe,\n",
+        ")\n",
+        "\n",
+        "print(response.choices[0].message)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3857c959d8f5"
+      },
+      "source": [
+        "### **Example**: Control thinking budget\n",
+        "\n",
+        "Gemini 2.5 models are trained to think through complex problems, leading to significantly improved reasoning. The Gemini API comes with a [`thinking_budget`](https://cloud.google.com/vertex-ai/generative-ai/docs/thinking#budget) parameter which gives you control how much the model thinks during its responses.\n",
+        "\n",
+        "See the following mapping between the OpenAI API parameter `reasoning_effort` and the Gemini API parameter `thinking_budget`:\n",
+        "\n",
+        "- reasoning_effort: `none` > thinking_budget: `0`\n",
+        "- reasoning_effort: `low` > thinking_budget: `1024`\n",
+        "- reasoning_effort: `medium` > thinking_budget: `8192`\n",
+        "- reasoning_effort: `high` > thinking_budget: `24576`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "98f16a7eb5c9"
+      },
+      "outputs": [],
+      "source": [
+        "prompt = \"\"\"\n",
+        "Write a bash script that takes a matrix represented as a string with \n",
+        "format '[1,2],[3,4],[5,6]' and prints the transpose in the same format.\n",
+        "\"\"\"\n",
+        "\n",
+        "response = client.chat.completions.create(\n",
+        "    model=\"google/gemini-2.5-flash-preview-04-17\",\n",
+        "    reasoning_effort=\"medium\",\n",
+        "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
+        ")\n",
+        "\n",
+        "Markdown(response.choices[0].message.content)"
       ]
     }
   ],

--- a/gemini/chat-completions/intro_chat_completions_api.ipynb
+++ b/gemini/chat-completions/intro_chat_completions_api.ipynb
@@ -90,9 +90,9 @@
         "id": "84f0f73a0f76"
       },
       "source": [
-        "| | |\n",
-        "|-|-|\n",
-        "|Author(s) | [Eric Dong](https://github.com/gericdong)|"
+        "| Author |\n",
+        "| --- |\n",
+        "| [Eric Dong](https://github.com/gericdong) |"
       ]
     },
     {
@@ -161,7 +161,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "id": "NyKGtVQjgx13"
       },
@@ -231,13 +231,13 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
+      "execution_count": null,
       "metadata": {
         "id": "kolJkBLdHaw0"
       },
       "outputs": [],
       "source": [
-        "from IPython.display import Markdown\n",
+        "from IPython.display import Markdown, display\n",
         "from google.auth import default\n",
         "from google.auth.transport.requests import Request\n",
         "import openai"
@@ -256,7 +256,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 14,
+      "execution_count": null,
       "metadata": {
         "id": "i0qceuiQEPHv"
       },
@@ -278,7 +278,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 15,
+      "execution_count": null,
       "metadata": {
         "id": "c-MRhsnlj6iw"
       },
@@ -307,7 +307,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 16,
+      "execution_count": null,
       "metadata": {
         "id": "r7OhyH46H2H5"
       },
@@ -331,7 +331,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": null,
       "metadata": {
         "id": "JQTWLCzoHyUA"
       },
@@ -421,14 +421,16 @@
       },
       "outputs": [],
       "source": [
-        "response = client.chat.completions.create(\n",
+        "output_text = \"\"\n",
+        "markdown_display_area = display(Markdown(output_text), display_id=True)\n",
+        "\n",
+        "for chunk in client.chat.completions.create(\n",
         "    model=MODEL_ID,\n",
         "    messages=[{\"role\": \"user\", \"content\": \"Why is the sky blue?\"}],\n",
         "    stream=True,\n",
-        ")\n",
-        "\n",
-        "for chunk in response:\n",
-        "    print(chunk.choices[0].delta.content, end=\"\")"
+        "):\n",
+        "    output_text += chunk.choices[0].delta.content\n",
+        "    markdown_display_area.update(Markdown(output_text))"
       ]
     },
     {
@@ -548,7 +550,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 19,
+      "execution_count": null,
       "metadata": {
         "id": "GoEv7CKNXZu1"
       },
@@ -646,10 +648,12 @@
         "\n",
         "See the following mapping between the OpenAI API parameter `reasoning_effort` and the Gemini API parameter `thinking_budget`:\n",
         "\n",
-        "- reasoning_effort: `none` > thinking_budget: `0`\n",
-        "- reasoning_effort: `low` > thinking_budget: `1024`\n",
-        "- reasoning_effort: `medium` > thinking_budget: `8192`\n",
-        "- reasoning_effort: `high` > thinking_budget: `24576`"
+        "| `reasoning_effort` | `thinking_budget` |\n",
+        "|--------------------|-------------------|\n",
+        "| `none`             | `0`               |\n",
+        "| `low`              | `1024`            |\n",
+        "| `medium`           | `8192`            |\n",
+        "| `high`             | `24576`           |"
       ]
     },
     {


### PR DESCRIPTION
Add thinking example in chat completions API

- Remove "Gemini" from API name
- Remove reboot
- Use global endpoint
- Add controlled generation example
- Add thinking budget example