### PR TITLE
docs: Add demo videos to React and Plain JS READMEs

### DIFF
--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/plain-js-demo-app/README.md
@@ -2,6 +2,8 @@
 
 WebSocket client for Google's Gemini Live API with audio/video streaming support. No frameworks, just vanilla JavaScript.
 
+[![Plain JS Demo Video](https://img.youtube.com/vi/RLM1Qsp64WU/hqdefault.jpg)](https://www.youtube.com/watch?v=RLM1Qsp64WU)
+
 ## Quick Start
 
 ```bash

--- a/gemini/multimodal-live-api/native-audio-websocket-demo-apps/react-demo-app/README.md
+++ b/gemini/multimodal-live-api/native-audio-websocket-demo-apps/react-demo-app/README.md
@@ -2,6 +2,8 @@
 
 A React-based client for Google's Gemini Live API, featuring real-time audio/video streaming and a WebSocket proxy for secure authentication.
 
+[![React Demo Video](https://img.youtube.com/vi/wCrz8tw6xXs/hqdefault.jpg)](https://www.youtube.com/watch?v=wCrz8tw6xXs)
+
 ## Quick Start
 
 ### 1. Backend Setup


### PR DESCRIPTION
# Description

This PR updates the README documentation for the React and Plain JS Gemini Live API demos to include embedded YouTube demonstration videos.