### PR TITLE
feat(ge-demo-generator): adopt Gemini 3.6 Flash and Gemini 3.5 Flash-Lite

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -630,6 +630,7 @@ GDM
 gdp
 geboten
 gecos
+gedemo
 gemhall
 genai
 genkit

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -11,7 +11,7 @@ The **GE Demo Generator** is a low-code web application built on Google Apps Scr
 - **Reality-Grounded Demos**: The tool provisions actual BigQuery analytics, Google Maps grounding, and Firestore persistence databases for a raw, living demo experience.
 
 ### ⚙️ Technical Features
-- **Triple-Agent Autonomous Architecture**: Features a multi-agent execution framework powered by **Gemini 3.5 Flash** by default. Consists of a coordinator (`root_agent`) for chat, simple retrieval, and A2UI card rendering; an analytical sub-agent (`deep_analysis_agent`) for complex inline calculations; and a standalone background worker (`background_agent`) run asynchronously for long-running background tasks and recurring cron scheduled tasks. Models are configurable via `--model-analysis-agent` and `--model-root-agent` CLI flags.
+- **Triple-Agent Autonomous Architecture**: Features a multi-agent execution framework powered by **Gemini 3.6 Flash** by default. Consists of a coordinator (`root_agent`) for chat, simple retrieval, and A2UI card rendering; an analytical sub-agent (`deep_analysis_agent`) for complex inline calculations; and a standalone background worker (`background_agent`) run asynchronously for long-running background tasks and recurring cron scheduled tasks. Models are configurable via `--model-analysis-agent` and `--model-root-agent` CLI flags.
 - **Autonomous Workflow Pipelines & Guardrails**: Incorporates advanced background pipelines for both workflow-based operations (`SCAN -> ANALYZE -> PLAN -> EXECUTE -> VERIFY -> REPORT` with human-in-the-loop escalations) and deep analytical tasks. All background tasks are protected by an **Anti-Shallow Guard** self-check to ensure rigorous statistical results and extensive data tool coverage.
 - **MCP Server Catalog**: A curated catalog of pre-configured MCP servers (Government & Legal, Finance, Social, Japan-Specific, Environment & Weather, Google Official) with one-click add, recipe bundles, and custom URL import.
 - **A2UI (Agent-to-UI) Compliant**: Streams interactive Bento Grid layouts, Analytics Charts, and interactive confirmation cards using the A2UI SDK (`a2ui-agent-sdk`) via `<a2ui-json>` tags embedded in model responses. Integrates rich Welcome Card onboarding and step-by-step Workflow Execution Plan patterns.
@@ -188,7 +188,7 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 | Property | Default | Description |
 |---|---|---|
 | `LOCATION` | `global` | Vertex AI Agent Platform API location (e.g., `us-central1`, `global`) |
-| `MODEL` | `gemini-3.5-flash` | Gemini model name for data generation |
+| `MODEL` | `gemini-3.6-flash` | Gemini model name for data generation |
 | `TEMPLATE_REPO` | this repository | Git URL the generated setup script fetches `agent_template/` from at run time |
 | `TEMPLATE_REF` | `main` | Branch, tag, or commit SHA of the agent template. A branch/tag is resolved to a concrete commit SHA at script-generation time (each generated script is pinned to that SHA); set a 40-hex SHA to hard-pin |
 | `TEMPLATE_SUBDIR` | `search/gemini-enterprise/ge-demo-generator/agent_template` | Repo path of the template directory |
@@ -271,7 +271,7 @@ When a user generates a demo through the web UI, the tool:
    - Provisions Firestore with operational documents
    - Deploys a **Data Viewer** web app (Flask on Cloud Run Functions Gen2)
    - Scaffolds an ADK agent project with MCP toolsets, A2UI support, and an A2A FastAPI server exposing a chat agent (`root_agent` and `deep_analysis_agent` sub-agent) and a background worker (`background_agent` via `/execute_task` runner)
