### PR TITLE
docs: add PYTHONPATH setup instructions for llmevalkit

### DIFF
--- a/tools/llmevalkit/README.md
+++ b/tools/llmevalkit/README.md
@@ -8,7 +8,31 @@ LLMEvalKit is a tool designed to help developers evaluate and improve the perfor
 
 **Authors: [Mike Santoro](https://github.com/Michael-Santoro), [Katherine Larson](https://github.com/kat-litinsky)**
 
+
+## ⚠️ Important: Running from Repository Root
+
+Before running LLMEvalKit, ensure you:
+
+1. Clone the repository:
+```bash
+git clone https://github.com/GoogleCloudPlatform/generative-ai.git
+cd generative-ai
+```
+
+2. Add the repository root to your Python path:
+```bash
+export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+```
+
+Or run Python with the path:
+```bash
+PYTHONPATH=. python tools/llmevalkit/index.py
+```
+
+This is required because `vapo_lib.py` imports from `gemini.prompts.prompt_optimizer.vapo_lib`.
+
 ## 🚀 Getting Started
+
 
 There are two ways to work through a tutorial of this application one method is more stable one is less stable.
 


### PR DESCRIPTION
## Summary

Fixes #2448 - 添加 PYTHONPATH 设置说明解决 ModuleNotFoundError。

## Problem

用户运行 llmevalkit 时遇到：
```
ModuleNotFoundError: No module named 'gemini'
```

原因是 `vapo_lib.py` 导入 `from gemini.prompts.prompt_optimizer.vapo_lib`，需要从仓库根目录运行。

## Solution

在 README 中添加：
- 如何克隆仓库
- 如何设置 PYTHONPATH
- 如何正确运行应用

## Changes

- `tools/llmevalkit/README.md`: 添加运行说明

Fixes #2448