### PR TITLE
feat: Add thought signature example in OpenAI chat completions API

### DIFF
--- a/gemini/chat-completions/intro_chat_completions_api.ipynb
+++ b/gemini/chat-completions/intro_chat_completions_api.ipynb
@@ -119,6 +119,7 @@
         "- Control thinking budget\n",
         "- Set safety settings\n",
         "- Use context caching\n",
+        "- Use thought signature\n",
         "- Use `thought_tag_marker`\n"
       ]
     },
@@ -316,7 +317,7 @@
       },
       "outputs": [],
       "source": [
-        "MODEL_ID = \"google/gemini-2.0-flash-001\"  # @param {type:\"string\"}"
+        "MODEL_ID = \"google/gemini-2.5-flash\"  # @param {type:\"string\"}"
       ]
     },
     {
@@ -695,12 +696,12 @@
       "outputs": [],
       "source": [
         "prompt = \"\"\"\n",
-        "Write a bash script that takes a matrix represented as a string with \n",
+        "Write a bash script that takes a matrix represented as a string with\n",
         "format '[1,2],[3,4],[5,6]' and prints the transpose in the same format.\n",
         "\"\"\"\n",
         "\n",
         "response = client.chat.completions.create(\n",
-        "    model=\"google/gemini-2.5-flash\",\n",
+        "    model=MODEL_ID,\n",
         "    reasoning_effort=\"medium\",\n",
         "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
         ")\n",
@@ -920,10 +921,254 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "a952c50e-8238-4221-a224-0918b75b65a3"
+      },
+      "source": [
+        "### **Example**: Use thought signature\n",
+        "\n",
+        "A thought signature is an encrypted representation of the model's internal reasoning process for a given turn in a conversation. By passing this signature back to the model in subsequent requests, you provide it with the context of its previous thoughts, allowing it to build upon its reasoning and maintain a coherent line of inquiry.\n",
+        "\n",
+        "Thought signatures provide a powerful mechanism to maintain context in multi-turn conversations, enabling the model to tackle more complex, multi-step tasks that require reasoning and the use of external tools through function calling."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "e53c1c9e-094d-4548-935c-1a8451a52e10"
+      },
+      "source": [
+        "#### Conditional Thermostat Control\n",
+        "\n",
+        "In this scenario, a user wants to set a thermostat based on the current weather. The request is: \"If it's too hot or too cold in London, set the thermostat to a comfortable temperature.\"\n",
+        "\n",
+        "This requires the model to:\n",
+        "\n",
+        "- Call a tool to get the weather in London.\n",
+        "- Use the returned weather information to decide if another tool needs to be called.\n",
+        "- Call the tool to set the thermostat if the condition is met."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3f1ab84c-e5a3-485a-929e-d30f688b6523"
+      },
+      "source": [
+        "**Step 1**: Define Functions and Tools\n",
+        "\n",
+        "First, we define the two functions the model can use: `get_current_temperature` and `set_thermostat_temperature`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "092382b9-08b8-42df-8718-41357f1210e1"
+      },
+      "outputs": [],
+      "source": [
+        "import json\n",
+        "\n",
+        "def get_current_temperature(location: str) -> dict:\n",
+        "    \"\"\"Gets the current weather temperature for a given location.\"\"\"\n",
+        "    print(f\"Tool Call: get_current_temperature(location={location})\")\n",
+        "    # Mocking a real API call.\n",
+        "    return {\"temperature\": 30, \"unit\": \"celsius\"}\n",
+        "\n",
+        "\n",
+        "def set_thermostat_temperature(temperature: int) -> dict:\n",
+        "    \"\"\"Sets the thermostat to a desired temperature.\"\"\"\n",
+        "    print(f\"Tool Call: set_thermostat_temperature(temperature={temperature})\")\n",
+        "    # In a real app, this would interact with a thermostat API.\n",
+        "    return {\"status\": \"success\"}\n",
+        "\n",
+        "tools = [\n",
+        "    {\n",
+        "        \"type\": \"function\",\n",
+        "        \"function\": {\n",
+        "            \"name\": \"get_current_temperature\",\n",
+        "            \"description\": \"Gets the current weather temperature for a given location.\",\n",
+        "            \"parameters\": {\n",
+        "                \"type\": \"object\",\n",
+        "                \"properties\": {\"location\": {\"type\": \"string\"}},\n",
+        "                \"required\": [\"location\"],\n",
+        "            },\n",
+        "        },\n",
+        "    },\n",
+        "    {\n",
+        "        \"type\": \"function\",\n",
+        "        \"function\": {\n",
+        "            \"name\": \"set_thermostat_temperature\",\n",
+        "            \"description\": \"Sets the thermostat to a desired temperature.\",\n",
+        "            \"parameters\": {\n",
+        "                \"type\": \"object\",\n",
+        "                \"properties\": {\"temperature\": {\"type\": \"integer\"}},\n",
+        "                \"required\": [\"temperature\"],\n",
+        "            },\n",
+        "        },\n",
+        "    },\n",
+        "]"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "d9d3a3b1-52d8-4741-9a2a-a43e44180197"
+      },
+      "source": [
+        "**Step 2**: First Turn - Get the Weather\n",
+        "\n",
+        "We send the initial prompt to the model. We expect it to call the `get_current_temperature` function and return a thought signature to maintain the context of the user's conditional request."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "92b2632b-c5d4-473c-a73e-41e0a32954e2"
+      },
+      "outputs": [],
+      "source": [
+        "prompt = \"\"\"\n",
+        "If it's too hot or too cold in London, set the temperature to a comfortable level.\n",
+        "Make your own reasonable assumption for what 'comfortable' means and do not ask for clarification.\n",
+        "\"\"\"\n",
+        "\n",
+        "messages = [\n",
+        "    {\"role\": \"user\", \"content\": prompt},\n",
+        "]\n",
+        "\n",
+        "response1 = client.chat.completions.create(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=messages,\n",
+        "    tools=tools,\n",
+        "    extra_body={\n",
+        "        \"extra_body\": {\n",
+        "            \"google\": {\n",
+        "                \"thinking_config\": {\n",
+        "                    \"include_thoughts\": True,\n",
+        "                },\n",
+        "            },\n",
+        "        },\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(response1.choices[0].message.tool_calls)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "3a69330b-1a33-40e9-9903-4137d3a2c38b"
+      },
+      "source": [
+        "**Step 3**: Second Turn - Set the Thermostat\n",
+        "\n",
+        "Now, we send the model's previous response and the result from our first tool call back to the model. The previous response from the model contains the thought signature, which will be passed back to the model. Using this context, the model will decide if it needs to call the `set_thermostat_temperature` function."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "0149957a-4058-4449-b900-24a02a38e99a"
+      },
+      "outputs": [],
+      "source": [
+        "# Append user prompt and assistant response to messages\n",
+        "messages.append(response1.choices[0].message)\n",
+        "\n",
+        "# Execute the tool\n",
+        "tool_call_1 = response1.choices[0].message.tool_calls[0]\n",
+        "result_1 = get_current_temperature(**json.loads(tool_call_1.function.arguments))\n",
+        "\n",
+        "# Append tool response to messages\n",
+        "messages.append(\n",
+        "    {\n",
+        "        \"role\": \"tool\",\n",
+        "        \"tool_call_id\": tool_call_1.id,\n",
+        "        \"content\": json.dumps(result_1),\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "response2 = client.chat.completions.create(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=messages,\n",
+        "    tools=tools,\n",
+        "    extra_body={\n",
+        "        \"extra_body\": {\n",
+        "            \"google\": {\n",
+        "                \"thinking_config\": {\n",
+        "                    \"include_thoughts\": True,\n",
+        "                },\n",
+        "            },\n",
+        "        },\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "print(response2.choices[0].message.tool_calls)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f2f20b6f-3e3f-453c-b441-843a31a8314a"
+      },
+      "source": [
+        "**Step 4**: Final Turn - Get user-facing response\n",
+        "\n",
+        "Finally, we send the conversation history, including the second function call and its result, back to the model to get a final, user-friendly text response."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "e6f244f9-9b10-489d-810f-386a3840382b"
+      },
+      "outputs": [],
+      "source": [
+        "# Append assistant response to messages\n",
+        "messages.append(response2.choices[0].message)\n",
+        "\n",
+        "# Execute the tool\n",
+        "tool_call_2 = response2.choices[0].message.tool_calls[0]\n",
+        "result_2 = set_thermostat_temperature(**json.loads(tool_call_2.function.arguments))\n",
+        "\n",
+        "# Append tool response to messages\n",
+        "messages.append(\n",
+        "    {\n",
+        "        \"role\": \"tool\",\n",
+        "        \"tool_call_id\": tool_call_2.id,\n",
+        "        \"content\": json.dumps(result_2),\n",
+        "    }\n",
+        ")\n",
+        "\n",
+        "response3 = client.chat.completions.create(\n",
+        "    model=MODEL_ID,\n",
+        "    messages=messages,\n",
+        "    tools=tools,\n",
+        "    extra_body={\n",
+        "        \"extra_body\": {\n",
+        "            \"google\": {\n",
+        "                \"thinking_config\": {\n",
+        "                    \"include_thoughts\": True,\n",
+        "                },\n",
+        "            },\n",
+        "        },\n",
+        "    },\n",
+        ")\n",
+        "\n",
+        "Markdown(response3.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "6de86575b07f"
       },
       "source": [
-        "### **Example**:  Use `thought_tag_marker`\t\n",
+        "### **Example**:  Use `thought_tag_marker`\n",
         "\n",
         "This parameter is used to separate a model's thoughts from its responses for models with Thinking available. If not specified, no tags will be returned around the model's thoughts. If present, subsequent queries will strip the thought tags and mark the thoughts appropriately for context. This helps preserve the appropriate context for subsequent queries."
       ]
@@ -943,7 +1188,7 @@
         "\"\"\"\n",
         "\n",
         "response = client.chat.completions.create(\n",
-        "    model=\"google/gemini-2.5-flash\",\n",
+        "    model=MODEL_ID,\n",
         "    messages=[{\"role\": \"user\", \"content\": prompt}],\n",
         "    extra_body={\n",
         "        \"extra_body\": {\n",
@@ -1031,11 +1276,20 @@
         "print(\"\\n--- Answer ---\")\n",
         "print(answer)"
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "jhWyCcUfVLEU"
+      },
+      "outputs": [],
+      "source": []
     }
   ],
   "metadata": {
     "colab": {
-      "name": "intro_chat_completions_api.ipynb",
+      "provenance": [],
       "toc_visible": true
     },
     "kernelspec": {


### PR DESCRIPTION
Add thought signature example in OpenAI chat completions API.

- pass model response containing thought signature to the multi turn conversation history
- update the model to Gemini 2.5 Flash.