### PR TITLE
chore(ge-demo-generator): point template fetch defaults at this repository

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -88,8 +88,8 @@ const CONFIG = {
   // repo at this pinned ref at run time. Pin to a commit SHA so every
   // generated script keeps fetching exactly the files it was built for.
   // Override via Script Properties (TEMPLATE_REPO / TEMPLATE_REF) for testing.
-  TEMPLATE_REPO: SCRIPT_PROPS.getProperty('TEMPLATE_REPO') || 'https://github.com/ryotat7/generative-ai.git',
-  TEMPLATE_REF: SCRIPT_PROPS.getProperty('TEMPLATE_REF') || '90bdbdf27f88e45b6311b7864a4ebeb6f9595024',
+  TEMPLATE_REPO: SCRIPT_PROPS.getProperty('TEMPLATE_REPO') || 'https://github.com/GoogleCloudPlatform/generative-ai.git',
+  TEMPLATE_REF: SCRIPT_PROPS.getProperty('TEMPLATE_REF') || '8ae1538c9bd2b20104f7949f0f1e6457bbd87b4c',
   TEMPLATE_SUBDIR: SCRIPT_PROPS.getProperty('TEMPLATE_SUBDIR') || 'search/gemini-enterprise/ge-demo-generator/agent_template',
   LOG_SHEET_URL: SCRIPT_PROPS.getProperty('LOG_SHEET_URL')
 };


### PR DESCRIPTION
Follow-up to #2963 (as noted in the review thread): now that the sample is merged, switch the `TEMPLATE_REPO` / `TEMPLATE_REF` defaults from the development fork to this repository at the merge commit `8ae1538c`. Verified the pinned sparse fetch from this repository works (0.8 s, 38 files). Two-line change in `app/Code.gs`.