### PR TITLE
chore: Migrate gsutil to gcloud storage in agents/agent_engine/

### DIFF
--- a/agents/agent_engine/memory_bank/tutorial_get_started_with_multimodal_agents_with_memory_bank.ipynb
+++ b/agents/agent_engine/memory_bank/tutorial_get_started_with_multimodal_agents_with_memory_bank.ipynb
@@ -226,7 +226,7 @@
         "USER_ID = \"traveler_123\"\n",
         "\n",
         "# Create the staging bucket for Agent Engine\n",
-        "!gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "!gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "client = Client(project=PROJECT_ID, location=LOCATION)"
       ]

--- a/agents/agent_engine/tutorial_a2a_on_agent_engine.ipynb
+++ b/agents/agent_engine/tutorial_a2a_on_agent_engine.ipynb
@@ -220,7 +220,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "# !gsutil mb -l $LOCATION -p $PROJECT_ID $BUCKET_URI\n",
+        "# !gcloud storage buckets create -l $LOCATION -p $PROJECT_ID $BUCKET_URI\n",
         "\n",
         "# Initialize Vertex AI session\n",
         "vertexai.init(project=PROJECT_ID, location=LOCATION, staging_bucket=BUCKET_URI)\n",

--- a/agents/agent_engine/tutorial_claude_with_adk_on_agent_engine.ipynb
+++ b/agents/agent_engine/tutorial_claude_with_adk_on_agent_engine.ipynb
@@ -209,7 +209,7 @@
     "GOOGLE_CLOUD_BUCKET = f\"gs://{GOOGLE_CLOUD_BUCKET_NAME}\"\n",
     "\n",
     "# Create the bucket if it doesn't exist\n",
-    "! gsutil mb -l $GOOGLE_CLOUD_LOCATION -p $GOOGLE_CLOUD_PROJECT $GOOGLE_CLOUD_BUCKET\n",
+    "! gcloud storage buckets create -l $GOOGLE_CLOUD_LOCATION -p $GOOGLE_CLOUD_PROJECT $GOOGLE_CLOUD_BUCKET\n",
     "\n",
     "# Initialize Vertex AI client\n",
     "vertexai.init(\n",
@@ -1244,7 +1244,7 @@
     "    agent_engine_name = remote_app.delete(force=True)\n",
     "\n",
     "if delete_bucket:\n",
-    "    !gsutil rm -r $GOOGLE_CLOUD_BUCKET\n"
+    "    !gcloud storage rm -r $GOOGLE_CLOUD_BUCKET\n"
    ]
   }
  ],

--- a/agents/agent_engine/tutorial_get_started_with_cloud_api_registry.ipynb
+++ b/agents/agent_engine/tutorial_get_started_with_cloud_api_registry.ipynb
@@ -255,7 +255,7 @@
       "outputs": [],
       "source": [
         "# Create the bucket\n",
-        "!gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+        "!gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
         "print(\"\\n✅ Bucket created successfully!\")"
       ]
     },
@@ -1340,7 +1340,7 @@
         "\n",
         "if delete_bucket:\n",
         "    print(\"\\n🗑️  Deleting Cloud Storage bucket...\")\n",
-        "    !gsutil rm -r {BUCKET_URI}\n",
+        "    !gcloud storage rm -r {BUCKET_URI}\n",
         "    print(\"✅ Bucket deleted successfully!\")\n",
         "\n",
         "print(\"\\n✅ Cleanup complete!\")"

--- a/agents/agent_engine/tutorial_get_started_with_live_api_on_agent_engine.ipynb
+++ b/agents/agent_engine/tutorial_get_started_with_live_api_on_agent_engine.ipynb
@@ -217,7 +217,7 @@
         "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"1\"\n",
         "\n",
         "# Create the staging bucket for Agent Engine\n",
-        "!gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "!gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "# Initialize Vertex AI\n",
         "vertexai.init(project=PROJECT_ID, location=LOCATION)\n",

--- a/agents/agent_engine/tutorial_mcp_on_agent_engine.ipynb
+++ b/agents/agent_engine/tutorial_mcp_on_agent_engine.ipynb
@@ -217,7 +217,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+        "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
         "\n",
         "# Set environment variables required for ADK\n",
         "os.environ[\"GOOGLE_GENAI_USE_VERTEXAI\"] = \"TRUE\"\n",
@@ -842,7 +842,7 @@
         "        agent_engine.delete(force=True)\n",
         "\n",
         "if delete_bucket:\n",
-        "    !gsutil rm -r {BUCKET_URI}"
+        "    !gcloud storage rm -r {BUCKET_URI}"
       ]
     }
   ],


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `agents/agent_engine/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)