### PR TITLE
feat: Add Node.js install instructions to React demo READMEs

### DIFF
--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/customer-support-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/customer-support-demo-app/README.md
@@ -42,6 +42,8 @@ python server.py
 
 In a new terminal, start the React application:
 
+Ensure you have Node.js and npm installed. If not, download and install them from [nodejs.org](https://nodejs.org/en/download/).
+
 ```bash
 # Install Node modules
 npm install

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/gaming-assistant-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/gaming-assistant-demo-app/README.md
@@ -44,6 +44,8 @@ python server.py
 
 In a new terminal, start the React application:
 
+Ensure you have Node.js and npm installed. If not, download and install them from [nodejs.org](https://nodejs.org/en/download/).
+
 ```bash
 # Install Node modules
 npm install

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/react-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/react-demo-app/README.md
@@ -23,6 +23,8 @@ python server.py
 
 In a new terminal, start the React application:
 
+Ensure you have Node.js and npm installed. If not, download and install them from [nodejs.org](https://nodejs.org/en/download/).
+
 ```bash
 # Install Node modules
 npm install

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/realtime-advisor-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/realtime-advisor-demo-app/README.md
@@ -43,6 +43,8 @@ python server.py
 
 In a new terminal, start the React application:
 
+Ensure you have Node.js and npm installed. If not, download and install them from [nodejs.org](https://nodejs.org/en/download/).
+
 ```bash
 # Install Node modules
 npm install


### PR DESCRIPTION

This PR updates the README documentation for the React-based Gemini Live API demos to include a prerequisite step for installing Node.js and npm. This ensures that users who are new to the ecosystem have clear instructions on how to set up their environment before running npm install.

