### PR TITLE
refactor: Add a note for multiple GCS input files for batch prediction

### DIFF
--- a/gemini/batch-prediction/intro_batch_prediction.ipynb
+++ b/gemini/batch-prediction/intro_batch_prediction.ipynb
@@ -291,6 +291,7 @@
         "This tutorial uses Cloud Storage as an example. The requirements for Cloud Storage input are:\n",
         "\n",
         "- File format: [JSON Lines (JSONL)](https://jsonlines.org/)\n",
+        "- Multiple files are supported with regex such as gs://bucketname/path/to/*.jsonl\n",
         "- Located in `us-central1`\n",
         "- Appropriate read permissions for the service account\n",
         "\n",


### PR DESCRIPTION
Batch prediction also supports multiple GCS input files using regex below:

Multiple files are supported with regex such as gs://bucketname/path/to/*.jsonl
