### PR TITLE
fix: Veo prompt format

### DIFF
--- a/vision/getting-started/veo3_video_generation.ipynb
+++ b/vision/getting-started/veo3_video_generation.ipynb
@@ -643,9 +643,7 @@
       "outputs": [],
       "source": [
         "if prompt == \"\":\n",
-        "    prompt = (\n",
-        "        \"zoom out of the flower field, play whimsical music\"  # @param {type: 'string'}\n",
-        "    )"
+        "    prompt = \"zoom out of the flower field, play whimsical music\"  # @param {type: 'string'}"
       ]
     },
     {


### PR DESCRIPTION
# Description

Fix the formatting of the Veo image to video prompt so that it renders correctly in Colab, allowing users to edit the prompt if they wish 
