### PR TITLE
feat: add video durations

### DIFF
--- a/vision/getting-started/veo3_video_generation.ipynb
+++ b/vision/getting-started/veo3_video_generation.ipynb
@@ -379,13 +379,13 @@
       "source": [
         "### Generate videos from a text prompt\n",
         "\n",
-        "With Veo 3, you have the option to generate 8 second videos from a text prompt. In order to generate a video in the following sample, specify the following info:\n",
+        "With Veo 3, you have the option to generate videos from a text prompt. In order to generate a video in the following sample, specify the following info:\n",
         "- **Prompt:** A detailed description of the video you would like to see. Only edit the prompt if you didn't generate a detailed prompt with Gemini in the previous section.\n",
         "- **Prompt enhancement:** The model offers the option to enhance your provided prompt.\n",
         "- **Audio generation:** Set `generate_audio` to True if you'd like audio to be included in the output video.\n",
         "- **Aspect ratio:** 16:9 or 9:16.\n",
         "- **Number of videos:** Set this value to 1 or 2.\n",
-        "- **Video duration:** 8 seconds\n",
+        "- **Video duration:** 4, 6, or 8 seconds.\n",
         "- **Resolution:** Can be 1080p or 720p."
       ]
     },
@@ -419,7 +419,7 @@
         "    config=types.GenerateVideosConfig(\n",
         "        aspect_ratio=\"16:9\",\n",
         "        number_of_videos=1,\n",
-        "        duration_seconds=8,\n",
+        "        duration_seconds=4,\n",
         "        resolution=\"1080p\",\n",
         "        person_generation=\"allow_adult\",\n",
         "        enhance_prompt=enhance_prompt,\n",
@@ -665,7 +665,7 @@
         "    config=types.GenerateVideosConfig(\n",
         "        aspect_ratio=\"16:9\",\n",
         "        number_of_videos=1,\n",
-        "        duration_seconds=8,\n",
+        "        duration_seconds=6,\n",
         "        resolution=\"1080p\",\n",
         "        person_generation=\"allow_adult\",\n",
         "        enhance_prompt=enhance_prompt,\n",


### PR DESCRIPTION
# Description
Add new feature to generate videos with Veo 3 that are 4, 6, or 8 seconds 


