### PR TITLE
fix: prevent gradio-voice crash when entering project credentials

### DIFF
--- a/gemini/multimodal-live-api/gradio-voice/app.py
+++ b/gemini/multimodal-live-api/gradio-voice/app.py
@@ -168,6 +168,7 @@ with gr.Blocks(css=css) as demo:
             outputs=[webrtc],
             time_limit=90,
             concurrency_limit=2,
+            send_input_on="submit",
         )
     submit.click(
         lambda: (gr.update(visible=False), gr.update(visible=True)),


### PR DESCRIPTION
# Description

The `gradio-voice` app crashed immediately when users typed text into the Project ID field. This happened because input changes triggered processing of all components, including the WebRTC component which had no data yet. The fix delays input processing until the audio stream actually starts, letting users fill out the form normally before connecting.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- If you are creating a new notebook/sample:
  - [ ] You are listed as the author in your notebook or `README` file.
  - [ ] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).

Fixes #2198