-   - Defaults to **Gemini 3.5 Flash** for all three agents, with support for model override via `--model-analysis-agent` and `--model-root-agent` CLI flags
+   - Defaults to **Gemini 3.6 Flash** for all three agents, with support for model override via `--model-analysis-agent` and `--model-root-agent` CLI flags
    - Automatically builds a container image and deploys the Agent FastAPI server to **Cloud Run** (with `--min-instances 0` to control standby costs).
    - Provisions IAM bindings and environment configurations automatically.
    - Discovers any existing Gemini Enterprise Apps in your project and registers the newly deployed Cloud Run agent automatically.
@@ -511,7 +511,7 @@ A monolithic Google Apps Script file (~17.7k lines, ~952 KB) that contains:
 | **Favorites & Deletion** | `toggleFavorite`, `deleteHistoryItem` | Per-user favorites and owner-only history deletion |
 | **Vertex AI Agent Platform Utilities** | `callVertexAI`, `callVertexAIWithSearch`, `executeWithRetry` | API calls with retry logic and Google Search grounding |
 | **Customer Domain Research** | `researchCompanyByDomain`, `mergeTemplateWithCompanyInfo` | Google Search-grounded company research, challenge identification, and workflow discovery |
-| **MCP Import & Analysis** | `analyzeMcpRepository` | Analyzes GitHub repos via `gemini-3.1-flash-lite` and integrates custom MCP servers as co-located sidecars in the agent container |
+| **MCP Import & Analysis** | `analyzeMcpRepository` | Analyzes GitHub repos via `gemini-3.5-flash-lite` and integrates custom MCP servers as co-located sidecars in the agent container |
 
 #### Error Handling (`SetupError.html`)
 
@@ -545,12 +545,12 @@ When the user runs the generated setup script in Cloud Shell, the following arch
 
 #### Agent Architecture
 
-The synthesized agent uses a **triple-agent/multi-agent autonomous execution** architecture to achieve high-depth operational execution alongside optimal latency and cost. The architecture features three specialized agent instances, all utilizing **Gemini 3.5 Flash** by default for rapid response and high token efficiency:
+The synthesized agent uses a **triple-agent/multi-agent autonomous execution** architecture to achieve high-depth operational execution alongside optimal latency and cost. The architecture features three specialized agent instances, all utilizing **Gemini 3.6 Flash** by default for rapid response and high token efficiency:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  root_agent (LlmAgent — Coordinator)                         │
-│  Model: gemini-3.5-flash (AGENT_MODEL_LITE)                  │
+│  Model: gemini-3.6-flash (AGENT_MODEL_LITE)                  │
 │  Role: Chat coordinator, simple queries, A2UI card builder    │
 │  Instruction: Generated system prompt + A2UI schema          │
 │               + Background-First Routing Rules               │
@@ -566,7 +566,7 @@ The synthesized agent uses a **triple-agent/multi-agent autonomous execution** a
 │                                                              │
 │  ┌──────────────────────────────────────────────────────┐    │
 │  │  deep_analysis_agent (LlmAgent — Analytical Sub)     │    │
-│  │  Model: gemini-3.5-flash (AGENT_MODEL)                │    │
+│  │  Model: gemini-3.6-flash (AGENT_MODEL)                │    │
 │  │  Role: Complex inline multi-step reasoning            │    │
 │  │  Tools: Same shared toolset                           │    │
 │  │  Transfer: Returns to root_agent on completion        │    │
@@ -580,7 +580,7 @@ The synthesized agent uses a **triple-agent/multi-agent autonomous execution** a
 
 ┌──────────────────────────────────────────────────────────────┐
 │  background_agent (LlmAgent — Standalone Worker)              │
-│  Model: gemini-3.5-flash (AGENT_MODEL)                       │
+│  Model: gemini-3.6-flash (AGENT_MODEL)                       │
 │  Role: Autonomous background operations & deep analysis       │
 │  Instruction: Main instruction + Pipeline guardrails         │
 │               + Anti-Shallow Guard (no UI / no transfers)    │
