### PR TITLE
refactor: Update vertexai.preview imports to stable API in search/

### DIFF
--- a/search/vertexai-search-options/vertexai_search_options.ipynb
+++ b/search/vertexai-search-options/vertexai_search_options.ipynb
@@ -304,7 +304,7 @@
         "    SafetySetting,\n",
         "    Tool,\n",
         ")\n",
-        "import vertexai.preview.generative_models as generative_models"
+        "import vertexai.generative_models as generative_models"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Update `vertexai.preview` imports to stable `vertexai` module paths in `search/`
- These APIs (GenerativeModel, TextEmbeddingModel, etc.) have been promoted from preview to stable

## Changes
- `vertexai.preview.generative_models` → `vertexai.generative_models`
- `vertexai.preview.language_models` → `vertexai.language_models`
- `vertexai.preview.vision_models` → `vertexai.vision_models`

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)