### PR TITLE
Fix incorrect link to Live API with the Gen AI SDK notebook in intro_…

### DIFF
--- a/gemini/multimodal-live-api/intro_multimodal_live_api.ipynb
+++ b/gemini/multimodal-live-api/intro_multimodal_live_api.ipynb
@@ -1643,7 +1643,7 @@
         "## What's next\n",
         "\n",
         "\n",
-        "- Try [getting started with the Live API with the Gen AI SDK](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/getting-started/intro_genai_sdk.ipynb)\n",
+        "- Try [getting started with the Live API with the Gen AI SDK](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb)\n",
         "- Learn how to [build a web application that enables you to use your voice and camera to talk to Gemini 2.0 through the Live API.](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/gemini/multimodal-live-api/websocket-demo-app)\n",
         "- See the [Live API reference docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/multimodal-live).\n",
         "- Explore other notebooks in the [Google Cloud Generative AI GitHub repository](https://github.com/GoogleCloudPlatform/generative-ai)."


### PR DESCRIPTION
…multimodal_live_api.ipynb

Corrects the hyperlink in the "What's Next" section. The link for "getting started with the Live API" previously pointed to the generic Gemini intro instead of the specific Live API SDK notebook.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
- [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).

Fixes #<issue_number_goes_here> 🦕
