### PR TITLE
feat: Add activity handling (interrupt) setting to plain JS demo

### DIFF
--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/geminilive.js
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/geminilive.js
@@ -148,6 +148,8 @@ class GeminiLiveAPI {
       start_of_speech_sensitivity: "START_SENSITIVITY_UNSPECIFIED",
     };
 
+    this.activityHandling = "ACTIVITY_HANDLING_UNSPECIFIED";
+
     this.apiHost = "us-central1-aiplatform.googleapis.com";
     this.serviceUrl = `wss://${this.apiHost}/ws/google.cloud.aiplatform.v1beta1.LlmBidiService/BidiGenerateContent`;
 
@@ -319,6 +321,7 @@ class GeminiLiveAPI {
 
         realtime_input_config: {
           automatic_activity_detection: this.automaticActivityDetection,
+          activity_handling: this.activityHandling,
         },
       },
     };

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/index.html
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/index.html
@@ -267,6 +267,19 @@ You are a helpful assistant. Be concise and friendly.</textarea
                 </option>
               </select>
             </div>
+
+            <div>
+              <label for="activityHandling">Activity Handling:</label><br />
+              <select id="activityHandling">
+                <option value="ACTIVITY_HANDLING_UNSPECIFIED" selected>
+                  Default (Interrupts)
+                </option>
+                <option value="START_OF_ACTIVITY_INTERRUPTS">
+                  Interrupt (Barge-in)
+                </option>
+                <option value="NO_INTERRUPTION">No Interruption</option>
+              </select>
+            </div>
           </details>
 
           <br />

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/script.js
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/frontend/script.js
@@ -36,6 +36,7 @@ function initDOM() {
     "prefixPadding",
     "endSpeechSensitivity",
     "startSpeechSensitivity",
+    "activityHandling",
     "connectBtn",
     "disconnectBtn",
     "connectionStatus",
@@ -154,6 +155,9 @@ async function connect() {
       end_of_speech_sensitivity: elements.endSpeechSensitivity.value,
       start_of_speech_sensitivity: elements.startSpeechSensitivity.value,
     };
+
+    // Set activity handling
+    state.client.activityHandling = elements.activityHandling.value;
 
     // Add custom tools only if Google grounding is disabled
     const isGroundingEnabled = elements.enableGrounding.checked;


### PR DESCRIPTION
# Description
This PR adds a configuration option to the Plain JS Gemini Live API demo to control "Activity Handling" (barge-in/interruption). Users can now explicitly toggle whether the model should stop speaking when the user interrupts, or continue speaking.
