### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/prompts/

### DIFF
--- a/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer.ipynb
+++ b/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer.ipynb
@@ -219,7 +219,7 @@
         "# fmt: on\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+        "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
         "\n",
         "import vertexai\n",
         "\n",
@@ -2186,7 +2186,7 @@
         "    latest_job.delete()\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil -m rm -r $BUCKET_URI"
+        "    ! gcloud storage rm -r $BUCKET_URI"
       ]
     }
   ],

--- a/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_custom_metric.ipynb
+++ b/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_custom_metric.ipynb
@@ -217,7 +217,7 @@
     "BUCKET_NAME = \"[your-bucket-name]\"  # @param {type: \"string\", placeholder: \"[your-bucket-name]\", isTemplate: true}\n",
     "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
     "\n",
-    "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+    "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
     "\n",
     "import vertexai\n",
     "\n",
@@ -1274,7 +1274,7 @@
     "    !gcloud functions delete 'custom_engagement_personalization_metric' --gen2 --region {LOCATION} --quiet\n",
     "\n",
     "if delete_bucket:\n",
-    "    ! gsutil -m rm -r $BUCKET_URI"
+    "    ! gcloud storage rm -r $BUCKET_URI"
    ]
   }
  ],

--- a/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_long_prompt.ipynb
+++ b/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_long_prompt.ipynb
@@ -215,7 +215,7 @@
     "BUCKET_NAME = \"[your-bucket-name]\"  # @param {type: \"string\", placeholder: \"[your-bucket-name]\", isTemplate: true}\n",
     "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
     "\n",
-    "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+    "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
     "\n",
     "import vertexai\n",
     "\n",
@@ -988,7 +988,7 @@
     "    latest_job.delete()\n",
     "\n",
     "if delete_bucket:\n",
-    "    ! gsutil -m rm -r $BUCKET_URI"
+    "    ! gcloud storage rm -r $BUCKET_URI"
    ]
   }
  ],

--- a/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_tool_usage.ipynb
+++ b/gemini/prompts/prompt_optimizer/get_started_with_vertex_ai_prompt_optimizer_tool_usage.ipynb
@@ -215,7 +215,7 @@
     "BUCKET_NAME = \"[your-bucket-name]\"  # @param {type: \"string\", placeholder: \"[your-bucket-name]\", isTemplate: true}\n",
     "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
     "\n",
-    "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
+    "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}\n",
     "\n",
     "import vertexai\n",
     "\n",
@@ -1378,7 +1378,7 @@
     "    latest_job.delete()\n",
     "\n",
     "if delete_bucket:\n",
-    "    ! gsutil -m rm -r $BUCKET_URI"
+    "    ! gcloud storage rm -r $BUCKET_URI"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/prompts/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)