### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/batch-prediction/

### DIFF
--- a/gemini/batch-prediction/monitor_batch_prediction_gemini_api.ipynb
+++ b/gemini/batch-prediction/monitor_batch_prediction_gemini_api.ipynb
@@ -249,7 +249,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -803,7 +803,7 @@
         "\n",
         "# Delete the Cloud Storage bucket\n",
         "if delete_bucket:\n",
-        "    ! gsutil -m rm -r {BUCKET_URI}\n",
+        "    ! gcloud storage rm -r {BUCKET_URI}\n",
         "\n",
         "# delete dataset\n",
         "if delete_bigquery_dataset:\n",


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/batch-prediction/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)