### PR TITLE
feat(ge-demo-generator): Gemini Enterprise app auto-provisioning and direct agent link

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1400,6 +1400,7 @@ pyc
 pydantic
 pydrive
 pydub
+PYEOF
 PYINK
 pymupdf
 pyo

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.25-public',
+  APP_VERSION: 'v11.30-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -3692,15 +3692,215 @@ else
   echo "    your account lacks permission to list apps — in which case detection may be"
   echo "    a false negative.)"
   echo ""
-  echo "   You MUST have a Gemini Enterprise instance already created in this project."
-  echo "   If you haven't, please create one here first:"
-  echo "   https://console.cloud.google.com/gemini-enterprise/products?project=$PROJECT_ID"
-  echo ""
-  read -p "Have you confirmed the instance exists? (y/n) " -n 1 -r
-  echo
-  if [[ ! \$REPLY =~ ^[Yy]$ ]]; then
-      echo "Exiting. Please create the instance and run the script again."
-      exit 1
+
+  GE_APP_CREATED=""
+  if [ ! -z "\$GE_TOKEN" ]; then
+    # The bulk API-enable step runs later in this script, so make sure the
+    # Discovery Engine API is on before probing subscriptions (fresh projects).
+    gcloud services enable discoveryengine.googleapis.com --project "\$PROJECT_ID" >/dev/null 2>&1 || true
+    # Check for an active Gemini Enterprise subscription (license config).
+    GE_LICENSE_STATE=$(curl -s -H "Authorization: Bearer \$GE_TOKEN" -H "X-Goog-User-Project: \$PROJECT_ID" \
+      "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/licenseConfigs" \
+      | python3 -c '
+import sys, json
+try:
+    configs = json.load(sys.stdin).get("licenseConfigs", [])
+    active = any(c.get("state") == "ACTIVE" and c.get("subscriptionTier") == "SUBSCRIPTION_TIER_SEARCH_AND_ASSISTANT" for c in configs)
+    print("ACTIVE" if active else "INACTIVE")
+except Exception:
+    print("UNKNOWN")
+' 2>/dev/null)
+
+    # No active subscription: offer to start a free trial automatically.
+    # Safety: the request always pins freeTrial=true and the result is only
+    # accepted if the server confirms an ACTIVE free trial. A paid
+    # subscription is NEVER purchased automatically.
+    if [ "\$GE_LICENSE_STATE" != "ACTIVE" ]; then
+      echo "ℹ️  No active Gemini Enterprise subscription was found in this project."
+      echo "   The script can provision this project for Gemini Enterprise and start a"
+      echo "   free trial subscription. Proceeding means you accept:"
+      echo "   - the Terms for data use (https://cloud.google.com/retail/data-use-terms)"
+      echo "   - the Gemini Enterprise (Agentspace) quality-of-service terms"
+      read -p "   Start a free trial subscription automatically? (y/n) " -n 1 -r
+      echo
+      if [[ \$REPLY =~ ^[Yy]$ ]]; then
+        TRIAL_OUT=$(python3 - "\$PROJECT_ID" "\$GE_TOKEN" << 'PYEOF'
+import sys, json, time, datetime, urllib.request, urllib.error
+project_id, token = sys.argv[1], sys.argv[2]
+headers = {
+    "Authorization": "Bearer " + token,
+    "Content-Type": "application/json",
+    "X-Goog-User-Project": project_id,
+}
+api = "https://discoveryengine.googleapis.com/v1alpha/"
+
+# Step 1: provision the project for Discovery Engine / Gemini Enterprise.
+# This creates the default user store required by license configs. Idempotent
+# on already-provisioned projects. The user consented to the terms above.
+prov_body = {
+    "acceptDataUseTerms": True,
+    "dataUseTermsVersion": "2022-11-23",
+    "saasParams": {"acceptBizQos": True},
+}
+req = urllib.request.Request(api + "projects/" + project_id + ":provision",
+                             data=json.dumps(prov_body).encode("utf-8"), headers=headers)
+try:
+    with urllib.request.urlopen(req) as resp:
+        op = json.loads(resp.read().decode("utf-8"))
+except urllib.error.HTTPError as e:
+    print("TRIAL_FAIL: provisioning failed: HTTP " + str(e.code) + " " + e.read().decode("utf-8")[:300])
+    sys.exit(1)
+except Exception as e:
+    print("TRIAL_FAIL: provisioning failed: " + str(e))
+    sys.exit(1)
+deadline = time.time() + 120
+while not op.get("done") and op.get("name") and time.time() < deadline:
+    time.sleep(5)
+    try:
+        with urllib.request.urlopen(urllib.request.Request(api + op["name"], headers=headers)) as resp:
+            op = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        pass
+if not op.get("done") or op.get("error"):
+    print("TRIAL_FAIL: provisioning did not complete: " + json.dumps(op.get("error") or {})[:300])
+    sys.exit(1)
+
+# Step 2: create the free trial license config. freeTrial is pinned to True
+# and the result is only accepted if the server confirms an ACTIVE free
+# trial - a paid subscription is NEVER purchased automatically.
+today = datetime.date.today()
+end = today + datetime.timedelta(days=30)
+body = {
+    "subscriptionTier": "SUBSCRIPTION_TIER_SEARCH_AND_ASSISTANT",
+    "licenseCount": "50",
+    "subscriptionTerm": "SUBSCRIPTION_TERM_CUSTOM",
+    "startDate": {"year": today.year, "month": today.month, "day": today.day},
+    "endDate": {"year": end.year, "month": end.month, "day": end.day},
+    "freeTrial": True,
+}
+url = (api + "projects/" + project_id
+       + "/locations/global/licenseConfigs?licenseConfigId=free_trial_agent_space")
+req = urllib.request.Request(url, data=json.dumps(body).encode("utf-8"), headers=headers)
+try:
+    with urllib.request.urlopen(req) as resp:
+        data = json.loads(resp.read().decode("utf-8"))
+except urllib.error.HTTPError as e:
+    print("TRIAL_FAIL: HTTP " + str(e.code) + " " + e.read().decode("utf-8")[:300])
+    sys.exit(1)
+except Exception as e:
+    print("TRIAL_FAIL: " + str(e))
+    sys.exit(1)
+if data.get("freeTrial") is True and data.get("state") == "ACTIVE":
+    print("TRIAL_OK")
+else:
+    print("TRIAL_FAIL: the created config is not a confirmed active free trial"
+          + " (state=" + str(data.get("state")) + ", freeTrial=" + str(data.get("freeTrial"))
+          + "). Please check the Gemini Enterprise console.")
+    sys.exit(1)
+PYEOF
+) || true
+        if echo "\$TRIAL_OUT" | grep -q "^TRIAL_OK"; then
+          echo "   ✅ Free trial subscription activated."
+          GE_LICENSE_STATE="ACTIVE"
+        else
+          echo "   ⚠️  Could not start a free trial automatically:"
+          echo "\$TRIAL_OUT" | sed 's/^/      /'
+        fi
+      fi
+    fi
+
+    # Active subscription: offer to create the Gemini Enterprise app automatically.
+    if [ "\$GE_LICENSE_STATE" = "ACTIVE" ]; then
+      read -p "   Create a Gemini Enterprise app in this project automatically now? (y/n) " -n 1 -r
+      echo
+      if [[ \$REPLY =~ ^[Yy]$ ]]; then
+        echo "   ⏳ Creating Gemini Enterprise app (this can take a minute or two)..."
+        CREATE_OUT=$(python3 - "\$PROJECT_ID" "\$GE_TOKEN" << 'PYEOF'
+import sys, json, time, urllib.request, urllib.error
+project_id, token = sys.argv[1], sys.argv[2]
+headers = {
+    "Authorization": "Bearer " + token,
+    "Content-Type": "application/json",
+    "X-Goog-User-Project": project_id,
+}
+engine_id = "gemini-enterprise-" + str(int(time.time()))
+base = ("https://discoveryengine.googleapis.com/v1alpha/projects/" + project_id
+        + "/locations/global/collections/default_collection/engines")
+body = {
+    "displayName": "Gemini Enterprise",
+    "solutionType": "SOLUTION_TYPE_SEARCH",
+    "appType": "APP_TYPE_INTRANET",
+    "industryVertical": "GENERIC",
+    "searchEngineConfig": {
+        "searchTier": "SEARCH_TIER_ENTERPRISE",
+        "searchAddOns": ["SEARCH_ADD_ON_LLM"],
+        "requiredSubscriptionTier": "SUBSCRIPTION_TIER_SEARCH_AND_ASSISTANT",
+    },
+}
+req = urllib.request.Request(base + "?engineId=" + engine_id,
+                             data=json.dumps(body).encode("utf-8"), headers=headers)
+try:
+    with urllib.request.urlopen(req) as resp:
+        op = json.loads(resp.read().decode("utf-8"))
+except urllib.error.HTTPError as e:
+    print("CREATE_FAIL: HTTP " + str(e.code) + " " + e.read().decode("utf-8")[:300])
+    sys.exit(1)
+except Exception as e:
+    print("CREATE_FAIL: " + str(e))
+    sys.exit(1)
+op_name = op.get("name", "")
+deadline = time.time() + 180
+while op_name and not op.get("done") and time.time() < deadline:
+    time.sleep(5)
+    try:
+        poll = urllib.request.Request("https://discoveryengine.googleapis.com/v1alpha/" + op_name, headers=headers)
+        with urllib.request.urlopen(poll) as resp:
+            op = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        pass
+if op.get("error"):
+    print("CREATE_FAIL: " + json.dumps(op["error"])[:300])
+    sys.exit(1)
+# Wait until the new app is visible in the engines list (later steps re-list it).
+while time.time() < deadline:
+    try:
+        lst = urllib.request.Request(base, headers=headers)
+        with urllib.request.urlopen(lst) as resp:
+            engines = json.loads(resp.read().decode("utf-8")).get("engines", [])
+        if any(e.get("name", "").endswith("/" + engine_id) for e in engines):
+            print("GE_APP_CREATED:" + engine_id)
+            sys.exit(0)
+    except Exception:
+        pass
+    time.sleep(5)
+print("CREATE_FAIL: the app did not appear in the engines list within the timeout")
+sys.exit(1)
+PYEOF
+) || true
+        GE_APP_CREATED=$(echo "\$CREATE_OUT" | grep "^GE_APP_CREATED:" | cut -d':' -f2)
+        if [ ! -z "\$GE_APP_CREATED" ]; then
+          echo "   ✅ Created Gemini Enterprise app: \$GE_APP_CREATED (location: global)"
+          echo "Proceeding automatically."
+        else
+          echo "   ⚠️  Automatic app creation failed:"
+          echo "\$CREATE_OUT" | sed 's/^/      /'
+        fi
+      fi
+    fi
+  fi
+
+  if [ -z "\$GE_APP_CREATED" ]; then
+    echo ""
+    echo "   You MUST have a Gemini Enterprise instance already created in this project."
+    echo "   If you haven't, please create one here first:"
+    echo "   https://console.cloud.google.com/gemini-enterprise/products?project=$PROJECT_ID"
+    echo ""
+    read -p "Have you confirmed the instance exists? (y/n) " -n 1 -r
+    echo
+    if [[ ! \$REPLY =~ ^[Yy]$ ]]; then
+        echo "Exiting. Please create the instance and run the script again."
+        exit 1
+    fi
   fi
 fi
 
@@ -4941,13 +5141,28 @@ ${params.importedMcpList.map((mcp, idx) => {
   echo "🔗 Quick Access Links"
   echo "---------------------------------------------------------"
   if [ ! -z "\$AGENT_ID" ]; then
-    echo "💬 Start Chatting in Gemini Enterprise:"
-    echo "   👉 https://console.cloud.google.com/gemini-enterprise/locations/\$SELECTED_LOC/engines/\$SELECTED_APP_ID/overview/dashboard?&project=\$PROJECT_ID"
-    echo "   💡 Click the 'Preview' button at the top to launch Gemini Enterprise, then select 'Agents' from the left menu to start chatting with your deployed agent."
+    # Resolve the web app config id (cid) so the link opens the agent directly.
+    LINK_TOKEN=$(gcloud auth application-default print-access-token 2>/dev/null || gcloud auth print-access-token)
+    if [ "\$SELECTED_LOC" = "global" ]; then
+      WC_ENDPOINT="discoveryengine.googleapis.com"
+    else
+      WC_ENDPOINT="\${SELECTED_LOC}-discoveryengine.googleapis.com"
+    fi
+    CONFIG_ID=$(curl -s -H "Authorization: Bearer \$LINK_TOKEN" -H "X-Goog-User-Project: \$PROJECT_ID" \
+      "https://\$WC_ENDPOINT/v1alpha/projects/\$PROJECT_ID/locations/\$SELECTED_LOC/collections/default_collection/engines/\$SELECTED_APP_ID/widgetConfigs/default_search_widget_config" \
+      | python3 -c 'import sys, json; print(json.load(sys.stdin).get("configId", ""))' 2>/dev/null) || true
+    if [ ! -z "\$CONFIG_ID" ]; then
+      echo "💬 Start Chatting with Your Agent:"
+      echo "   👉 https://vertexaisearch.cloud.google.com/home/cid/\$CONFIG_ID/r/agent/\$AGENT_ID/session/-"
+    else
+      echo "💬 Start Chatting in Gemini Enterprise:"
+      echo "   👉 https://console.cloud.google.com/gemini-enterprise/locations/\$SELECTED_LOC/engines/\$SELECTED_APP_ID/overview/dashboard?project=\$PROJECT_ID"
+      echo "   💡 Click the 'Preview' button at the top to launch Gemini Enterprise, then select 'Agents' from the left menu to start chatting with your deployed agent."
+    fi
     echo ""
   else
     echo "💻 Gemini Enterprise Console:"
-    echo "   👉 https://console.cloud.google.com/gemini-enterprise/overview?&project=\$PROJECT_ID"
+    echo "   👉 https://console.cloud.google.com/gemini-enterprise/overview?project=\$PROJECT_ID"
     echo ""
   fi
   

--- a/search/gemini-enterprise/ge-demo-generator/app/index.html
+++ b/search/gemini-enterprise/ge-demo-generator/app/index.html
@@ -2223,12 +2223,12 @@ limitations under the License.
               <div class="roadmap-step">
                 <div class="roadmap-dot"></div>
                 <h4 class="text-sm font-bold text-gray-200 uppercase tracking-tight mb-1">Step 3: Deploy</h4>
-                <p class="text-xs text-gray-400">Copy the setup script from <b>Step 3</b> and paste it into Google Cloud Shell. The script will provision resources in your selected Google Cloud project, deploy the agent to Cloud Run, and register it in Gemini Enterprise.</p>
+                <p class="text-xs text-gray-400">Copy the setup script from <b>Step 3</b> and paste it into Google Cloud Shell. The script will provision resources in your selected Google Cloud project, deploy the agent to Cloud Run, and register it in Gemini Enterprise. No Gemini Enterprise app yet? The script offers to start a free trial subscription and create the app for you automatically.</p>
               </div>
               <div class="roadmap-step">
                 <div class="roadmap-dot"></div>
                 <h4 class="text-sm font-bold text-gray-200 uppercase tracking-tight mb-1">Step 4: Run Live Demo</h4>
-                <p class="text-xs text-gray-400">Once the script completes, open the Gemini Enterprise app to interact with your agent. To help you run an effective demonstration, use the generated demo prompts tailored specifically to your business challenge and the sample data.</p>
+                <p class="text-xs text-gray-400">Once the script completes, open the direct agent link printed at the end of the script output — it starts a new conversation with your agent in Gemini Enterprise. To help you run an effective demonstration, use the generated demo prompts tailored specifically to your business challenge and the sample data.</p>
               </div>
             </div>
 
@@ -2370,7 +2370,7 @@ limitations under the License.
                   <div>
                     <h4 class="text-sm font-bold text-sky-400 uppercase tracking-tight mb-1">💡 Recommended Environment</h4>
                     <p class="text-[13px] text-gray-300 leading-relaxed">
-                      Click the button on the right to open Cloud Shell directly in your Google Cloud Console. We highly recommend using Cloud Shell as it comes pre-installed with all the necessary tools for this setup script. Alternatively, a step-by-step walkthrough is available by <a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_tutorial=search/gemini-enterprise/ge-demo-generator/README.md&cloudshell_git_repo=https://github.com/GoogleCloudPlatform/generative-ai.git" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline hover:text-sky-300 transition-all">launching the Cloud Shell Tutorial</a>.
+                      Click the button on the right to open Cloud Shell directly in your Google Cloud Console. We highly recommend using Cloud Shell as it comes pre-installed with all the necessary tools for this setup script. Alternatively, a step-by-step walkthrough is available by <a href="https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/generative-ai.git&cloudshell_git_branch=main&cloudshell_workspace=search/gemini-enterprise/ge-demo-generator&cloudshell_tutorial=search/gemini-enterprise/ge-demo-generator/tutorial.md" target="_blank" rel="noopener noreferrer" class="text-sky-400 underline hover:text-sky-300 transition-all">launching the Cloud Shell Tutorial</a>.
                     </p>
                   </div>
                   <a href="https://console.cloud.google.com/welcome?cloudshell=true" target="_blank" rel="noopener noreferrer"

--- a/search/gemini-enterprise/ge-demo-generator/tutorial.md
+++ b/search/gemini-enterprise/ge-demo-generator/tutorial.md
@@ -1,0 +1,139 @@
+# BigQuery MCP Agent Demo: Guided Walkthrough
+> **Note:** You do NOT need to create a Gemini Enterprise app in advance. If the setup script does not find one in your project, it offers to start a 30-day free trial subscription and create the app automatically (you will be asked to consent to the data-use and quality-of-service terms during the run).
+
+
+Welcome! This tutorial will guide you through the setup and execution of your synthesized BigQuery MCP Agent demo.
+
+## Prerequisites
+
+Before we begin, ensure you have the necessary APIs enabled and the correct project selected.
+
+<walkthrough-project-setup>
+</walkthrough-project-setup>
+
+### 🛠️ Set Your Project
+Ensure your Cloud Shell is targeting the correct project:
+
+<walkthrough-test-code-block>
+gcloud config set project {{project-id}}
+</walkthrough-test-code-block>
+
+---
+
+## Step 1: Provision Demo Environment in Your Project
+
+The Demo Generator has synthesized a custom setup script for you. This script is responsible for provisioning the BigQuery dataset and setting up the agent code within YOUR Google Cloud environment.
+
+1. Go back to the **GE Demo Generator** Web UI.
+2. Under **Step 3: Deploy**, click the **Copy** button next to the **Setup Script**.
+3. **Paste the command** into the Cloud Shell terminal window (at the bottom of your screen) and press **Enter**.
+
+> [!IMPORTANT]
+> This app does not provision resources directly. Running this script is the required step to create the demo environment in your own project.
+
+> **Note:** The script is uniquely named (e.g., `setup-demo-retail-inventory-831afa90.sh`) and creates a matching directory.
+
+```bash
+# Paste your setup command here in the terminal window below
+```
+
+---
+
+## Step 2: Access Your Agent in Gemini Enterprise
+
+Once the setup script from Step 1 completes, your agent is automatically deployed to Cloud Run and registered in Gemini Enterprise.
+
+1. The fastest way in: open the **direct agent link** printed at the end of the setup script output (`https://vertexaisearch.cloud.google.com/home/cid/.../r/agent/.../session/-`) — it opens a new conversation with your agent.
+2. Alternatively, open the [Gemini Enterprise Console](https://console.cloud.google.com/gemini-enterprise/apps) in your Google Cloud project and find your agent from there.
+3. You can verify the deployment status with:
+
+```bash
+gcloud run services list --filter="metadata.name:demo-" --format="table(name,region,status.url)"
+```
+
+---
+
+## Step 3: Explore & Preview
+
+Your agent is now live in Gemini Enterprise. Start a conversation from the direct agent link printed by the setup script, or from the [Gemini Enterprise Console](https://console.cloud.google.com/gemini-enterprise/apps).
+
+#### 💡 Real-Time Data Viewer Application
+If your setup included the Bento Grid operations console, the Data Viewer is automatically deployed as a Cloud Run Function. Look for the **Data Viewer URL** printed at the end of the setup script output.
+
+> **Note (IAP-protected)**: The viewer is not public — it is protected by Identity-Aware Proxy, and only the deploying user is granted access automatically. **Open the viewer URL once in your browser before the demo** to complete Google sign-in. To let other people open it directly, add them with the `gcloud beta iap web add-iam-policy-binding` command printed in the setup summary (screen-sharing your own browser needs no extra grants).
+
+
+---
+
+## Step 4: Try the Scenarios
+
+Use the **Step 4: Run Live Demo** section in your Demo Generator for tailored prompts.
+
+**Example Prompts:**
+- "Analyze sales trends using the BigQuery tool."
+- "Correlate demographic data with real-world locations via Google Maps."
+- "Update maintenance status on item #104 and post verification logs into Firestore."
+- "Approve the flagged safety incident and update the operations grid instantly."
+
+
+---
+
+## 🛠️ Troubleshooting: Reliability in Cloud Run
+
+If your agent occasionally stops responding or feels slow in Cloud Run:
+
+### 1. Handling "Cold Starts"
+Cloud Run may spin down instances after inactivity (cold starts). The first request after a break might take longer as it loads heavy libraries (like `pandas` or `scikit-learn`). 
+- **Tip**: Sending the same prompt again usually works as the container is then "warm."
+- **Solution**: For scaled usage, consider using a warmer service or reducing the number of heavy dependencies in your `requirements.txt`.
+
+### 2. BigQuery Token Lags
+Retrieving fresh auth tokens for BigQuery can sometimes add latency.
+- **Fix Applied**: Our generated `tools.py` now includes stability patches that cache tokens for 30 minutes to ensure smooth tool execution.
+
+### 3. Execution Timeouts
+The default timeout for Cloud Run is 60 seconds. If your agent performs many sequential tool calls, it might hit this limit.
+- **Optimization**: Use `gemini-3.1-pro-preview` for high-speed reasoning, and try to keep tool queries efficient.
+
+### 4. 403 Insufficient Scope Errors
+If you see "Request had insufficient authentication scopes" in the logs:
+- **Solution**: Refresh your local credentials in Cloud Shell with mandatory scopes (Note: `maps-platform` is NOT a valid standalone scope; use `cloud-platform` instead):
+  `gcloud auth application-default login --scopes="https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/bigquery,openid,https://www.googleapis.com/auth/userinfo.email"`
+- **Required Action**: After running the command, you MUST **restart the agent** (Ctrl+C and run the launch command again) to clear the cached tokens.
+
+### 5. Cloud Run Deployment Failures (Org Policies)
+If the setup fails to provision the Data Viewer application or the main Agent service:
+- **Cause**: Many enterprise Google Cloud projects restrict unauthenticated endpoints via organization policies (like `constraints/iam.allowedPolicyMemberDomains`).
+- **Mitigation**: The setup script is designed to print a warning and proceed even if the **Data Viewer** deployment fails due to ingress policies. You can still preview the multi-agent setup locally using `adk web` (Step 3).
+
+### 6. 403 Permission Denied on Tool Invocation
+If sub-agents fail to modify Firestore or pull from BigQuery:
+- **Action**: Ensure the default Cloud Run Compute Service Account (`[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`) has been successfully provisioned with the following roles:
+  - `roles/mcp.toolUser`
+  - `roles/datastore.user` (For Firestore)
+  - `roles/bigquery.dataViewer` & `roles/bigquery.jobUser`
+  - `roles/aiplatform.user`
+
+
+---
+
+## 🧹 Cleanup: Removing Demo Resources
+
+When you're done with your demo, you can easily clean up all created resources by running the setup script with the `--cleanup` flag:
+
+```bash
+# Replace with your actual script name
+bash setup-demo-xxx.sh --cleanup
+```
+
+This will remove:
+- **BigQuery Dataset**: The demo dataset and all its tables
+- **Maps API Key**: The auto-generated API key for Google Maps
+- **Local Directory**: The demo folder in your Cloud Shell home
+
+> **Note:** You'll be prompted for confirmation before any resources are deleted.
+
+---
+
+### Need Help?
+See the [GE Demo Generator README](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator) or open an issue on the [GoogleCloudPlatform/generative-ai](https://github.com/GoogleCloudPlatform/generative-ai/issues) repository. Support is handled on a best-effort basis.


### PR DESCRIPTION
# Description

Feature update for `search/gemini-enterprise/ge-demo-generator` (APP_VERSION `v11.30-public`), continuing #2986.

## What's new

- **Gemini Enterprise app auto-provisioning** — when the setup script finds no Gemini Enterprise app in the target project, it now offers to start a 30-day free-trial subscription and create the app automatically (with explicit consent to the data-use and quality-of-service terms), removing the last manual prerequisite from a fresh-project setup.
- **Direct agent link** — the setup script prints a deep link that opens a conversation with the freshly registered agent in one click, instead of asking users to navigate the console; the wizard's guide copy points at it.
- **Cloud Shell walkthrough tutorial** — adds `tutorial.md` (consolidating #2992) and fixes the wizard's tutorial link to carry the full cloudshell parameter set (branch, workspace, tutorial path). The tutorial reflects this release's behavior: no pre-existing Gemini Enterprise app is required, and the direct agent link is the fastest way in.
- The internal-only "tips for Google internal users" wizard panel is intentionally NOT ported.

No changes to `agent_template/` — this release is generation-layer only, so with the generation-time `TEMPLATE_REF` resolution introduced in #2986 there is nothing to pin and no follow-up PR is needed.

## Verification

- `python3 validate_examples.py` — 33/33 template files.
- Generated setup scripts across the feature matrix: `bash -n` clean; skeleton diffs against the internal reference show only the known architecture differences; all shared emitted file bodies byte-equal.
- `node --check` on all Apps Script files and inline HTML scripts.
