### PR TITLE
fix: update multimodal dataset intro colab for datasets.assemble tuple return

### DIFF
--- a/gemini/multimodal-dataset/intro_vertex_ai_multimodal_dataset.ipynb
+++ b/gemini/multimodal-dataset/intro_vertex_ai_multimodal_dataset.ipynb
@@ -619,7 +619,7 @@
       "source": [
         "**Assemble and inspect the dataset.**\n",
         "\n",
-        "The dataset assembly creates a BigQuery table with the assembled examples in a single `request` column. The assembly method returns the BigQuery URI of the assembled table."
+        "The dataset assembly creates a BigQuery table with the assembled examples in a single `request` column. The assembly method returns a `(table_id, dataframe)` tuple; pass `load_dataframe=True` to also load the assembled table as a BigFrames DataFrame for inspection."
       ]
     },
     {
@@ -631,13 +631,14 @@
       },
       "outputs": [],
       "source": [
-        "assembly_bq_uri = client.datasets.assemble(\n",
+        "table_id, assembly = client.datasets.assemble(\n",
         "    name=flowers.name,\n",
         "    gemini_request_read_config=read_config,\n",
+        "    load_dataframe=True,\n",
         ")\n",
         "\n",
         "# Inspect assembled dataset\n",
-        "bpd.read_gbq_table(assembly_bq_uri.removeprefix(\"bq://\")).head()"
+        "assembly.head()"
       ]
     },
     {
@@ -914,17 +915,17 @@
         ")\n",
         "```\n",
         "\n",
-        "Alternatively, you can still assemble the dataset manually and pass the assembly BigQuery URI:\n",
+        "Alternatively, you can still assemble the dataset manually and pass the assembled BigQuery table:\n",
         "\n",
         "```py\n",
-        "prediction_assembly_bq_uri = client.datasets.assemble(\n",
+        "table_id, _ = client.datasets.assemble(\n",
         "    name=flowers_prediction.name,\n",
         "    gemini_request_read_config=read_config,\n",
         ")\n",
         "\n",
         "job = genai_client.batches.create(\n",
         "    model=model,\n",
-        "    src=prediction_assembly_bq_uri,\n",
+        "    src=f\"bq://{table_id}\",\n",
         ")\n",
         "```\n",
         "\n",
@@ -1009,8 +1010,8 @@
         "    multimodal_dataset=flowers_prediction\n",
         ")\n",
         "\n",
-        "# Assemble the dataset with a read config and get the assembly BigQuery URI\n",
-        "prediction_assembly_bq_uri = client.datasets.assemble(\n",
+        "# Assemble the dataset with a read config and get the assembled BigQuery table id\n",
+        "prediction_table_id, _ = client.datasets.assemble(\n",
         "    name=flowers_prediction.name,\n",
         "    gemini_request_read_config=read_config,\n",
         ")"
@@ -1030,8 +1031,8 @@
         "job = genai_client.batches.create(\n",
         "    # use the model selected above\n",
         "    model=model,\n",
-        "    # Use the assembly BigQuery URI as source\n",
-        "    src=prediction_assembly_bq_uri,\n",
+        "    # Use the assembled BigQuery table as source\n",
+        "    src=f\"bq://{prediction_table_id}\",\n",
         ")\n",
         "\n",
         "\n",


### PR DESCRIPTION
## Summary

Updates the multimodal dataset intro colab for the `datasets.assemble` change shipped in **google-cloud-aiplatform v1.159.0**, where `client.datasets.assemble` now returns a `(table_id, dataframe)` tuple (with a `load_dataframe` parameter, default `False`) instead of the BigQuery URI string.

Without this, the notebook breaks against v1.159.0 (the returned tuple was being passed where a `bq://` URI string was expected).

## Changes

- **Assemble & inspect:** `table_id, assembly = client.datasets.assemble(..., load_dataframe=True)` → `assembly.head()` (was `assembly_bq_uri = ...` → `bpd.read_gbq_table(assembly_bq_uri.removeprefix("bq://")).head()`).
- **Batch prediction (manual-assemble path):** `table_id, _ = client.datasets.assemble(...)` → `src=f"bq://{table_id}"` (the tuple's `table_id` drops the `bq://` prefix, so it is re-added).
- Updated the accompanying description text to say `assemble` returns a `(table_id, dataframe)` tuple.