### PR TITLE
chore: Migrate gsutil to gcloud storage in sdk/

### DIFF
--- a/sdk/intro_genai_sdk.ipynb
+++ b/sdk/intro_genai_sdk.ipynb
@@ -1124,7 +1124,7 @@
         "    TIMESTAMP = datetime.datetime.now().strftime(\"%Y%m%d%H%M%S\")\n",
         "    BUCKET_URI = f\"gs://{PROJECT_ID}-{TIMESTAMP}\"\n",
         "\n",
-        "    ! gsutil mb -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
+        "    ! gcloud storage buckets create -l {LOCATION} -p {PROJECT_ID} {BUCKET_URI}"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `sdk/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)