### PR TITLE
refactor: Batch API also supports global endpoint now

### DIFF
--- a/gemini/batch-prediction/intro_batch_prediction.ipynb
+++ b/gemini/batch-prediction/intro_batch_prediction.ipynb
@@ -511,20 +511,7 @@
         "id": "bfb2a462a7c6"
       },
       "source": [
-        "## BigQuery\n",
-        "\n",
-        "⚠️ Batch predictions using BigQuery currently does not support Global endpoints. "
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "9c694724e069"
-      },
-      "outputs": [],
-      "source": [
-        "client = genai.Client(vertexai=True, project=PROJECT_ID, location=\"us-central1\")"
+        "## BigQuery"
       ]
     },
     {


### PR DESCRIPTION
Batch API BigQuery support also supports global endpoint now.

Remove the special handling to use us-centrals for BigQuery.
