### PR TITLE
docs: Add README.md to gemini/rag-engine/

### DIFF
--- a/gemini/rag-engine/README.md
+++ b/gemini/rag-engine/README.md
@@ -1,0 +1,22 @@
+# RAG Engine
+
+Sample notebooks demonstrating the Vertex AI RAG Engine with Gemini on Google Cloud.
+
+## Notebooks
+
+| Notebook | Description |
+| --- | --- |
+| [intro_rag_engine.ipynb](intro_rag_engine.ipynb) | Introduction to the Vertex AI RAG Engine |
+| [rag_engine_evaluation.ipynb](rag_engine_evaluation.ipynb) | Evaluate RAG Engine performance |
+| [rag_engine_eval_service_sdk.ipynb](rag_engine_eval_service_sdk.ipynb) | RAG Engine evaluation with the Eval Service SDK |
+| [rag_engine_vector_search.ipynb](rag_engine_vector_search.ipynb) | RAG Engine with Vector Search |
+| [rag_engine_vertex_ai_search.ipynb](rag_engine_vertex_ai_search.ipynb) | RAG Engine with Vertex AI Search |
+| [rag_engine_feature_store.ipynb](rag_engine_feature_store.ipynb) | RAG Engine with Feature Store |
+| [rag_engine_pinecone.ipynb](rag_engine_pinecone.ipynb) | RAG Engine with Pinecone |
+| [rag_engine_weaviate.ipynb](rag_engine_weaviate.ipynb) | RAG Engine with Weaviate |
+
+## Getting Started
+
+1. Open one of the notebooks in [Google Colab](https://colab.research.google.com/) or [Vertex AI Workbench](https://cloud.google.com/vertex-ai/docs/workbench/introduction).
+2. Follow the instructions in the notebook to set up your Google Cloud project.
+3. Run the cells to explore the RAG Engine capabilities.


### PR DESCRIPTION
## Summary
- Add a README.md file to `gemini/rag-engine` to provide an overview of the samples available in this directory

## Context
This directory was missing a README.md file, making it harder for users to discover and understand the available samples.

- [x] I follow the [CONTRIBUTING Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md)