### PR TITLE
chore: Migrate gsutil to gcloud storage in workshops/rag-ops/

### DIFF
--- a/workshops/rag-ops/2.1_mvp_data_processing.ipynb
+++ b/workshops/rag-ops/2.1_mvp_data_processing.ipynb
@@ -977,7 +977,7 @@
         "\n",
         "\n",
         "# # Upload the pickle file to GCS\n",
-        "# !gsutil cp data_extraction_dataframe.pkl {gcs_location}"
+        "# !gcloud storage cp data_extraction_dataframe.pkl {gcs_location}"
       ]
     }
   ],

--- a/workshops/rag-ops/2.2_mvp_chunk_embeddings.ipynb
+++ b/workshops/rag-ops/2.2_mvp_chunk_embeddings.ipynb
@@ -870,7 +870,7 @@
         "# # the AI Platform service agent. This allows the service agent to write objects\n",
         "# # to the specified Cloud Storage bucket.\n",
         "\n",
-        "# !gsutil iam ch \\\n",
+        "# !gcloud storage buckets add-iam-policy-binding \\\n",
         "#   \"$(gcloud projects get-iam-policy $PROJECT_ID \\\n",
         "#   --flatten=\"bindings[].members\" \\\n",
         "#   --filter=\"bindings.role:roles/aiplatform.serviceAgent\" \\\n",
@@ -882,7 +882,7 @@
         "# #           --flatten=\"bindings[].members\"                          \\\n",
         "# #           --filter=\"bindings.role:roles/aiplatform.serviceAgent\"  \\\n",
         "# #           --format=\"value(bindings.members)\")\n",
-        "# # !for SERVICE_ACCOUNT in $SERVICE_ACCOUNTS; do gsutil iam ch \"$SERVICE_ACCOUNT:roles/storage.objectCreator\" gs://mlops-for-genai; done"
+        "# # !for SERVICE_ACCOUNT in $SERVICE_ACCOUNTS; do gcloud storage buckets add-iam-policy-binding \"$SERVICE_ACCOUNT:roles/storage.objectCreator\" gs://mlops-for-genai; done"
       ]
     },
     {
@@ -1154,7 +1154,7 @@
         "\n",
         "\n",
         "# # Upload the pickle file to GCS\n",
-        "# !gsutil cp {pickle_file_name} {gcs_location}"
+        "# !gcloud storage cp {pickle_file_name} {gcs_location}"
       ]
     }
   ],

--- a/workshops/rag-ops/2.3_mvp_rag.ipynb
+++ b/workshops/rag-ops/2.3_mvp_rag.ipynb
@@ -918,7 +918,7 @@
         "\n",
         "\n",
         "# # Upload the pickle file to GCS\n",
-        "# !gsutil cp {pickle_file_name} {gcs_location}"
+        "# !gcloud storage cp {pickle_file_name} {gcs_location}"
       ]
     }
   ],

--- a/workshops/rag-ops/2.4_mvp_evaluation.ipynb
+++ b/workshops/rag-ops/2.4_mvp_evaluation.ipynb
@@ -998,7 +998,7 @@
         "\n",
         "\n",
         "# # Upload the pickle file to GCS\n",
-        "# !gsutil cp {pickle_file_name} {gcs_location}"
+        "# !gcloud storage cp {pickle_file_name} {gcs_location}"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in the RAG-Ops workshop notebooks
- `gsutil cp` → `gcloud storage cp`
- `gsutil iam ch` → `gcloud storage buckets add-iam-policy-binding`

## Files changed
- `workshops/rag-ops/2.1_mvp_data_processing.ipynb`
- `workshops/rag-ops/2.2_mvp_chunk_embeddings.ipynb`
- `workshops/rag-ops/2.3_mvp_rag.ipynb`
- `workshops/rag-ops/2.4_mvp_evaluation.ipynb`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [ ] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)
- [x] Tests and linter pass (`nox -s format`)