### PR TITLE
chore: Add Apache 2.0 copyright header to gemini/sample-apps notebook

### DIFF
--- a/gemini/sample-apps/fixmycar/manuals/GenerateMockAutoManual.ipynb
+++ b/gemini/sample-apps/fixmycar/manuals/GenerateMockAutoManual.ipynb
@@ -1,198 +1,219 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "ee1706bbf647"
-      },
-      "source": [
-        "## Generate a mock auto owner's manual using Gemini\n",
-        "\n",
-        "Megan O'Keefe, 2024"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "a709c36ce130"
-      },
-      "outputs": [],
-      "source": [
-        "%pip install \"google-cloud-aiplatform>=1.38\""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "Dczys2Z4OXtF"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud config set project YOUR_PROJECT_ID"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qytITa3uORgf"
-      },
-      "outputs": [],
-      "source": [
-        "! gcloud auth application-default login"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {
-        "id": "EIzxe56HO6a6"
-      },
-      "outputs": [],
-      "source": [
-        "import vertexai\n",
-        "from vertexai.generative_models import ChatSession, GenerativeModel"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "40d8418757b6"
-      },
-      "outputs": [],
-      "source": [
-        "# Set to your project and location\n",
-        "PROJECT_ID = \"your-project-id\"\n",
-        "REGION = \"us-central1\"  # change region as needed\n",
-        "MODEL = \"gemini-2.0-flash\"  # change model as needed"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {
-        "id": "OXCYfSDMOhYY"
-      },
-      "outputs": [],
-      "source": [
-        "vertexai.init(project=PROJECT_ID, location=REGION)\n",
-        "model = GenerativeModel(MODEL)\n",
-        "chat = model.start_chat()\n",
-        "\n",
-        "\n",
-        "def get_chat_response(chat: ChatSession, prompt: str) -> str:\n",
-        "    text_response = []\n",
-        "    responses = chat.send_message(prompt, stream=True)\n",
-        "    for chunk in responses:\n",
-        "        text_response.append(chunk.text)\n",
-        "    return \"\".join(text_response)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "id": "9mNNCvGdPLM-"
-      },
-      "outputs": [],
-      "source": [
-        "manual = []\n",
-        "system = \"You are an automobile owner's manual generator for the brand Cymbal. The car model is a Cymbal Starlight 2024. Your job is to generate a 30-page owner's manual. you will be given a topic, which represents one chapter of the manual. Generate one page of material in as much detail as possible. Use specific numbers and details. The topic is: \""
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 33,
-      "metadata": {
-        "id": "RBFING9dPpLl"
-      },
-      "outputs": [],
-      "source": [
-        "topics = [\n",
-        "    \"Safety\",\n",
-        "    \"Child safety\",\n",
-        "    \"Emergency Assistance\",\n",
-        "    \"Instrument cluster\",\n",
-        "    \"Warning lights\",\n",
-        "    \"Doors, windows, and locks\",\n",
-        "    \"Adjusting the seats and steering wheel\",\n",
-        "    \"Towing, cargo, and luggage\",\n",
-        "    \"Driving procedures with automatic transmission\",\n",
-        "    \"Lights and windshield wipers\",\n",
-        "    \"Refueling\",\n",
-        "    \"Cruise control and automatic support system\",\n",
-        "    \"Inclement weather driving\",\n",
-        "    \"Audio and Bluetooth system\",\n",
-        "    \"Heating and air conditioning\",\n",
-        "    \"Maintenance and care\",\n",
-        "    \"Emergencies\",\n",
-        "]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "DlyDTUdkQsfj"
-      },
-      "outputs": [],
-      "source": [
-        "for t in topics:\n",
-        "    print(t)\n",
-        "    p = system + \" \" + t\n",
-        "    res = get_chat_response(chat, p)\n",
-        "    manual.append(res)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "xrfa1DRWRoLq"
-      },
-      "outputs": [],
-      "source": [
-        "spl = \" \".join(manual).split(\" \")\n",
-        "print(len(spl))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 41,
-      "metadata": {
-        "id": "3PxRXUJYRjR3"
-      },
-      "outputs": [],
-      "source": [
-        "final_text = \"\".join(manual)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 42,
-      "metadata": {
-        "id": "D6P9BhcLQ44o"
-      },
-      "outputs": [],
-      "source": [
-        "with open(\"manual.txt\", \"w\") as m:\n",
-        "    m.write(final_text)"
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "name": "GenerateMockAutoManual.ipynb",
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2024 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ee1706bbf647"
+   },
+   "source": [
+    "## Generate a mock auto owner's manual using Gemini\n",
+    "\n",
+    "Megan O'Keefe, 2024"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "a709c36ce130"
+   },
+   "outputs": [],
+   "source": [
+    "%pip install \"google-cloud-aiplatform>=1.38\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Dczys2Z4OXtF"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud config set project YOUR_PROJECT_ID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qytITa3uORgf"
+   },
+   "outputs": [],
+   "source": [
+    "! gcloud auth application-default login"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "EIzxe56HO6a6"
+   },
+   "outputs": [],
+   "source": [
+    "import vertexai\n",
+    "from vertexai.generative_models import ChatSession, GenerativeModel"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "40d8418757b6"
+   },
+   "outputs": [],
+   "source": [
+    "# Set to your project and location\n",
+    "PROJECT_ID = \"your-project-id\"\n",
+    "REGION = \"us-central1\"  # change region as needed\n",
+    "MODEL = \"gemini-2.0-flash\"  # change model as needed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "OXCYfSDMOhYY"
+   },
+   "outputs": [],
+   "source": [
+    "vertexai.init(project=PROJECT_ID, location=REGION)\n",
+    "model = GenerativeModel(MODEL)\n",
+    "chat = model.start_chat()\n",
+    "\n",
+    "\n",
+    "def get_chat_response(chat: ChatSession, prompt: str) -> str:\n",
+    "    text_response = []\n",
+    "    responses = chat.send_message(prompt, stream=True)\n",
+    "    for chunk in responses:\n",
+    "        text_response.append(chunk.text)\n",
+    "    return \"\".join(text_response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "id": "9mNNCvGdPLM-"
+   },
+   "outputs": [],
+   "source": [
+    "manual = []\n",
+    "system = \"You are an automobile owner's manual generator for the brand Cymbal. The car model is a Cymbal Starlight 2024. Your job is to generate a 30-page owner's manual. you will be given a topic, which represents one chapter of the manual. Generate one page of material in as much detail as possible. Use specific numbers and details. The topic is: \""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "id": "RBFING9dPpLl"
+   },
+   "outputs": [],
+   "source": [
+    "topics = [\n",
+    "    \"Safety\",\n",
+    "    \"Child safety\",\n",
+    "    \"Emergency Assistance\",\n",
+    "    \"Instrument cluster\",\n",
+    "    \"Warning lights\",\n",
+    "    \"Doors, windows, and locks\",\n",
+    "    \"Adjusting the seats and steering wheel\",\n",
+    "    \"Towing, cargo, and luggage\",\n",
+    "    \"Driving procedures with automatic transmission\",\n",
+    "    \"Lights and windshield wipers\",\n",
+    "    \"Refueling\",\n",
+    "    \"Cruise control and automatic support system\",\n",
+    "    \"Inclement weather driving\",\n",
+    "    \"Audio and Bluetooth system\",\n",
+    "    \"Heating and air conditioning\",\n",
+    "    \"Maintenance and care\",\n",
+    "    \"Emergencies\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "DlyDTUdkQsfj"
+   },
+   "outputs": [],
+   "source": [
+    "for t in topics:\n",
+    "    print(t)\n",
+    "    p = system + \" \" + t\n",
+    "    res = get_chat_response(chat, p)\n",
+    "    manual.append(res)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "xrfa1DRWRoLq"
+   },
+   "outputs": [],
+   "source": [
+    "spl = \" \".join(manual).split(\" \")\n",
+    "print(len(spl))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "id": "3PxRXUJYRjR3"
+   },
+   "outputs": [],
+   "source": [
+    "final_text = \"\".join(manual)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "id": "D6P9BhcLQ44o"
+   },
+   "outputs": [],
+   "source": [
+    "with open(\"manual.txt\", \"w\") as m:\n",
+    "    m.write(final_text)"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "GenerateMockAutoManual.ipynb",
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }


### PR DESCRIPTION
## Summary
- Add missing Apache 2.0 copyright license header to notebooks in `gemini/sample-apps/`
- These notebooks were missing the standard copyright notice that other notebooks in the repo have

## Context
All notebooks in this repository should include the Apache 2.0 license header as per the project template.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)