### PR TITLE
fix: Fix Trace SDK import error by force-reinstalling dependencies

### DIFF
--- a/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
+++ b/gemini/agent-engine/tracing_agents_in_agent_engine.ipynb
@@ -205,7 +205,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install --upgrade --user --quiet \\\n",
+        "%pip install --upgrade --user --quiet --force-reinstall \\\n",
         "    \"google-cloud-aiplatform[agent_engines,langchain]\" \\\n",
         "    cloudpickle==3.0.0 \\\n",
         "    \"pydantic>=2.10\" \\\n",


### PR DESCRIPTION
Otherwise, the following import statement

  ```
  from google.cloud import trace_v1 as trace
  ```

throws an `ImportError`:

  ```
  ---------------------------------------------------------------------------

  ImportError                               Traceback (most recent call last)
  <ipython-input-3-dc4ebb6d09de> in <cell line: 0>()
        1 from datetime import datetime, timedelta
        2
  ----> 3 from google.cloud import trace_v1 as trace
        4 import pandas as pd
        5 from vertexai import agent_engines

  ImportError: cannot import name 'trace_v1' from 'google.cloud' (unknown location)

  ---------------------------------------------------------------------------
  ```

b/417488922
