### PR TITLE
Added the pre-requisite for AudioSegment library

### DIFF
--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -138,7 +138,7 @@
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "No17Cw5hgx12"
+        "id": "68664edd8334"
       },
       "source": [
         "### Install FFMpeg on your machine\n",

--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -137,24 +137,6 @@
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "### Install FFMpeg on your machine\n",
-        "\n",
-        "Install the FFMpeg libraries for running the AudioSegment library.",
-        "\n",
-        "If you're using Vertex AI, open the ""Terminal"". Run the following command:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "outputs": [],
-      "source": [
-        "sudo apt-get update && apt-get install ffmpeg -y"
-      ]
-    },
-    {
-      "cell_type": "markdown",
       "metadata": {
         "id": "No17Cw5hgx12"
       },

--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -137,9 +137,6 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {
-        "id": "No17Cw5hgx13"
-      },
       "source": [
         "### Install FFMpeg on your machine\n",
         "\n",
@@ -151,9 +148,6 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {
-        "id": "tFy3H3aPgx22"
-      },
       "outputs": [],
       "source": [
         "sudo apt-get update && apt-get install ffmpeg -y"

--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -138,6 +138,30 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "No17Cw5hgx13"
+      },
+      "source": [
+        "### Install FFMpeg on your machine\n",
+        "\n",
+        "Install the FFMpeg libraries for running the AudioSegment library.",
+        "\n",
+        "If you're using Vertex AI, open the ""Terminal"". Run the following command:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tFy3H3aPgx22"
+      },
+      "outputs": [],
+      "source": [
+        "sudo apt-get update && apt-get install ffmpeg -y"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "No17Cw5hgx12"
       },
       "source": [

--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -135,6 +135,30 @@
         "- **Setting Project Information:**  Setting up your Google Cloud project"
       ]
     },
+     {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "No17Cw5hgx12"
+      },
+      "source": [
+        "### Install FFMpeg on your machine\n",
+        "\n",
+        "Install the FFMpeg libraries for running the AudioSegment library.",
+        "\n",
+        "If you're using Vertex AI, open the ""Terminal"". Run the following command:"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "No17Cw5hgx12"
+      },
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "sudo apt-get update && apt-get install ffmpeg -y"
+      ]
+    },
     {
       "cell_type": "markdown",
       "metadata": {

--- a/gemini/orchestration/langgraph_gemini_podcast.ipynb
+++ b/gemini/orchestration/langgraph_gemini_podcast.ipynb
@@ -135,7 +135,7 @@
         "- **Setting Project Information:**  Setting up your Google Cloud project"
       ]
     },
-     {
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "No17Cw5hgx12"
@@ -145,15 +145,15 @@
         "\n",
         "Install the FFMpeg libraries for running the AudioSegment library.",
         "\n",
-        "If you're using Vertex AI, open the ""Terminal"". Run the following command:"
+        "If you're using Vertex AI, open the **Terminal**. Run the following command:"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "No17Cw5hgx12"
       },
-      "execution_count": null,
       "outputs": [],
       "source": [
         "sudo apt-get update && apt-get install ffmpeg -y"


### PR DESCRIPTION
An error pops up while running the audio consolidation using the Audio Segment library as follows:
"Couldn't find ffmpeg or avmpeg - defaulting to ffmpeg, but may not work warn("Couldn't find ffmpeg or avmpeg- defaulting to ffmpeg, but may not work", RuntimeWarning)"

To avoid this error, the ffmpeg package has to be installed on the machine. Added the instruction to install the "ffmpeg" package on the Terminal in the Vertex AI workbench.
