### PR TITLE
refactor: Update vertexai.preview imports to stable API in gemini/logging

### DIFF
--- a/gemini/logging/intro_request_response_logging.ipynb
+++ b/gemini/logging/intro_request_response_logging.ipynb
@@ -227,7 +227,7 @@
         "from google.cloud import bigquery\n",
         "\n",
         "# Use the preview module for this feature\n",
-        "from vertexai.preview.generative_models import GenerativeModel\n",
+        "from vertexai.generative_models import GenerativeModel\n",
         "\n",
         "# Ignore all warnings\n",
         "warnings.filterwarnings(\"ignore\")"


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `gemini/logging/`
- These APIs (GenerativeModel, TextEmbeddingModel, etc.) have been promoted from preview to stable

## Changes
- `vertexai.preview.generative_models` → `vertexai.generative_models`
- `vertexai.preview.language_models` → `vertexai.language_models`
- `vertexai.preview.vision_models` → `vertexai.vision_models`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)