### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/getting-started/

### DIFF
--- a/gemini/getting-started/intro_gemini_curl.ipynb
+++ b/gemini/getting-started/intro_gemini_curl.ipynb
@@ -584,7 +584,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil cp \"gs://cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg\" ./image.jpg"
+        "! gcloud storage cp \"gs://cloud-samples-data/generative-ai/image/320px-Felis_catus-cat_on_snow.jpg\" ./image.jpg"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/getting-started/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)