### PR TITLE
docs: Add README.md to gemini/mcp/

### DIFF
--- a/gemini/mcp/README.md
+++ b/gemini/mcp/README.md
@@ -1,0 +1,17 @@
+# Model Context Protocol (MCP)
+
+Sample notebooks demonstrating how to use the Model Context Protocol (MCP) with Gemini on Google Cloud.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [intro_to_mcp.ipynb](intro_to_mcp.ipynb) | Introduction to the Model Context Protocol |
+| [build_mcp_server_by_gemini.ipynb](build_mcp_server_by_gemini.ipynb) | Build an MCP server using Gemini |
+| [develop_mcp_with_gemini_and_adk.ipynb](develop_mcp_with_gemini_and_adk.ipynb) | Develop MCP applications with Gemini and the Agent Development Kit |
+
+## Getting Started
+
+1. Open one of the notebooks in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore MCP integration with Gemini.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/mcp` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)