### PR TITLE
refactor: Update vertexai.preview.generative_models imports in quickbot

### DIFF
--- a/gemini/sample-apps/quickbot/conversational-app-multi-playbook/backend/src/service/vertex_ai.py
+++ b/gemini/sample-apps/quickbot/conversational-app-multi-playbook/backend/src/service/vertex_ai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from langchain_google_vertexai import VertexAIEmbeddings
-from vertexai.preview.generative_models import GenerativeModel
+from vertexai.generative_models import GenerativeModel
 from google.cloud import bigquery
 from google.cloud.aiplatform import (
     MatchingEngineIndexEndpoint,

--- a/gemini/sample-apps/quickbot/conversational-app-single-playbook/backend/src/service/vertex_ai.py
+++ b/gemini/sample-apps/quickbot/conversational-app-single-playbook/backend/src/service/vertex_ai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from langchain_google_vertexai import VertexAIEmbeddings
-from vertexai.preview.generative_models import GenerativeModel
+from vertexai.generative_models import GenerativeModel
 from google.cloud import bigquery
 from google.cloud.aiplatform import (
     MatchingEngineIndexEndpoint,

--- a/gemini/sample-apps/quickbot/multi-agent-travel-concierge-with-adk/backend/src/service/vertex_ai.py
+++ b/gemini/sample-apps/quickbot/multi-agent-travel-concierge-with-adk/backend/src/service/vertex_ai.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from langchain_google_vertexai import VertexAIEmbeddings
-from vertexai.preview.generative_models import GenerativeModel
+from vertexai.generative_models import GenerativeModel
 from google.cloud import bigquery
 from google.cloud.aiplatform import MatchingEngineIndexEndpoint, MatchingEngineIndex
 from typing import List, MutableSequence


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `gemini/sample-apps/quickbot/`
- These APIs (GenerativeModel, TextEmbeddingModel, ImageGenerationModel, etc.) have been promoted from preview to stable

## Changes
- `from vertexai.preview.generative_models import ...` → `from vertexai.generative_models import ...`
- `from vertexai.preview.language_models import ...` → `from vertexai.language_models import ...`
- `from vertexai.preview.vision_models import ...` → `from vertexai.vision_models import ...`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)