### PR TITLE
chore(ge-demo-generator): re-point template fetch at this repository + two small fixes

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -264,6 +264,7 @@ clf
 clickable
 CLIs
 cloudrun
+CLOUDSDK
 cloudveil
 clsx
 cmap

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -3177,7 +3177,7 @@ ${ enableManagedAgent ? `
         echo "   ✅ Agent Engine cleanup verified (none remaining)."
       else
         echo "   ⚠️  \$_AE_LEFT Agent Engine(s) still listed (async deletion may be in progress)."
-        echo "       Re-run cleanup or check the Vertex AI console if they persist."
+        echo "       Re-run cleanup or check the Vertex AI Agent Platform console if they persist."
       fi
     fi
 
@@ -3549,7 +3549,7 @@ ${ enableManagedAgent ? `
 # Creation takes ~8-10 min, so it is STARTED here (right after the dashboards
 # bucket exists) and awaited in PHASE B after the Cloud Run deployment +
 # Gemini Enterprise registration, hiding most of the wait behind the rest of
-# the setup. No allowlist is needed - just the Vertex AI API + standard IAM.
+# the setup. No allowlist is needed - just the Vertex AI Agent Platform API + standard IAM.
 # VERIFIED live (2026-07-12): the create LRO never reports done:true, so
 # readiness is detected in PHASE B by polling GET on the agent itself.
 echo "🤖 Starting Managed Autonomous Agent provisioning (Antigravity, Preview)..."

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -88,8 +88,8 @@ const CONFIG = {
   // repo at this pinned ref at run time. Pin to a commit SHA so every
   // generated script keeps fetching exactly the files it was built for.
   // Override via Script Properties (TEMPLATE_REPO / TEMPLATE_REF) for testing.
-  TEMPLATE_REPO: SCRIPT_PROPS.getProperty('TEMPLATE_REPO') || 'https://github.com/ryotat7/generative-ai.git',
-  TEMPLATE_REF: SCRIPT_PROPS.getProperty('TEMPLATE_REF') || '0238bb2d70eb506fad9354a6e5164b995297bfb1',
+  TEMPLATE_REPO: SCRIPT_PROPS.getProperty('TEMPLATE_REPO') || 'https://github.com/GoogleCloudPlatform/generative-ai.git',
+  TEMPLATE_REF: SCRIPT_PROPS.getProperty('TEMPLATE_REF') || '49f0bddb7c1e2b0b90cee7643c5eb961d33adf92',
   TEMPLATE_SUBDIR: SCRIPT_PROPS.getProperty('TEMPLATE_SUBDIR') || 'search/gemini-enterprise/ge-demo-generator/agent_template',
   LOG_SHEET_URL: SCRIPT_PROPS.getProperty('LOG_SHEET_URL')
 };


### PR DESCRIPTION
Follow-up to #2977, same as #2970 after #2963: during review, `TEMPLATE_REPO` / `TEMPLATE_REF` were temporarily pinned to the PR branch fork so generated setup scripts worked before merge. This re-points them at this repository, pinned to the #2977 merge commit (`49f0bddb`) that contains the final `agent_template/` (including the Managed Agent helpers and deliverable skills). Verified with a live sparse-checkout fetch of the pinned ref from this repository — the exact commands the generated setup script runs — followed by a completeness check of the fetched template.

Also includes two small fixes found in end-to-end testing of the deployed sample:

- **Data Viewer header showed the raw business goal**: the Gemini-summarized `systemDescription` was computed but never used — the viewer substitution passed the raw `userGoal` (full markdown scenario text) as `GE_DASH_DESC`. Now passes `systemDescription` (which already falls back to `userGoal` on generation failure).
- **Spelling check findings** in `app/Code.gs` (two "Vertex AI Agent Platform" rewordings and a `CLOUDSDK` allow-list entry) that surface on this branch because the check runs against the merged #2977 content.