### PR TITLE
refactor: Update vertexai.preview imports to stable API in embeddings notebook

### DIFF
--- a/embeddings/intro_embeddings_tuning.ipynb
+++ b/embeddings/intro_embeddings_tuning.ipynb
@@ -434,7 +434,7 @@
         "import pandas as pd\n",
         "import vertexai\n",
         "from vertexai.generative_models import GenerationConfig, GenerativeModel\n",
-        "import vertexai.preview.generative_models as generative_models"
+        "import vertexai.generative_models as generative_models"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `embeddings/`
- These APIs (GenerativeModel, TextEmbeddingModel, etc.) have been promoted from preview to stable

## Changes
- `vertexai.preview.generative_models` → `vertexai.generative_models`
- `vertexai.preview.language_models` → `vertexai.language_models`
- `vertexai.preview.vision_models` → `vertexai.vision_models`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)