### PR TITLE
chore: Migrate gsutil to gcloud storage in gemini/rag-engine/

### DIFF
--- a/gemini/rag-engine/rag_engine_eval_service_sdk.ipynb
+++ b/gemini/rag-engine/rag_engine_eval_service_sdk.ipynb
@@ -361,7 +361,7 @@
         "    \"gs://github-repo/generative-ai/gemini/rag-engine/rag_engine_eval_service/\"\n",
         ")\n",
         "\n",
-        "!gsutil -m rsync -r -d $PUBLIC_DATA_PATH $CURRENT_BUCKET_PATH"
+        "!gcloud storage rsync -r -d $PUBLIC_DATA_PATH $CURRENT_BUCKET_PATH"
       ]
     },
     {

--- a/gemini/rag-engine/rag_engine_evaluation.ipynb
+++ b/gemini/rag-engine/rag_engine_evaluation.ipynb
@@ -552,7 +552,7 @@
         "    \"gs://github-repo/generative-ai/gemini/rag-engine/rag_engine_evaluation/beir-fiqa\"\n",
         ")\n",
         "\n",
-        "!gsutil -m rsync -r -d $PUBLIC_BEIR_FIQA_GCS_PATH $CURRENT_BUCKET_PATH"
+        "!gcloud storage rsync -r -d $PUBLIC_BEIR_FIQA_GCS_PATH $CURRENT_BUCKET_PATH"
       ]
     },
     {
@@ -748,7 +748,7 @@
       "source": [
         "# Optionally rename bucket name here.\n",
         "BUCKET_NAME = \"beir-test-bucket\"  # @param {type: \"string\"}\n",
-        "!gsutil mb gs://{BUCKET_NAME}"
+        "!gcloud storage buckets create gs://{BUCKET_NAME}"
       ]
     },
     {
@@ -772,7 +772,7 @@
         "\n",
         "!echo \"Uploading files from ${CONVERTED_DATASET_PATH} to ${GCS_BUCKET_PATH}\"\n",
         "# Upload RAG format dataset to GCS bucket.\n",
-        "!gsutil -m rsync -r -d $CONVERTED_DATASET_PATH $GCS_BUCKET_PATH"
+        "!gcloud storage rsync -r -d $CONVERTED_DATASET_PATH $GCS_BUCKET_PATH"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `gemini/rag-engine/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)