### PR TITLE
Import missing Blob class in intro_multimodal_live_api_genai_sdk.ipynb

### DIFF
--- a/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb
+++ b/gemini/multimodal-live-api/intro_multimodal_live_api_genai_sdk.ipynb
@@ -195,6 +195,7 @@
         "from google.genai.types import (\n",
         "    AudioTranscriptionConfig,\n",
         "    AutomaticActivityDetection,\n",
+        "    Blob,\n",
         "    Content,\n",
         "    EndSensitivity,\n",
         "    GoogleSearch,\n",


### PR DESCRIPTION
The 'Blob' class was used in the notebook in the last cell but missing from the imports, causing a runtime error. This change adds it to the google.genai.types import list.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [ ] You are listed as the author in your notebook or README file.
- [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).

Fixes #<issue_number_goes_here> 🦕
