### PR TITLE
chore: Migrate gsutil to gcloud storage in embeddings/

### DIFF
--- a/embeddings/hybrid-search.ipynb
+++ b/embeddings/hybrid-search.ipynb
@@ -472,7 +472,7 @@
       "source": [
         "# create bucket\n",
         "BUCKET_URI = f\"gs://{PROJECT_ID}-vs-hybridsearch-{UID}\"\n",
-        "! gsutil mb -l $LOCATION -p $PROJECT_ID $BUCKET_URI"
+        "! gcloud storage buckets create -l $LOCATION -p $PROJECT_ID $BUCKET_URI"
       ]
     },
     {
@@ -563,7 +563,7 @@
         "with open(\"items.json\", \"w\") as f:\n",
         "    for item in items:\n",
         "        f.write(f\"{item}\\n\")\n",
-        "! gsutil cp items.json $BUCKET_URI"
+        "! gcloud storage cp items.json $BUCKET_URI"
       ]
     },
     {
@@ -860,7 +860,7 @@
         "with open(\"items.json\", \"w\") as f:\n",
         "    for item in items:\n",
         "        f.write(f\"{item}\\n\")\n",
-        "! gsutil cp items.json $BUCKET_URI"
+        "! gcloud storage cp items.json $BUCKET_URI"
       ]
     },
     {
@@ -1028,7 +1028,7 @@
         "my_hybrid_index.delete()\n",
         "\n",
         "# delete Cloud Storage bucket\n",
-        "! gsutil rm -r \"{BUCKET_URI}\""
+        "! gcloud storage rm -r \"{BUCKET_URI}\""
       ]
     },
     {

--- a/embeddings/intro-textemb-vectorsearch.ipynb
+++ b/embeddings/intro-textemb-vectorsearch.ipynb
@@ -829,8 +829,8 @@
       "outputs": [],
       "source": [
         "BUCKET_URI = f\"gs://{PROJECT_ID}-embvs-tutorial-{UID}\"\n",
-        "! gsutil mb -l $LOCATION -p {PROJECT_ID} {BUCKET_URI}\n",
-        "! gsutil cp questions.json {BUCKET_URI}"
+        "! gcloud storage buckets create -l $LOCATION -p {PROJECT_ID} {BUCKET_URI}\n",
+        "! gcloud storage cp questions.json {BUCKET_URI}"
       ]
     },
     {
@@ -1070,7 +1070,7 @@
         "my_index.delete()\n",
         "\n",
         "# delete Cloud Storage bucket\n",
-        "! gsutil rm -r {BUCKET_URI}"
+        "! gcloud storage rm -r {BUCKET_URI}"
       ]
     },
     {

--- a/embeddings/intro_embeddings_tuning.ipynb
+++ b/embeddings/intro_embeddings_tuning.ipynb
@@ -368,7 +368,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {REGION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gcloud storage buckets create -l {REGION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -1427,7 +1427,7 @@
         "\n",
         "# Delete Cloud Storage objects that were created\n",
         "if delete_bucket:\n",
-        "    ! gsutil -m rm -r $BUCKET_URI\n",
+        "    ! gcloud storage rm -r $BUCKET_URI\n",
         "\n",
         "# Delete tutorial folder\n",
         "if delete_tutorial:\n",


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `embeddings/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)