### PR TITLE
fix: Grounding with Google Maps tool configuration fixes

### DIFF
--- a/gemini/grounding/intro-grounding-gemini.ipynb
+++ b/gemini/grounding/intro-grounding-gemini.ipynb
@@ -281,8 +281,6 @@
       "source": [
         "from IPython.display import Markdown, display\n",
         "from google.genai.types import (\n",
-        "    ApiKeyConfig,\n",
-        "    AuthConfig,\n",
         "    EnterpriseWebSearch,\n",
         "    GenerateContentConfig,\n",
         "    GenerateContentResponse,\n",
@@ -399,7 +397,7 @@
       },
       "outputs": [],
       "source": [
-        "MODEL_ID = \"gemini-2.0-flash\"  # @param {type: \"string\"}"
+        "MODEL_ID = \"gemini-2.5-flash\"  # @param {type: \"string\"}"
       ]
     },
     {
@@ -580,29 +578,7 @@
       "source": [
         "## Example: Grounding with Google Maps\n",
         "\n",
-        "You can also use Google Maps data for grounding with Gemini. See the [announcement blog](https://blog.google/products/earth/grounding-google-maps-generative-ai/) for more information.\n",
-        "\n",
-        "**NOTE:** This feature is allowlist-only, refer to the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps) for how to request access."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "0a9ce21ca573"
-      },
-      "source": [
-        "First, you will need to create a [Google Maps API Key](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps#access-to-google-maps)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "53102c85aa24"
-      },
-      "outputs": [],
-      "source": [
-        "GOOGLE_MAPS_API_KEY = \"[your-google-maps-api-key]\"  # @param {type: \"string\"}"
+        "You can also use Google Maps data for grounding with Gemini. See the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps) for more information.\n"
       ]
     },
     {
@@ -613,15 +589,8 @@
       },
       "outputs": [],
       "source": [
-        "google_maps_tool = Tool(\n",
-        "    google_maps=GoogleMaps(\n",
-        "        auth_config=AuthConfig(\n",
-        "            api_key_config=ApiKeyConfig(\n",
-        "                api_key_string=GOOGLE_MAPS_API_KEY,\n",
-        "            )\n",
-        "        )\n",
-        "    )\n",
-        ")\n",
+        "google_maps_tool = Tool(google_maps=GoogleMaps())\n",
+        "\n",
         "PROMPT = \"Recommend some good vegetarian food in Las Vegas.\"\n",
         "\n",
         "response = client.models.generate_content(\n",


### PR DESCRIPTION
Grounding with Google Maps tool configuration fixes:

1. Grounding with Google Maps generally available
2. No Maps API key required for tool configuration
3. Update model to 2.5 Flash