### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/evaluation/

### DIFF
--- a/gemini/evaluation/evaltask_approach/evaluate_rag_batch_pipeline.ipynb
+++ b/gemini/evaluation/evaltask_approach/evaluate_rag_batch_pipeline.ipynb
@@ -280,7 +280,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {REGION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gcloud storage buckets create -l {REGION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -1610,7 +1610,7 @@
         "delete_tutorial_dir = False\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil -m rm -r $BUCKET_URI\n",
+        "    ! gcloud storage rm -r $BUCKET_URI\n",
         "\n",
         "if delete_pipeline:\n",
         "    pipeline_list = aiplatform.PipelineJob.list()\n",

--- a/gemini/evaluation/evaltask_approach/multimodal_text_quality_rubric_evaluation.ipynb
+++ b/gemini/evaluation/evaltask_approach/multimodal_text_quality_rubric_evaluation.ipynb
@@ -203,7 +203,7 @@
         "BUCKET_NAME = \"[your-bucket-name]\"  # @param {type: \"string\", placeholder: \"[your-bucket-name]\", isTemplate: true}\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "!gsutil mb -l {LOCATION} {BUCKET_URI}\n",
+        "!gcloud storage buckets create -l {LOCATION} {BUCKET_URI}\n",
         "\n",
         "vertexai.init(project=PROJECT_ID, location=LOCATION)"
       ]

--- a/gemini/evaluation/evaluating_adk_agent.ipynb
+++ b/gemini/evaluation/evaluating_adk_agent.ipynb
@@ -205,7 +205,7 @@
         "# fmt: on\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "!gsutil mb -l {LOCATION} {BUCKET_URI}\n",
+        "!gcloud storage buckets create -l {LOCATION} {BUCKET_URI}\n",
         "\n",
         "os.environ[\"GOOGLE_CLOUD_PROJECT\"] = PROJECT_ID\n",
         "os.environ[\"GOOGLE_CLOUD_LOCATION\"] = LOCATION\n",


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/evaluation/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)