### PR TITLE
docs: Add required role to Vector Search quickstart

### DIFF
--- a/embeddings/vector-search-quickstart.ipynb
+++ b/embeddings/vector-search-quickstart.ipynb
@@ -93,7 +93,9 @@
       "source": [
         "### Prerequisites\n",
         "\n",
-        "This tutorial requires a Google Cloud project that is linked with a billing account. To create a new project, take a look at [this document](https://cloud.google.com/vertex-ai/docs/start/cloud-environment) to create a project and setup a billing account for it."
+        "This tutorial requires a Google Cloud project that is linked with a billing account. To create a new project, take a look at [this document](https://cloud.google.com/vertex-ai/docs/start/cloud-environment) to create a project and setup a billing account for it.",
+        "\n",
+        "To get the permissions that you need to give a service account access to enable APIs and interact with Vertex AI resources, ask your administrator to grant you the [Security Admin](https://cloud.google.com/iam/docs/roles-permissions/iam#iam.securityAdmin) (`roles/iam.securityAdmin`) IAM role on your project. For more information about granting roles, see [Manage access to projects, folders, and organizations](https://cloud.google.com/iam/docs/granting-changing-revoking-access)." 
       ]
     },
     {


### PR DESCRIPTION
Fixes #2320

Add an explicit requirement to have the Security Admin role to set permissions for the default service account in the project, instead of implicitly assuming the roles. 

I am not listed in the `CODEOWNERS` for this file, but this is also a one-off commit. I was also unable to run the `nox -s format` command due to an error in executing `import nbformat`.

/assign @kazunori279 

