### PR TITLE
chore: Migrate gsutil to gcloud storage in vision/

### DIFF
--- a/vision/getting-started/veo2_reference_to_video.ipynb
+++ b/vision/getting-started/veo2_reference_to_video.ipynb
@@ -244,7 +244,7 @@
         "def show_video(video):\n",
         "    if isinstance(video, str):\n",
         "        file_name = video.split(\"/\")[-1]\n",
-        "        !gsutil cp {video} {file_name}\n",
+        "        !gcloud storage cp {video} {file_name}\n",
         "        display(Video(file_name, embed=True, width=600))\n",
         "    else:\n",
         "        with open(\"sample.mp4\", \"wb\") as out_file:\n",

--- a/vision/getting-started/veo3_advanced_controls.ipynb
+++ b/vision/getting-started/veo3_advanced_controls.ipynb
@@ -244,7 +244,7 @@
         "def show_video(video: str | bytes) -> None:\n",
         "    if isinstance(video, str):\n",
         "        file_name = video.split(\"/\")[-1]\n",
-        "        !gsutil cp {video} {file_name}\n",
+        "        !gcloud storage cp {video} {file_name}\n",
         "        display(Video(file_name, embed=True, width=600))\n",
         "    else:\n",
         "        with open(\"sample.mp4\", \"wb\") as out_file:\n",


### PR DESCRIPTION
## Summary
- Migrate deprecated `gsutil` commands to the recommended `gcloud storage` CLI in `vision/`

## Context
Google Cloud recommends using `gcloud storage` commands instead of `gsutil`. See [migration guide](https://cloud.google.com/storage/docs/gsutil-migration).

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)