### PR TITLE
Update intro_context_caching.ipynb

### DIFF
--- a/gemini/context-caching/intro_context_caching.ipynb
+++ b/gemini/context-caching/intro_context_caching.ipynb
@@ -449,7 +449,7 @@
       "source": [
         "## Explicit caching\n",
         "\n",
-        "Using the explicit caching feature, you can pass some content to the model once, cache the input tokens, and then refer to the cached tokens for subsequent requests. The minimum input token count for context caching is 1,024 for 2.5 Flash and 2,048 for 2.5 Pro."
+        "Using the explicit caching feature, you can pass some content to the model once, cache the input tokens, and then refer to the cached tokens for subsequent requests. The minimum input token count for context caching is 2,048 for all models."
       ]
     },
     {


### PR DESCRIPTION
As per documentation below, the minimum input token count for context caching is 	2,048 for all models. Updated the code to reflect it correctly.

https://docs.cloud.google.com/vertex-ai/generative-ai/docs/context-cache/context-cache-overview#limits

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- If you are creating a new notebook/sample:
  - [x] You are listed as the author in your notebook or `README` file.
  - [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).

Fixes #<issue_number_goes_here> 🦕