@@ -694,7 +694,7 @@ The catalog also includes **recipe bundles** — pre-configured combinations of 
 #### Custom MCP Import (URL)
 
 Users can import any GitHub-hosted MCP server by providing the repository URL. The system:
-1. Fetches repository contents via Gemini-powered analysis (`gemini-3.1-flash-lite`)
+1. Fetches repository contents via Gemini-powered analysis (`gemini-3.5-flash-lite`)
 2. Identifies the entrypoint, language, required environment variables, and capabilities
 3. Generates the Dockerfile sidecar configuration and `supergateway` bridge commands
 4. Supports deduplication to prevent adding the same server twice
@@ -770,11 +770,11 @@ graph TD
 The setup script deploys the agent directly to Google Cloud Run and supports model overrides and automated cleanup via CLI flags:
 
 ```bash
-# Default models (gemini-3.5-flash)
+# Default models (gemini-3.6-flash)
 bash setup-demo-xxx.sh
 
 # Override models
-bash setup-demo-xxx.sh --model-analysis-agent gemini-3.1-pro-preview --model-root-agent gemini-3.1-flash-lite
+bash setup-demo-xxx.sh --model-analysis-agent gemini-3.1-pro-preview --model-root-agent gemini-3.5-flash-lite
 
 # Cleanup
 bash setup-demo-xxx.sh --cleanup
@@ -844,7 +844,7 @@ After running the setup script, the following directory structure is created:
 
 1. **Prompt**: The user says in Gemini Enterprise: *"Approve safety issue #104 and log update notes."*
 2. **A2A Routing**: Gemini Enterprise sends the message via A2A JSON-RPC to the Cloud Run FastAPI server.
-3. **Model Announcement**: The server emits a `🧠 Model: gemini-3.5-flash` status event in the thinking accordion.
+3. **Model Announcement**: The server emits a `🧠 Model: gemini-3.6-flash` status event in the thinking accordion.
 4. **Reasoning**: The `root_agent` identifies a write request and plans to use the Firestore MCP toolset.
 5. **Confirmation**: The agent renders an A2UI confirmation card (via `<a2ui-json>` tags) showing before/after data with Approve/Reject buttons and a `dataModelUpdate` for pre-populated fields.
 6. **User Approval**: The user clicks "Approve" in the interactive card, which sends a `sendText` action back to the agent.

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -886,13 +886,13 @@ _RETRY_OPTIONS = types.HttpRetryOptions(
 
 # Pro model — used by deep_analysis_agent for complex multi-step reasoning
 gemini_pro_model = Gemini(
-    model=os.environ.get("AGENT_MODEL", "gemini-3.5-flash"),
+    model=os.environ.get("AGENT_MODEL", "gemini-3.6-flash"),
     retry_options=_RETRY_OPTIONS
 )
 
 # Flash-Lite model — used by root_agent (coordinator) for most interactions
 gemini_lite_model = Gemini(
-    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.5-flash"),
+    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.6-flash"),
     retry_options=_RETRY_OPTIONS
 )
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
@@ -1266,7 +1266,7 @@ async def _classify_for_preflight(text, prev_user_text=""):
             vertexai=True, location=_loc, project=project_id,
             http_options={"api_version": "v1"},
         )
-        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.5-flash")
+        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.6-flash")
         _prompt = PREFLIGHT_CLASSIFIER_PROMPT + chr(10) + chr(10)
         if prev_user_text:
             _prompt = (_prompt + "PREVIOUS USER MESSAGE (language reference only - NOT the request):"
@@ -1639,13 +1639,13 @@ def _heal_session_events(session, force_aggressive=False):
     #   - force_aggressive=True (emergency, after a token-overflow ClientError)
     #   - the root model is a lightweight model (flash-lite) — always compact
     #   - the measured context size exceeds the char budget. Heavier models
-    #     (3.5-flash / pro) keep FULL context UNTIL near the limit, so normal
+    #     (3.6-flash / pro) keep FULL context UNTIL near the limit, so normal
     #     large reports are never trimmed — only runaway contexts are.
     # Char-based by design: generated-image bytes are NOT stored in history
     # (generate_image stashes them in session.state), so the real bloat is
     # text — SQL result sets, MCP payloads, multi-turn accumulation.
     # =========================================================================
-    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.5-flash").lower()
+    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.6-flash").lower()
     _is_lite = "lite" in _root_model
 
     def _event_char_size(_ev):
@@ -2663,8 +2663,8 @@ class AdkAgentToA2AExecutor(A2aAgentExecutor):
         # Maps agent name → model string for the thinking accordion header.
         # =============================================================================
         _agent_model_map = {
-            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.5-flash"),
-            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.5-flash"),
+            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.6-flash"),
+            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.6-flash"),
         }
         _model_announced = set()  # Track which agents have been announced
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -1513,7 +1513,9 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
             return {"status": "error", "detail": "Playwright is not installed in this environment: " + str(_imp)}
 
         client = genai_client.Client(vertexai=True, location=location, project=project)
-        model = os.environ.get("AGENT_MODEL", "gemini-3.5-flash")
+        # Pinned to gemini-3.5-flash: gemini-3.6-flash does not support the
+        # Computer Use tool, so this must NOT follow AGENT_MODEL.
+        model = os.environ.get("COMPUTER_USE_MODEL", "gemini-3.5-flash")
         cfg = types.GenerateContentConfig(
             temperature=1.0, top_p=0.95, top_k=40, max_output_tokens=8192,
             tools=[types.Tool(computer_use=types.ComputerUse(environment=types.Environment.ENVIRONMENT_BROWSER))],

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -21,7 +21,7 @@
  *
  * ── What Gets Generated ──────────────────────────────────────────────
  *   • Synthetic business data (BigQuery tables + optional Firestore docs)
- *   • Dual-model ADK agent (Gemini 3.1 Flash-Lite root → Pro analysis)
+ *   • Dual-model ADK agent (Gemini 3.5 Flash-Lite root → Pro analysis)
  *   • MCP toolsets — BigQuery, Maps, Firestore, Google Workspace (Gmail,
  *     Drive, Calendar, Chat, People), plus arbitrary GitHub MCP servers
  *   • A2A (Agent-to-Agent) server with A2UI interactive components
@@ -78,11 +78,11 @@ const SCRIPT_PROPS = PropertiesService.getScriptProperties();
 const CONFIG = {
   PROJECT_ID: SCRIPT_PROPS.getProperty('PROJECT_ID'),
   LOCATION: SCRIPT_PROPS.getProperty('LOCATION') || 'global',
-  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.5-flash',
+  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.6-flash',
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.30-public',
+  APP_VERSION: 'v11.31-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -156,7 +156,7 @@ function doGet() {
 
   template.projectId = CONFIG.PROJECT_ID;
   template.userEmail = Session.getActiveUser().getEmail();
-  template.generatorModel = CONFIG.MODEL || 'gemini-3.5-flash';
+  template.generatorModel = CONFIG.MODEL || 'gemini-3.6-flash';
   
   return template.evaluate()
     .setTitle('GE Demo Generator')
@@ -338,7 +338,7 @@ function initializeProject(projectId, logSheetUrl) {
   const newProps = {
     PROJECT_ID: projectId, 
     LOCATION: currentProps.LOCATION || 'global',
-    MODEL: currentProps.MODEL || 'gemini-3.5-flash',
+    MODEL: currentProps.MODEL || 'gemini-3.6-flash',
     LOG_SHEET_URL: logSheetUrl || currentProps.LOG_SHEET_URL || ''
   };
   
@@ -3104,9 +3104,9 @@ show_usage() {
   echo ""
   echo "Options:"
   echo "  --model-analysis-agent, -m <MODEL>  Set the deep analysis agent model"
-  echo "                                      (default: gemini-3.5-flash)"
+  echo "                                      (default: gemini-3.6-flash)"
   echo "  --model-root-agent <MODEL>          Set the root orchestration agent model"
-  echo "                                      (default: gemini-3.5-flash)"
+  echo "                                      (default: gemini-3.6-flash)"
   echo "  --cleanup, -c                       Delete all provisioned demo resources"
   echo "  --yes, -y                           Skip confirmation prompts (non-interactive use)"
   echo "  --help, -h                          Show this help message and exit"
@@ -3114,7 +3114,7 @@ show_usage() {
   echo "Examples:"
   echo "  bash $0                                  # Deploy with default models"
   echo "  bash $0 --model-analysis-agent gemini-3.1-pro-preview       # Use a different analysis model"
-  echo "  bash $0 --model-root-agent gemini-3.1-flash-lite            # Use a different root model"
+  echo "  bash $0 --model-root-agent gemini-3.5-flash-lite            # Use a different root model"
   echo "  bash $0 --cleanup                         # Remove all demo resources"
   echo "  bash $0 --cleanup --yes                   # Remove all demo resources without prompting"
   echo ""
@@ -3122,8 +3122,8 @@ show_usage() {
 
 
 # --- Argument Parsing ---
-AGENT_MODEL="gemini-3.5-flash"
-AGENT_MODEL_LITE="gemini-3.5-flash"
+AGENT_MODEL="gemini-3.6-flash"
+AGENT_MODEL_LITE="gemini-3.6-flash"
 ROOT_MODEL_CLI_OVERRIDE=false
 CLEANUP_MODE=false
 AUTO_CONFIRM=false
@@ -3573,7 +3573,7 @@ while true; do
   echo "Choose an option:"
   echo "  [Y] Yes, proceed with this project (Default)"
   echo "  [N] No, cancel deployment"
-  echo "  [M] Modify the root agent model (Change to gemini-3.1-flash-lite)"
+  echo "  [M] Modify the root agent model (Change to gemini-3.5-flash-lite)"
   echo ""
   read -p "▶ Enter choice [Y/n/m]: " REPLY
   echo
@@ -3595,16 +3595,16 @@ while true; do
     # --- Model Selection Flow ---
     echo ""
     echo "🧠 Configure Chat & Orchestration Model (root_agent):"
-    echo "   - root_agent (Chat/UI): Uses 'gemini-3.5-flash' by default."
-    echo "   - deep_analysis_agent (Reasoning): Uses 'gemini-3.5-flash'."
+    echo "   - root_agent (Chat/UI): Uses 'gemini-3.6-flash' by default."
+    echo "   - deep_analysis_agent (Reasoning): Uses 'gemini-3.6-flash'."
     echo ""
-    echo "   You can choose 'gemini-3.1-flash-lite' for the root_agent."
+    echo "   You can choose 'gemini-3.5-flash-lite' for the root_agent."
     echo "   While it yields simpler and more concise responses, it provides"
     echo "   much faster and snappier interactions for routine chat."
     echo "   For complex tasks requiring deep analysis, the root_agent can"
-    echo "   still delegate the work to the deep_analysis_agent (3.5-flash)."
+    echo "   still delegate the work to the deep_analysis_agent (3.6-flash)."
     echo ""
-    read -p "▶ Use lightweight gemini-3.1-flash-lite for root_agent? (Y/n): " CHOOSE_LITE
+    read -p "▶ Use lightweight gemini-3.5-flash-lite for root_agent? (Y/n): " CHOOSE_LITE
     CHOOSE_LITE=\$(echo "\$CHOOSE_LITE" | tr -d '\\r\\n\\t ')
     
     # Default to 'y' since they specifically selected 'M' to configure
@@ -3613,11 +3613,11 @@ while true; do
     fi
     
     if [[ "\$CHOOSE_LITE" =~ ^[Yy]$ ]]; then
-      AGENT_MODEL_LITE="gemini-3.1-flash-lite"
-      echo "   ✅ Configured root_agent to use: gemini-3.1-flash-lite"
+      AGENT_MODEL_LITE="gemini-3.5-flash-lite"
+      echo "   ✅ Configured root_agent to use: gemini-3.5-flash-lite"
     else
-      AGENT_MODEL_LITE="gemini-3.5-flash"
-      echo "   ℹ️  Keeping default root_agent: gemini-3.5-flash"
+      AGENT_MODEL_LITE="gemini-3.6-flash"
+      echo "   ℹ️  Keeping default root_agent: gemini-3.6-flash"
     fi
     echo ""
     # Directly proceed to deployment steps after configuration is complete
@@ -5299,7 +5299,7 @@ Output pure JSON only (no code blocks, no markdown):
     // Direct API call with flash-lite model for speed + higher token limit
     let location = CONFIG.LOCATION || 'global';
     const host = location === 'global' ? 'aiplatform.googleapis.com' : `${location}-aiplatform.googleapis.com`;
-    const researchModel = 'gemini-3.1-flash-lite';
+    const researchModel = 'gemini-3.5-flash-lite';
     const url = `https://${host}/v1/projects/${CONFIG.PROJECT_ID}/locations/${location}/publishers/google/models/${researchModel}:generateContent`;
     
     const payload = {
@@ -5414,7 +5414,7 @@ Output ONLY the scenario text. No JSON, no code blocks, no explanations.`;
   try {
     let location = CONFIG.LOCATION || 'global';
     const host = location === 'global' ? 'aiplatform.googleapis.com' : `${location}-aiplatform.googleapis.com`;
-    const model = 'gemini-3.1-flash-lite';
+    const model = 'gemini-3.5-flash-lite';
     const url = `https://${host}/v1/projects/${CONFIG.PROJECT_ID}/locations/${location}/publishers/google/models/${model}:generateContent`;
 
     const payload = {
@@ -5465,7 +5465,7 @@ function callVertexAI(prompt) {
 function callVertexAIWithSearch(prompt) {
   let location = CONFIG.LOCATION || 'global';
   const host = location === 'global' ? 'aiplatform.googleapis.com' : `${location}-aiplatform.googleapis.com`;
-  const searchModel = 'gemini-3.1-flash-lite';
+  const searchModel = 'gemini-3.5-flash-lite';
   const url = `https://${host}/v1/projects/${CONFIG.PROJECT_ID}/locations/${location}/publishers/google/models/${searchModel}:generateContent`;
   
   const payload = {
@@ -5676,7 +5676,7 @@ function classifyDemoTaxonomy_(userGoal, aiSummary, businessInstruction) {
 function callTaxonomyModel_(userGoal, aiSummary, businessInstruction, allowed) {
   const location = CONFIG.LOCATION || 'global';
   const host = location === 'global' ? 'aiplatform.googleapis.com' : `${location}-aiplatform.googleapis.com`;
-  const model = 'gemini-3.1-flash-lite';
+  const model = 'gemini-3.5-flash-lite';
   const url = `https://${host}/v1/projects/${CONFIG.PROJECT_ID}/locations/${location}/publishers/google/models/${model}:generateContent`;
 
   const fields = Object.keys(allowed); // subset of ['industry','persona','useCase']
@@ -6052,7 +6052,7 @@ function callGeminiApi(contextContent, url) {
   const region = CONFIG.LOCATION || 'global';
 
   const host = region === 'global' ? 'aiplatform.googleapis.com' : `${region}-aiplatform.googleapis.com`;
-  const endpoint = `https://${host}/v1/projects/${projectId}/locations/${region}/publishers/google/models/gemini-3.1-flash-lite:generateContent`;
+  const endpoint = `https://${host}/v1/projects/${projectId}/locations/${region}/publishers/google/models/gemini-3.5-flash-lite:generateContent`;
 
   const prompt = `You are an AI expert determining if custom MCP Servers can be safely provisioned on standard Cloud Run.
 Review the collected files enclosed in the <REPOSITORY_CONTEXT> tag below.
@@ -6182,7 +6182,7 @@ ${contextContent}
 }
 
 /**
- * Service endpoint for Magic Wand. Expands and refines scenario statement using gemini-3.1-flash-lite.
+ * Service endpoint for Magic Wand. Expands and refines scenario statement using gemini-3.5-flash-lite.
  * Robustly handles raw inputs, templates, and edited Markdown scenarios from domain research.
  * Features 3-retry loop with exponential backoff to handle transient rate limits (429) and server errors (5xx).
  * @param {string} rawGoal - The user's current scenario text.
@@ -6191,7 +6191,7 @@ ${contextContent}
 function optimizeGoalWithMagicWand(rawGoal, capabilityOpts) {
   let location = CONFIG.LOCATION || 'global';
   const host = location === 'global' ? 'aiplatform.googleapis.com' : `${location}-aiplatform.googleapis.com`;
-  const model = 'gemini-3.1-flash-lite';
+  const model = 'gemini-3.5-flash-lite';
   const url = `https://${host}/v1/projects/${CONFIG.PROJECT_ID}/locations/${location}/publishers/google/models/${model}:generateContent`;
 
   // Capability-aware optimization: when the Managed Agent toggle is on, the

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
@@ -35,10 +35,10 @@ const SCRIPT_PROPS = PropertiesService.getScriptProperties();
 const CONFIG = {
   PROJECT_ID: SCRIPT_PROPS.getProperty('PROJECT_ID'),
   LOCATION: SCRIPT_PROPS.getProperty('LOCATION') || 'global',
-  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.5-flash',
+  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.6-flash',
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v1.6-public',
+  APP_VERSION: 'v1.7-public',
   MY_DEMOS_FOLDER: 'My Demos'
 };
 
@@ -68,7 +68,7 @@ function doGet(e) {
   template.appVersion = CONFIG.APP_VERSION;
   template.projectId = CONFIG.PROJECT_ID;
   template.userEmail = Session.getActiveUser().getEmail();
-  template.generatorModel = CONFIG.MODEL || 'gemini-3.5-flash';
+  template.generatorModel = CONFIG.MODEL || 'gemini-3.6-flash';
 
   let webAppUrl = '';
   try {
@@ -115,7 +115,7 @@ function initializeProject(projectId) {
   const newProps = {
     PROJECT_ID: projectId,
     LOCATION: currentProps.LOCATION || 'global',
-    MODEL: currentProps.MODEL || 'gemini-3.5-flash'
+    MODEL: currentProps.MODEL || 'gemini-3.6-flash'
   };
 
   scriptProps.setProperties(newProps);
@@ -254,7 +254,7 @@ function repairTruncatedJson(jsonStr) {
 
 /**
  * Detects the language a business goal is WRITTEN in (not the language of the
- * countries/companies it mentions) with a fast gemini-3.1-flash-lite call, so the
+ * countries/companies it mentions) with a fast gemini-3.5-flash-lite call, so the
  * planning prompt can enforce it as a hard constant instead of asking the planning
  * model to detect-and-follow (which drifts toward locale-associated languages on
  * long outputs). Returns an English language name (e.g. "English", "Indonesian")
@@ -270,7 +270,7 @@ function detectGoalLanguage_(userGoal) {
   try {
     const location = CONFIG.LOCATION || 'global';
     const host = location === 'global' ? 'aiplatform.googleapis.com' : location + '-aiplatform.googleapis.com';
-    const url = 'https://' + host + '/v1/projects/' + CONFIG.PROJECT_ID + '/locations/' + location + '/publishers/google/models/gemini-3.1-flash-lite:generateContent';
+    const url = 'https://' + host + '/v1/projects/' + CONFIG.PROJECT_ID + '/locations/' + location + '/publishers/google/models/gemini-3.5-flash-lite:generateContent';
     const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: { temperature: 0, maxOutputTokens: 512 } };
     const response = UrlFetchApp.fetch(url, {
       method: 'POST', contentType: 'application/json',
@@ -534,7 +534,7 @@ function optimizeGoalWithMagicWand(rawGoal, persona) {
   if (!rawGoal || !String(rawGoal).trim()) return { success: false, error: 'Nothing to optimize.' };
   const location = CONFIG.LOCATION || 'global';
   const host = location === 'global' ? 'aiplatform.googleapis.com' : location + '-aiplatform.googleapis.com';
-  const model = 'gemini-3.1-flash-lite';
+  const model = 'gemini-3.5-flash-lite';
   const url = 'https://' + host + '/v1/projects/' + CONFIG.PROJECT_ID + '/locations/' + location + '/publishers/google/models/' + model + ':generateContent';
 
   const prompt =
@@ -613,7 +613,7 @@ function translateTemplates(lang, items) {
   try {
     const location = CONFIG.LOCATION || 'global';
     const host = location === 'global' ? 'aiplatform.googleapis.com' : location + '-aiplatform.googleapis.com';
-    const model = 'gemini-3.1-flash-lite';
+    const model = 'gemini-3.5-flash-lite';
     const url = 'https://' + host + '/v1/projects/' + CONFIG.PROJECT_ID + '/locations/' + location + '/publishers/google/models/' + model + ':generateContent';
     const payload = { contents: [{ role: 'user', parts: [{ text: prompt }] }], generationConfig: { temperature: 0.2, maxOutputTokens: 8192 } };
     const response = UrlFetchApp.fetch(url, {
@@ -695,7 +695,7 @@ function researchCompanyByDomain(domain, persona) {
   try {
     const location = CONFIG.LOCATION || 'global';
     const host = location === 'global' ? 'aiplatform.googleapis.com' : location + '-aiplatform.googleapis.com';
-    const researchModel = 'gemini-3.1-flash-lite';
+    const researchModel = 'gemini-3.5-flash-lite';
     const url = 'https://' + host + '/v1/projects/' + CONFIG.PROJECT_ID + '/locations/' + location +
       '/publishers/google/models/' + researchModel + ':generateContent';
 

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
@@ -35,7 +35,7 @@ deployment; the root project's `clasp push` does not include it.
    not the repo root one).
 3. Set Script Properties via the editor: run `initializeProject(projectId)` — or set
    `PROJECT_ID` manually. Optional: `LOCATION` (default `global`), `MODEL`
-   (default `gemini-3.5-flash`).
+   (default `gemini-3.6-flash`).
 4. Deploy as a Web App with **Execute as: User accessing the web app** and **Access: anyone
    in your domain** (matches `appsscript.json`).
 5. Each user grants Drive/Docs/Sheets/Slides + Vertex AI Agent Platform consent on first open, and needs


### PR DESCRIPTION
# Description

Model refresh for `search/gemini-enterprise/ge-demo-generator` (APP_VERSION `v11.31-public`), continuing #2993. Gemini 3.6 Flash and Gemini 3.5 Flash-Lite went GA on 2026-07-21.

## What's changed

- **Default agent/generation model** `gemini-3.5-flash` → `gemini-3.6-flash` (CONFIG default, `AGENT_MODEL` / `AGENT_MODEL_LITE` defaults in the setup script and agent templates, help text).
- **Lightweight helper calls** (magic wand, domain research, language detection, MCP repo analysis) `gemini-3.1-flash-lite` → `gemini-3.5-flash-lite`.
- **Computer Use pin**: `gemini-3.6-flash` does not support the Computer Use tool, so the browser session no longer follows `AGENT_MODEL` — it reads a new `COMPUTER_USE_MODEL` env var (default `gemini-3.5-flash`, which does support it).
- **GE Demo Generator Lite** → `v1.7-public` with the same refresh.
- README model references updated.

No pinning changes needed: generated scripts resolve `agent_template/` from `main` at generation time (#2986), so the template-side Computer Use pin ships atomically with this merge.

## Verification

- `python3 validate_examples.py` — 33/33 template files.
- Generated setup scripts across the feature matrix: `bash -n` clean; skeleton diffs against the internal reference show only the known architecture differences, with model defaults byte-identical per site (including the intentional `gemini-3.5-flash` Computer Use pin).
- `node --check` on all Apps Script files.