### PR TITLE
refactor: Update vertexai.preview imports to stable API in accelerating_product_innovation

### DIFF
--- a/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/edit_image.py
+++ b/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/edit_image.py
@@ -29,7 +29,7 @@ import PIL
 import streamlit as st
 from PIL import Image
 from app.pages_utils.imagen import predict_edit_image
-from vertexai.preview.vision_models import Image as vertex_image
+from vertexai.vision_models import Image as vertex_image
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 

--- a/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/embedding_model.py
+++ b/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/embedding_model.py
@@ -7,7 +7,7 @@ import backoff
 from google.api_core.exceptions import ResourceExhausted
 import numpy as np
 import streamlit as st
-from vertexai.preview.language_models import TextEmbeddingModel
+from vertexai.language_models import TextEmbeddingModel
 
 
 @st.cache_resource

--- a/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/imagen.py
+++ b/gemini/sample-apps/accelerating_product_innovation/app/pages_utils/imagen.py
@@ -15,7 +15,7 @@ from PIL import Image
 import aiohttp as cloud_function_call
 import streamlit as st
 import vertexai
-from vertexai.preview.vision_models import ImageGenerationModel
+from vertexai.vision_models import ImageGenerationModel
 
 logging.basicConfig(format="%(levelname)s:%(message)s", level=logging.DEBUG)
 

--- a/gemini/sample-apps/accelerating_product_innovation/cloud_functions/gemini_call/main.py
+++ b/gemini/sample-apps/accelerating_product_innovation/cloud_functions/gemini_call/main.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from dotenv import load_dotenv
 import functions_framework
-from vertexai.preview import generative_models
-from vertexai.preview.generative_models import GenerativeModel
+from vertexai import generative_models
+from vertexai.generative_models import GenerativeModel
 
 load_dotenv()
 

--- a/gemini/sample-apps/accelerating_product_innovation/cloud_functions/imagen_call/main.py
+++ b/gemini/sample-apps/accelerating_product_innovation/cloud_functions/imagen_call/main.py
@@ -8,7 +8,7 @@ from typing import Any
 from dotenv import load_dotenv
 import functions_framework
 import vertexai
-from vertexai.preview.vision_models import ImageGenerationModel
+from vertexai.vision_models import ImageGenerationModel
 
 load_dotenv()
 

--- a/gemini/sample-apps/accelerating_product_innovation/cloud_functions/text_embedding/main.py
+++ b/gemini/sample-apps/accelerating_product_innovation/cloud_functions/text_embedding/main.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 import functions_framework
-from vertexai.preview.language_models import TextEmbeddingModel
+from vertexai.language_models import TextEmbeddingModel
 
 load_dotenv()
 


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `gemini/sample-apps/accelerating_product_innovation/`
- These APIs (GenerativeModel, TextEmbeddingModel, ImageGenerationModel, etc.) have been promoted from preview to stable

## Changes
- `from vertexai.preview.generative_models import ...` → `from vertexai.generative_models import ...`
- `from vertexai.preview.language_models import ...` → `from vertexai.language_models import ...`
- `from vertexai.preview.vision_models import ...` → `from vertexai.vision_models import ...`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)