### PR TITLE
docs: Add README.md to gemini/long-context/

### DIFF
--- a/gemini/long-context/README.md
+++ b/gemini/long-context/README.md
@@ -1,0 +1,15 @@
+# Long Context
+
+Sample notebooks demonstrating the long context window capabilities of Gemini on Google Cloud.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [intro_long_context.ipynb](intro_long_context.ipynb) | Introduction to long context processing with Gemini |
+
+## Getting Started
+
+1. Open the notebook in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore long context capabilities.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/long-context` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)