### PR TITLE
feat: Add request level example for retry

### DIFF
--- a/sdk/retries/configure_retries.ipynb
+++ b/sdk/retries/configure_retries.ipynb
@@ -377,7 +377,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "id": "b5386769b966"
+      },
       "source": [
         "## **Option 2**: Configuring Retries at the Request Level\n",
         "\n",
@@ -387,7 +389,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "id": "620c8177fc44"
+      },
       "outputs": [],
       "source": [
         "response = client.models.generate_content(\n",
@@ -396,16 +400,16 @@
         "    config=types.GenerateContentConfig(\n",
         "        http_options=types.HttpOptions(\n",
         "            retry_options=types.HttpRetryOptions(\n",
-        "               initial_delay=1.0,\n",
-        "               attempts=10,\n",
-        "               http_status_codes=[429, 500, 502, 503, 504],\n",
+        "                initial_delay=1.0,\n",
+        "                attempts=10,\n",
+        "                http_status_codes=[429, 500, 502, 503, 504],\n",
         "            ),\n",
         "            timeout=120 * 1000,\n",
         "        )\n",
-        "    )\n",
+        "    ),\n",
         ")\n",
         "\n",
-        "print(response.text)"
+        "display(Markdown(response.text))"
       ]
     }
   ],


### PR DESCRIPTION
Add a request level example for retry.

As another option to the client level setting.