### PR TITLE
chore: Migrate gsutil to gcloud storage in audio/speech/

### DIFF
--- a/audio/speech/getting-started/chirp_2/get_started_with_chirp_2_sdk.ipynb
+++ b/audio/speech/getting-started/chirp_2/get_started_with_chirp_2_sdk.ipynb
@@ -286,7 +286,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l $LOCATION -p $PROJECT_ID $BUCKET_URI"
+        "! gcloud storage buckets create -l $LOCATION -p $PROJECT_ID $BUCKET_URI"
       ]
     },
     {
@@ -1310,7 +1310,7 @@
         "delete_bucket = False\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil rm -r $BUCKET_URI"
+        "    ! gcloud storage rm -r $BUCKET_URI"
       ]
     },
     {

--- a/audio/speech/getting-started/get_started_with_chirp_3_transcription.ipynb
+++ b/audio/speech/getting-started/get_started_with_chirp_3_transcription.ipynb
@@ -557,7 +557,7 @@
         "\n",
         "transcript = response.results[audio_gcs_uri].uri\n",
         "\n",
-        "!gsutil cp {transcript} output.json\n",
+        "!gcloud storage cp {transcript} output.json\n",
         "\n",
         "print(json.dumps(group_utterances_by_speaker_from_file(\"output.json\"), indent=4))"
       ]


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `audio/speech/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)