### PR TITLE
chore: Migrate gsutil to gcloud storage in open-models/

### DIFF
--- a/open-models/evaluation/vertex_ai_tgi_evaluate_llm_with_open_judge.ipynb
+++ b/open-models/evaluation/vertex_ai_tgi_evaluate_llm_with_open_judge.ipynb
@@ -237,7 +237,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "!gsutil mb -l {LOCATION} {BUCKET_URI}\n",
+        "!gcloud storage buckets create -l {LOCATION} {BUCKET_URI}\n",
         "\n",
         "EXPERIMENT_NAME = \"eval-open-judge\"  # @param {type:\"string\"}\n",
         "\n",

--- a/open-models/serving/vertex_ai_ollama_gemma2_rag_agent.ipynb
+++ b/open-models/serving/vertex_ai_ollama_gemma2_rag_agent.ipynb
@@ -334,7 +334,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "! gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "vertexai.init(project=PROJECT_ID, location=LOCATION, staging_bucket=BUCKET_URI)"
       ]

--- a/open-models/serving/vertex_ai_pytorch_inference_paligemma_with_custom_handler.ipynb
+++ b/open-models/serving/vertex_ai_pytorch_inference_paligemma_with_custom_handler.ipynb
@@ -359,7 +359,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -1365,7 +1365,7 @@
         "    delete_model.delete()\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil rm -r {BUCKET_URI}"
+        "    ! gcloud storage rm -r {BUCKET_URI}"
       ]
     }
   ],

--- a/open-models/serving/vertex_ai_pytorch_inference_pllum_with_custom_handler.ipynb
+++ b/open-models/serving/vertex_ai_pytorch_inference_pllum_with_custom_handler.ipynb
@@ -311,7 +311,7 @@
       },
       "outputs": [],
       "source": [
-        "! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
+        "! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {
@@ -1264,7 +1264,7 @@
         "    delete_model.delete()\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil rm -r {BUCKET_URI}"
+        "    ! gcloud storage rm -r {BUCKET_URI}"
       ]
     }
   ],

--- a/open-models/serving/vertex_ai_tgi_gemma_multi_lora_adapters_deployment.ipynb
+++ b/open-models/serving/vertex_ai_tgi_gemma_multi_lora_adapters_deployment.ipynb
@@ -1518,7 +1518,7 @@
         "    delete_model.delete()\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil rm -r {BUCKET_URI}"
+        "    ! gcloud storage rm -r {BUCKET_URI}"
       ]
     }
   ],

--- a/open-models/use-cases/bigquery_ml_llama_inference.ipynb
+++ b/open-models/use-cases/bigquery_ml_llama_inference.ipynb
@@ -276,10 +276,10 @@
         "if BUCKET_URI is None or BUCKET_URI.strip() == \"\" or BUCKET_URI == \"gs://\":\n",
         "    BUCKET_URI = f\"gs://{PROJECT_ID}-tmp-{now}-{str(uuid.uuid4())[:4]}\"\n",
         "    BUCKET_NAME = \"/\".join(BUCKET_URI.split(\"/\")[:3])\n",
-        "    ! gsutil mb -l {REGION} {BUCKET_URI}\n",
+        "    ! gcloud storage buckets create -l {REGION} {BUCKET_URI}\n",
         "else:\n",
         "    assert BUCKET_URI.startswith(\"gs://\"), \"BUCKET_URI must start with `gs://`.\"\n",
-        "    shell_output = ! gsutil ls -Lb {BUCKET_NAME} | grep \"Location constraint:\" | sed \"s/Location constraint://\"\n",
+        "    shell_output = ! gcloud storage ls -Lb {BUCKET_NAME} | grep \"Location constraint:\" | sed \"s/Location constraint://\"\n",
         "    bucket_region = shell_output[0].strip().lower()\n",
         "    if bucket_region != REGION:\n",
         "        raise ValueError(\n",
@@ -304,7 +304,7 @@
         "\n",
         "\n",
         "# Provision permissions to the SERVICE_ACCOUNT with the GCS bucket\n",
-        "! gsutil iam ch serviceAccount:{SERVICE_ACCOUNT}:roles/storage.admin $BUCKET_NAME\n",
+        "! gcloud storage buckets add-iam-policy-binding serviceAccount:{SERVICE_ACCOUNT}:roles/storage.admin $BUCKET_NAME\n",
         "\n",
         "! gcloud config set project $PROJECT_ID\n",
         "! gcloud projects add-iam-policy-binding --no-user-output-enabled {PROJECT_ID} --member=serviceAccount:{SERVICE_ACCOUNT} --role=\"roles/storage.admin\"\n",
@@ -888,7 +888,7 @@
         "delete_bucket = True  # @param {type:\"boolean\"}\n",
         "# fmt: on\n",
         "if delete_bucket:\n",
-        "    ! gsutil -m rm -r $BUCKET_NAME"
+        "    ! gcloud storage rm -r $BUCKET_NAME"
       ]
     },
     {

--- a/open-models/use-cases/vertex_ai_deepseek_smolagents.ipynb
+++ b/open-models/use-cases/vertex_ai_deepseek_smolagents.ipynb
@@ -286,7 +286,7 @@
         "\n",
         "BUCKET_URI = f\"gs://{BUCKET_NAME}\"\n",
         "\n",
-        "! gsutil mb -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
+        "! gcloud storage buckets create -p $PROJECT_ID -l $LOCATION $BUCKET_URI\n",
         "\n",
         "vertexai.init(project=PROJECT_ID, location=LOCATION, staging_bucket=BUCKET_URI)"
       ]
@@ -1473,7 +1473,7 @@
         "delete_remote_agent = False\n",
         "\n",
         "if delete_bucket:\n",
-        "    ! gsutil rm -r $BUCKET_URI\n",
+        "    ! gcloud storage rm -r $BUCKET_URI\n",
         "if delete_endpoint:\n",
         "    deepseek_endpoint.delete(force=True)\n",
         "if delete_model:\n",


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `open-models/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)