### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/agent-engine/

### DIFF
--- a/gemini/agent-engine/evaluating_crewai_agent_engine_customized_template.ipynb
+++ b/gemini/agent-engine/evaluating_crewai_agent_engine_customized_template.ipynb
@@ -254,7 +254,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "! gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "EXPERIMENT_NAME = \"evaluate-re-agent\"  # @param {type:\"string\"}\n",
         "\n",

--- a/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
+++ b/gemini/agent-engine/evaluating_langchain_agent_engine_prebuilt_template.ipynb
@@ -254,7 +254,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "! gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "EXPERIMENT_NAME = \"evaluate-re-agent\"  # @param {type:\"string\"}\n",
         "\n",

--- a/gemini/agent-engine/evaluating_langgraph_agent_engine_customized_template.ipynb
+++ b/gemini/agent-engine/evaluating_langgraph_agent_engine_customized_template.ipynb
@@ -256,7 +256,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "! gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "EXPERIMENT_NAME = \"evaluate-re-agent\"  # @param {type:\"string\"}\n",
         "\n",

--- a/gemini/agent-engine/tutorial_mcp_toolbox_for_databases.ipynb
+++ b/gemini/agent-engine/tutorial_mcp_toolbox_for_databases.ipynb
@@ -1282,7 +1282,7 @@
       "outputs": [],
       "source": [
         "# Create a Cloud Storage bucket, if it doesn't already exist\n",
-        "!gsutil mb -c standard {STAGING_BUCKET}"
+        "!gcloud storage buckets create -c standard {STAGING_BUCKET}"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/agent-engine/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)