### PR TITLE
refactor: update the text and model for grounding

### DIFF
--- a/gemini/grounding/intro-grounding-gemini.ipynb
+++ b/gemini/grounding/intro-grounding-gemini.ipynb
@@ -588,7 +588,7 @@
       "source": [
         "## Example: Grounding with Google Maps\n",
         "\n",
-        "You can also use Google Maps data for grounding with Gemini. See the [documenation](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps) for more information."
+        "You can also use Google Maps data for grounding with Gemini. See the [documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/grounding/grounding-with-google-maps) for more information."
       ]
     },
     {


### PR DESCRIPTION
Update the text and model for grounding:

- Reference to the Grounding with Google Maps docs instead of the announcement blog, which is out-of-date
- Use 2.5 Flash instead of 2.0 Flash
