### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/multimodal-live-api/

### DIFF
--- a/gemini/multimodal-live-api/real_time_rag_retail_gemini_2_0.ipynb
+++ b/gemini/multimodal-live-api/real_time_rag_retail_gemini_2_0.ipynb
@@ -441,8 +441,8 @@
       },
       "outputs": [],
       "source": [
-        "!gsutil cp \"gs://github-repo/generative-ai/gemini2/use-cases/retail_rag/documents/CymbalBikesReturnPolicy.pdf\" \"documents/CymbalBikesReturnPolicy.pdf\"\n",
-        "!gsutil cp \"gs://github-repo/generative-ai/gemini2/use-cases/retail_rag/documents/CymbalBikesServices.pdf\" \"documents/CymbalBikesServices.pdf\""
+        "!gcloud storage cp \"gs://github-repo/generative-ai/gemini2/use-cases/retail_rag/documents/CymbalBikesReturnPolicy.pdf\" \"documents/CymbalBikesReturnPolicy.pdf\"\n",
+        "!gcloud storage cp \"gs://github-repo/generative-ai/gemini2/use-cases/retail_rag/documents/CymbalBikesServices.pdf\" \"documents/CymbalBikesServices.pdf\""
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/multimodal-live-api/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)