### PR TITLE
fix: Update the thinking budget range

### DIFF
--- a/gemini/getting-started/intro_gemini_2_5_pro.ipynb
+++ b/gemini/getting-started/intro_gemini_2_5_pro.ipynb
@@ -379,7 +379,7 @@
         "**Notes**\n",
         "\n",
         "- By default, the model automatically controls how much it thinks up to a maximum of 8192 tokens.\n",
-        "- The maximum thinking budget that you can set is 32768 tokens, and the minimum you can set is 128.\n",
+        "- The maximum thinking budget that you can set is `32768` tokens, and the minimum you can set is `128`.\n",
         "\n",
         "Then use the `generate_content` or `generate_content_stream` method to send a request to generate content with the `thinking_config`."
       ]

--- a/gemini/getting-started/intro_gemini_2_5_pro.ipynb
+++ b/gemini/getting-started/intro_gemini_2_5_pro.ipynb
@@ -379,7 +379,7 @@
         "**Notes**\n",
         "\n",
         "- By default, the model automatically controls how much it thinks up to a maximum of 8192 tokens.\n",
-        "- The maximum thinking budget that you can set is 24576 tokens, and the minimum you can set is 64.\n",
+        "- The maximum thinking budget that you can set is 32768 tokens, and the minimum you can set is 128.\n",
         "\n",
         "Then use the `generate_content` or `generate_content_stream` method to send a request to generate content with the `thinking_config`."
       ]


### PR DESCRIPTION
Update the thinking budget range for Gemini 2.5 Pro preview to [128, 32768]
