### PR TITLE
Update gpt_oss_20B_finetuning_with_unsloth.ipynb - typo in the title

### DIFF
--- a/open-models/fine-tuning/gpt_oss_20B_finetuning_with_unsloth.ipynb
+++ b/open-models/fine-tuning/gpt_oss_20B_finetuning_with_unsloth.ipynb
@@ -29,7 +29,7 @@
         "id": "JAPoU8Sm5E6e"
       },
       "source": [
-        "# Fine-tuning GPT OSS 20B with Unsloth omn Vertex AI Colab Enterprise and Nvidia A100 40GB GPU\n",
+        "# Fine-tuning GPT OSS 20B with Unsloth on Vertex AI Colab Enterprise and Nvidia A100 40GB GPU\n",
         "\n",
         "<table align=\"left\">\n",
         "  <td style=\"text-align: center\">\n",


### PR DESCRIPTION
Typo in the title 
"omn Vertex AI"

replaced by 
"on Vertex AI"