### PR TITLE
refactor: add more info for the API version

### DIFF
--- a/gemini/url-context/intro_url_context.ipynb
+++ b/gemini/url-context/intro_url_context.ipynb
@@ -391,7 +391,7 @@
         "\n",
         "You can combine the URL context tool with Grounding with Google Search. This allows the model to first search for relevant information online and then use the URL context tool to get a deeper understanding of the content from the search results.\n",
         "\n",
-        "> ⚠️ This feature is experimental and only available in API version `v1beta1`."
+        "> ⚠️ This feature is experimental and only available in API version `v1beta1`. By default, the SDK uses the beta API endpoints. You also can set the API version to `v1beta1` explicitly, as below:"
       ]
     },
     {


### PR DESCRIPTION
Add the following info about the API version in the SDK:

"By default, the SDK uses the beta API endpoints. You also can set the API version to `v1beta1` explicitly."