### PR TITLE
docs: Add README.md to gemini/use-cases/code/

### DIFF
--- a/gemini/use-cases/code/README.md
+++ b/gemini/use-cases/code/README.md
@@ -1,0 +1,17 @@
+# Code Use Cases
+
+Sample notebooks demonstrating code-related use cases with Gemini on Google Cloud.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [analyze_codebase.ipynb](analyze_codebase.ipynb) | Analyze and understand codebases with Gemini |
+| [code_retrieval_augmented_generation.ipynb](code_retrieval_augmented_generation.ipynb) | Code retrieval-augmented generation |
+| [code_scanning_and_vulnerability_detection.ipynb](code_scanning_and_vulnerability_detection.ipynb) | Code scanning and vulnerability detection with Gemini |
+
+## Getting Started
+
+1. Open one of the notebooks in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore code analysis capabilities.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/use-cases/code` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)