### PR TITLE
chore: correct auth and bucket creation snippets

### DIFF
--- a/embeddings/vector-search-2-quickstart.ipynb
+++ b/embeddings/vector-search-2-quickstart.ipynb
@@ -104,6 +104,26 @@
     {
       "cell_type": "markdown",
       "metadata": {
+        "id": "ZBbY9yJvbuL1"
+      },
+      "source": [
+        "## Install the Vector Search SDK"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "69744e32"
+      },
+      "outputs": [],
+      "source": [
+        "%pip install google-cloud-vectorsearch"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
         "id": "bQ5q_KMkbXSi"
       },
       "source": [
@@ -173,26 +193,6 @@
       "outputs": [],
       "source": [
         "! gcloud services enable vectorsearch.googleapis.com aiplatform.googleapis.com --project \"{PROJECT_ID}\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ZBbY9yJvbuL1"
-      },
-      "source": [
-        "## Install the Vector Search SDK"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "69744e32"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install google-cloud-vectorsearch"
       ]
     },
     {


### PR DESCRIPTION
* API enabling command uses gcloud so must be executed after the authentication block (which is now simplified, explicit token is not needed)
* Fix GCS bucket creation command ordering