### PR TITLE
docs: Add README.md to gemini/use-cases/retail/

### DIFF
--- a/gemini/use-cases/retail/README.md
+++ b/gemini/use-cases/retail/README.md
@@ -1,0 +1,17 @@
+# Retail Use Cases
+
+Sample notebooks demonstrating retail use cases with Gemini on Google Cloud.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [multimodal_retail_recommendations.ipynb](multimodal_retail_recommendations.ipynb) | Multimodal retail product recommendations with Gemini |
+| [product_attributes_extraction.ipynb](product_attributes_extraction.ipynb) | Product attribute extraction with Gemini |
+| [product_image_background_generation.ipynb](product_image_background_generation.ipynb) | Product image background generation |
+
+## Getting Started
+
+1. Open one of the notebooks in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore retail-specific AI capabilities.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/use-cases/retail` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)