### PR TITLE
docs: Add README.md to gemini/use-cases/graphrag/

### DIFF
--- a/gemini/use-cases/graphrag/README.md
+++ b/gemini/use-cases/graphrag/README.md
@@ -1,0 +1,16 @@
+# Graph RAG
+
+Sample notebooks demonstrating Graph-based Retrieval-Augmented Generation (RAG) on Google Cloud with Gemini.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [agentic_graph_rag_neo4j.ipynb](agentic_graph_rag_neo4j.ipynb) | Agentic Graph RAG with Neo4j and Gemini |
+| [graph_rag_spanner_sdk_adk.ipynb](graph_rag_spanner_sdk_adk.ipynb) | Graph RAG with Spanner, Gen AI SDK, and Agent Development Kit |
+
+## Getting Started
+
+1. Open one of the notebooks in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore Graph RAG techniques.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/use-cases/graphrag` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)