### PR TITLE
refactor: Update vertexai.preview imports to stable API in gemini/rag-engine

### DIFF
--- a/gemini/rag-engine/rag_engine_vertex_ai_search.ipynb
+++ b/gemini/rag-engine/rag_engine_vertex_ai_search.ipynb
@@ -485,7 +485,7 @@
       "outputs": [],
       "source": [
         "from vertexai.preview import rag\n",
-        "from vertexai.preview.generative_models import GenerativeModel, Tool"
+        "from vertexai.generative_models import GenerativeModel, Tool"
       ]
     },
     {

--- a/gemini/rag-engine/rag_engine_weaviate.ipynb
+++ b/gemini/rag-engine/rag_engine_weaviate.ipynb
@@ -263,7 +263,7 @@
       "outputs": [],
       "source": [
         "from vertexai.preview import rag\n",
-        "from vertexai.preview.generative_models import GenerativeModel, Tool"
+        "from vertexai.generative_models import GenerativeModel, Tool"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `gemini/rag-engine/`
- These APIs (GenerativeModel, TextEmbeddingModel, etc.) have been promoted from preview to stable

## Changes
- `vertexai.preview.generative_models` → `vertexai.generative_models`
- `vertexai.preview.language_models` → `vertexai.language_models`
- `vertexai.preview.vision_models` → `vertexai.vision_models`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)