### PR TITLE
feat(ge-demo-generator): autonomous-task reliability (orphan recovery, scheduling) and computer-use fixes (v11.32-v11.37)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1458,6 +1458,7 @@ rarians
 ratelimit
 rawbytes
 rbc
+rbeat
 rbf
 rbm
 rdoc
@@ -1518,6 +1519,7 @@ rsi
 RSI
 rslora
 rsp
+rstarted
 RTN
 rubra
 rubrum
@@ -1917,6 +1919,8 @@ wcontext
 wcslen
 wdir
 WDIR
+wdoc
+wdocs
 weaviate
 webcam
 webclient

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -782,8 +782,13 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
     "web pages programmatically and has NO interactive browser. Tasks whose PRIMARY goal is "
     "operating a site - clicking, typing, filling forms, working a portal, or a browse the "
     "user wants to watch live - are YOURS via computer_use_browse; never delegate them. "
-    "Delegate instead only when web reading merely feeds a bigger job that also needs a "
-    "downloadable file deliverable, a Workspace action, or software work. For such a "
+    "LIVE-BROWSE TRIGGER: whenever the request mentions web browsing (in ANY language) or "
+    "names a specific external site, page, portal, or URL to consult, you MUST run the live "
+    "browser on it FIRST - even if the same pages could in principle be read "
+    "programmatically. The visible browser run IS part of what the user asked to see; "
+    "skipping it and delegating everything is a routing error. "
+    "Delegate when web reading feeds a bigger job that also needs a "
+    "downloadable file deliverable, a Workspace action, or software work - but for such a "
     "COMPOSITE job the order is: short focused browse FIRST (live-view link shown), then "
     "delegate_autonomous_task in the SAME turn with the browse result_summary inside "
     "input_data labeled 'BROWSER FINDINGS (gathered live from <url>):'.\n"
@@ -814,8 +819,13 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
         "computer_use_browse - the browser screenshots still stream into THIS chat automatically.\n"
         "  You MUST show the link BEFORE calling computer_use_browse, because that call blocks until "
         "the browser finishes - showing it after is too late to watch live. The result_summary is "
-        "your answer. Inline is capped (~12 steps); if it returns status 'partial', offer to re-run "
-        "as a background task.\n"
+        "your answer. Inline is capped (about 30 steps / 4 minutes of browsing). If it returns "
+        "status 'partial' and browsing WAS the user's primary ask, do NOT stop there: in the SAME "
+        "turn call register_background_task with a task_prompt that CONTINUES the browse via "
+        "computer_use_browse from where it left off (background runs get a much larger step "
+        "budget), present what was already found, and tell the user the deeper browse continues "
+        "in the background. If the browse was a pre-browse feeding a delegation, pass the partial "
+        "findings on per the PRE-BROWSE rule instead.\n"
         "- LONG or multi-page jobs (deep audits, many pages, monitoring): use register_background_task "
         "with a task_prompt that instructs the background agent to use computer_use_browse. Its result "
         "includes a live_view_url; surface it the same Markdown-link way.\n"
@@ -1548,7 +1558,10 @@ Decide by CAPABILITY, in this order:
    WATCH - handle it yourself with the browser tools per the COMPUTER USE
    section (inline, or register_background_task for long multi-page jobs).
    The autonomous agent reads pages programmatically and has NO interactive
-   browser, so do NOT delegate pure browser-operation tasks. Delegate only
+   browser, so do NOT delegate pure browser-operation tasks. This rule ALSO
+   fires whenever the request mentions web browsing (in any language) or
+   names a specific external site / page / URL to consult - the live
+   browser run is part of what the user asked to see. Delegate only
    when the browsing merely feeds a bigger job that also needs a file
    deliverable, a Workspace action, or software work - and in that case
    run the browse FIRST yourself and pass the findings via input_data
@@ -1573,7 +1586,8 @@ case call delegate_autonomous_task as your VERY FIRST action with that
 brief, and NEVER re-ask clarifying questions. When no card was shown, the
 brief was judged specific enough: also delegate as your VERY FIRST action
 without asking your own questions. """ + ("""SOLE EXCEPTION - PRE-BROWSE: when
-the brief needs data that only interactive browsing can obtain, the
+the brief mentions web browsing or names a specific site / page / URL to
+consult (or needs data only interactive browsing can obtain), the
 COMPUTER USE browse sequence comes first and delegate_autonomous_task
 immediately after, in the SAME turn; clarifying questions remain
 forbidden either way. """ if os.environ.get("ENABLE_COMPUTER_USE") == "1" else "") + """The tool manages inline-vs-background by
@@ -1602,11 +1616,13 @@ When delegating:
   files uploaded to this chat. Extract their contents yourself first (your
   vision / file parsing) and pass the structured findings as text via
   input_data.
-""" + ("""- PRE-BROWSE: when the task ALSO depends on data that only interactive
-  browsing can obtain (a specific portal, a competitor page, a form-gated
-  site), gather it BEFORE delegating using the COMPUTER USE section's exact
-  sequence (start_browser_session -> show the live-view link -> a single
-  computer_use_browse with a NARROW goal that fits the inline step cap).
+""" + ("""- PRE-BROWSE: when the task mentions web browsing, names a specific
+  external site / page / portal / URL to consult, or depends on data that
+  only interactive browsing can obtain, gather that part BEFORE delegating
+  using the COMPUTER USE section's exact sequence (start_browser_session ->
+  show the live-view link -> a single computer_use_browse with a NARROW
+  goal that fits the inline step cap). This is MANDATORY when a site is
+  named - the live browse is a showcase moment, not an optimization choice.
   Then put the result_summary into input_data under the label
   "BROWSER FINDINGS (gathered live from <url>):" so the autonomous agent
   builds on real, fresh web data. If the browse returns status 'partial',

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -1087,6 +1087,25 @@ def _inject_completed_tasks(callback_context):
     if not _fs or not _demo_id:
         callback_context.state["_bg_task_results"] = ""
         return None
+    # Orphan recovery sweep (v11.32), BEFORE the completed-tasks query so a
+    # task recovered here is announced in this same turn. Autonomous tasks
+    # are monitored by in-process daemon threads; a Cloud Run instance
+    # recycle kills them and freezes the doc at status 'working' (observed
+    # live 2026-07-22: SIGTERM 16 min into a task, doc stuck at 90% while
+    # the sandbox finished server-side 30 min later). The sweep only touches
+    # docs whose monitor heartbeat is stale - see _ma_recover_orphaned_task.
+    try:
+        _wdocs = _fs.collection(_demo_id + "_task_executions").where(
+            "status", "==", "working").limit(5).stream()
+        for _wdoc in _wdocs:
+            _wd = _wdoc.to_dict()
+            if _wd.get("interaction_id"):
+                try:
+                    tools._ma_recover_orphaned_task(_wdoc.reference, _wd, False)
+                except Exception:
+                    pass
+    except Exception:
+        pass
     try:
         _docs = _fs.collection(_demo_id + "_task_executions").where(
             "reported_to_user", "==", False
@@ -1123,11 +1142,30 @@ def _inject_completed_tasks(callback_context):
                     _rd = _rdoc.to_dict()
                     _tail_lines = [_l for _l in (_rd.get("log_tail", "") or "").split(chr(10)) if _l.strip()]
                     _last_line = _tail_lines[-1][-140:] if _tail_lines else ""
-                    _rlines.append("Task '" + _rd.get("task_id", "") + "' still running: "
+                    # Honest progress (v11.32): lead with elapsed time + monitor
+                    # liveness; the percentage is an activity estimate capped at
+                    # 90 and must not be read as a completion fraction.
+                    _age_bits = []
+                    try:
+                        import datetime as _dt
+                        _now = _dt.datetime.now(_dt.timezone.utc)
+                        _rstarted = tools._ma_parse_iso_utc(_rd.get("started_at"))
+                        if _rstarted is not None:
+                            _age_bits.append(str(int((_now - _rstarted).total_seconds() / 60)) + " min elapsed")
+                        _rbeat = tools._ma_parse_iso_utc(_rd.get("updated_at"))
+                        if _rbeat is not None:
+                            _age_bits.append("last activity " + str(int((_now - _rbeat).total_seconds() / 60)) + " min ago")
+                    except Exception:
+                        pass
+                    _age_txt = (" (" + ", ".join(_age_bits) + ")") if _age_bits else ""
+                    _rlines.append("Task '" + _rd.get("task_id", "") + "' still running" + _age_txt + ": "
                                    + str(_rd.get("progress_pct", 0)) + "% - " + _last_line)
                 if _rlines:
                     _prev = callback_context.state.get("_bg_task_results", "") or ""
-                    _rmsg = "--- TASKS STILL RUNNING (progress info, NOT completed) ---" + chr(10) + chr(10).join(_rlines) + chr(10) + "--- END RUNNING ---"
+                    _rmsg = ("--- TASKS STILL RUNNING (progress info, NOT completed; the percentage is an "
+                             "activity estimate CAPPED at 90, not a completion fraction - when mentioning "
+                             "progress, lead with elapsed time / latest activity and never say 'almost done' "
+                             "from the number) ---" + chr(10) + chr(10).join(_rlines) + chr(10) + "--- END RUNNING ---")
                     callback_context.state["_bg_task_results"] = (_prev + chr(10) + _rmsg).strip()
             except Exception:
                 pass

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -1067,6 +1067,9 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
     # window, so the F1 hang pattern does not apply.
     _all_tools.append(tools.delegate_autonomous_task)
     _all_tools.append(tools.get_autonomous_task_status)
+    # Recurring autonomous schedules (v11.33): Cloud Scheduler fires
+    # /execute_task, which delegates to the sandbox headlessly.
+    _all_tools.append(tools.register_scheduled_autonomous_task)
 if (os.environ.get("ENABLE_MANAGED_AGENT") == "1" and (os.environ.get("ENABLE_WORKSPACE_MCP") == "1" or os.environ.get("ENABLE_WORKSPACE_AUTH") == "1")):
     # Drive handoff needs BOTH the user's Workspace OAuth (drive.file) and the
     # Managed Agent deliverables in GCS.
@@ -1633,12 +1636,15 @@ When delegating:
   not enabled in this demo.""") + """
 - SPLIT COMPOSITE REQUESTS: the autonomous agent CANNOT create scheduled /
   recurring jobs, dashboards hosted by this platform, or database alert
-  rules - those live in YOUR toolset. When a request combines autonomous
-  work (research / file deliverables / Workspace actions) with a recurring
-  monitoring job or schedule, delegate ONLY the autonomous part and, in
-  the SAME turn, set up the recurring part yourself with
-  register_scheduled_task (and tell the user you did both). Never put
-  "set up a daily job" wording into task_description.
+  rules - those live in YOUR toolset. When the user wants autonomous work
+  (research / file deliverables / Workspace actions) to run on a RECURRING
+  schedule, register it with register_scheduled_autonomous_task - each fire
+  then delegates to the sandbox automatically, even while the user is
+  offline, and results are announced on their next message. When a request
+  combines a ONE-SHOT autonomous task with a recurring demo-database
+  monitoring job, delegate the autonomous part and set up the database job
+  with register_scheduled_task in the SAME turn (and tell the user you did
+  both). Never put "set up a daily job" wording into task_description.
 - Call delegate_autonomous_task EXACTLY ONCE per user request.
 - Status 'completed': present the report verbatim as markdown (it is already
   in the user's language) including any deliverable download links.
@@ -2091,7 +2097,14 @@ SCHEDULED TASKS:
 - register_scheduled_task: Register a recurring task with cron schedule.
 - update_scheduled_task: Change the cron schedule of an existing task.
 - delete_scheduled_task: Remove a scheduled task and its Cloud Scheduler job.
-- run_scheduled_task_now: Trigger ONE immediate background execution of an
+""" + ("""- register_scheduled_autonomous_task: Register a RECURRING schedule for
+  AUTONOMOUS sandbox work (web research, file deliverables, Workspace
+  actions). Fires even while the user is offline; each fire creates an
+  autonomous ticket whose progress and completion are announced
+  automatically on the user's next message. Use for "every day / week, do
+  X" requests that need the autonomous agent - NOT register_scheduled_task
+  (that one runs the demo-database background worker).
+""" if os.environ.get("ENABLE_MANAGED_AGENT") == "1" else "") + """- run_scheduled_task_now: Trigger ONE immediate background execution of an
   already-registered scheduled task (manual test run). Returns a ticket
   instantly; the result is reported automatically when done (or via
   get_task_result).
@@ -2456,6 +2469,11 @@ SCHEDULED TASKS:
   The task runs via Cloud Scheduler at the specified intervals.
 - update_scheduled_task: Change the cron schedule of an existing scheduled task.
 - delete_scheduled_task: Remove a scheduled task and its Cloud Scheduler job.
+""" + ("""- register_scheduled_autonomous_task: Register a RECURRING schedule for
+  AUTONOMOUS sandbox work (web research, file deliverables, Workspace
+  actions). Fires even while the user is offline; results are announced
+  automatically on the user's next message.
+""" if os.environ.get("ENABLE_MANAGED_AGENT") == "1" else "") + """
 - run_scheduled_task_now: Trigger ONE immediate background execution of an
   already-registered scheduled task (manual test run). Returns a ticket
   instantly; the result is reported automatically when done (or via
@@ -2738,6 +2756,8 @@ WRONG: beginRendering object without tags (missing tags and brackets = SYSTEM CR
 _bg_tools = [t for t in _all_tools if t is not tools.background_task_tool]
 _bg_tools = [t for t in _bg_tools if t is not tools.register_scheduled_task]
 _bg_tools = [t for t in _bg_tools if t is not tools.run_scheduled_task_now]
+if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
+    _bg_tools = [t for t in _bg_tools if t is not tools.register_scheduled_autonomous_task]
 
 _bg_computer_use_section = r"""
 --- COMPUTER USE (BROWSER AGENT) ---

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
@@ -1050,9 +1050,10 @@ logger = logging_client.logger(__name__)
 # Pre-browse delegation-note fragment (used inside the Managed-Agent-guarded
 # briefing-press handler; empty when Computer Use is off).
 _MA_PREBROWSE_EXCEPTION = (
-    'EXCEPTION - PRE-BROWSE: if the brief needs data that only interactive browsing '
-    'can obtain, run the COMPUTER USE browse sequence first and delegate immediately '
-    'after, in this same turn. '
+    'EXCEPTION - PRE-BROWSE: if the brief mentions web browsing or names a '
+    'specific site / page / URL to consult (or needs data only interactive '
+    'browsing can obtain), run the COMPUTER USE browse sequence first and '
+    'delegate immediately after, in this same turn. '
 ) if os.environ.get("ENABLE_COMPUTER_USE") == "1" else ""
 
 # Pre-browse planner override fragment: only meaningful when BOTH the Managed

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
@@ -4781,6 +4781,40 @@ async def execute_task(request: Request):
                 _wlogger.warning("execute_task: task %s already %s, skipping re-execution", _task_id, _current.get("status"))
                 return {"status": _current.get("status"), "task_id": _task_id}
 
+            # Scheduled AUTONOMOUS fire (v11.33): delegate to the sandbox
+            # agent instead of running the background worker. Each fire
+            # creates its own per-run autonomous ticket; the SCHEDULE's
+            # execution doc only records fire metadata and stays status
+            # 'scheduled', so cancelling it stops future fires via the
+            # cancelled guard above.
+            if os.environ.get("ENABLE_MANAGED_AGENT") == "1" and _def_data.get("task_type") == "scheduled_autonomous":
+                _fire_res = {}
+                try:
+                    _fire_res = _agent_tools._ma_fire_scheduled_autonomous(_def_data, _msg_id)
+                except Exception as _fire_err:
+                    _fire_res = {"status": "error", "message": str(_fire_err)[:200]}
+                _wlogger.warning("execute_task: scheduled_autonomous %s fire -> %s (ticket=%s)",
+                                 _task_id, str(_fire_res.get("status", "")), str(_fire_res.get("ticket-id", "")))
+                try:
+                    _fire_now = _dt.datetime.now(_dt.timezone.utc)
+                    _fire_line = ("[" + _fire_now.strftime("%H:%M:%S") + "] SCHEDULER: fire -> "
+                                  + str(_fire_res.get("status", "")) + " ticket "
+                                  + str(_fire_res.get("ticket-id", "") or "-") + chr(10))
+                    _sched_update = {
+                        "status": "scheduled",
+                        "last_fired_at": _fire_now.isoformat(),
+                        "log_tail": (((_current or {}).get("log_tail", "") or "") + _fire_line)[-1500:],
+                    }
+                    if _msg_id:
+                        _sched_update["last_sched_msg_id"] = _msg_id
+                    _exec_ref.set(_sched_update, merge=True)
+                except Exception:
+                    pass
+                return {"status": str(_fire_res.get("status", "error")), "task_id": _task_id,
+                        "ticket": str(_fire_res.get("ticket-id", ""))}
+
+
+
             # Update status to working — use set(merge=True) so it works for
             # both pre-existing docs (immediate tasks) and new docs (scheduled tasks)
             _now = _dt.datetime.now(_dt.timezone.utc).isoformat()

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -2564,6 +2564,13 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
     # task_executions doc + _inject_completed_tasks announcement) while a daemon
     # thread keeps consuming the SSE stream. Cloud Run runs with min-instances=1
     # and no CPU throttling, so the thread survives after the turn returns.
+    # CAVEAT (v11.32, observed live 2026-07-22): min-instances keeps AN instance
+    # warm but Cloud Run still RECYCLES instances at will (SIGTERM mid-task); the
+    # daemon threads die with the process and the task doc freezes at 'working'.
+    # Monitoring is therefore best-effort push + guaranteed pull: every status
+    # check and every turn's _inject_completed_tasks sweep can finalize an
+    # orphaned doc directly from the persisted interaction (see
+    # _ma_recover_orphaned_task).
     # =============================================================================
     _MANAGED_AGENT_ID = os.environ.get("MANAGED_AGENT_ID", "").strip()
     _MANAGED_AGENT_LOCATION = "global"  # the Managed Agents API is global-only
@@ -2577,6 +2584,10 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
     # After the SSE stream window closes, the interaction keeps running
     # server-side (background=true); we keep polling GET for this much longer.
     _MA_POLL_EXTRA_S = int(os.environ.get("MANAGED_AGENT_POLL_EXTRA_S", "3600"))
+    # Monitor heartbeat staleness (v11.32): the monitor thread rewrites the task
+    # doc every ~12s; this much silence means the monitor process is dead and
+    # pull-based recovery may finalize the doc from the live interaction.
+    _MA_MONITOR_STALE_S = int(os.environ.get("MANAGED_AGENT_MONITOR_STALE_S", "180"))
 
     _ma_creds = None
 
@@ -2968,6 +2979,47 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
         if _evt is not None:
             _evt.set()
 
+    def _ma_harvest_interaction_report(data):
+        """Rebuilds the report text from a persisted interaction GET body.
+
+        Collects text from ALL non-input steps (not just type model_output -
+        long agentic runs have surfaced text under other step shapes).
+        user_input steps are EXCLUDED: they contain the task message (and
+        possibly the Workspace token). Returns '' when the steps carry no text
+        at all - observed live 2026-07-22 on a completed 52-step run whose GET
+        body held only function_call/function_result steps - so callers MUST
+        handle an empty harvest with a fallback report."""
+        _texts = []
+        def _collect_step_texts(node):
+            if isinstance(node, dict):
+                for _k, _v in node.items():
+                    if _k == "text" and isinstance(_v, str) and _v.strip():
+                        _texts.append(_v)
+                    else:
+                        _collect_step_texts(_v)
+            elif isinstance(node, list):
+                for _item in node:
+                    _collect_step_texts(_item)
+        for _step in (data.get("steps") or []):
+            if isinstance(_step, dict) and _step.get("type") != "user_input":
+                _collect_step_texts(_step)
+        return (chr(10) + chr(10)).join(_texts)
+
+    def _ma_log_empty_harvest_shape(data):
+        """Diagnostic for an empty harvest: log the step STRUCTURE only (never
+        content - it could include the task message / token)."""
+        try:
+            import logging as _l
+            _shape = []
+            for _step in (data.get("steps") or []):
+                if isinstance(_step, dict):
+                    _ctypes = [(_c.get("type", "?") if isinstance(_c, dict) else "?") for _c in (_step.get("content") or [])]
+                    _shape.append(str(_step.get("type", "?")) + ":" + ",".join(_ctypes))
+            _l.getLogger("managed_agent").warning(
+                "poll harvest found NO text; interaction step shapes: %s", "; ".join(_shape)[:800])
+        except Exception:
+            pass
+
     def _ma_poll_interaction(shared):
         """Polls GET .../interactions/<id> after the SSE stream is gone.
 
@@ -3016,41 +3068,11 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
                     shared["environment_id"] = _data["environment_id"]
                 _status = _data.get("status", "")
                 if _status == "completed":
-                    # Harvest report text from ALL non-input steps (not just
-                    # type model_output - long agentic runs have surfaced text
-                    # under other step shapes). user_input steps are EXCLUDED:
-                    # they contain the task message (and possibly the Workspace
-                    # token).
-                    _texts = []
-                    def _collect_step_texts(node):
-                        if isinstance(node, dict):
-                            for _k, _v in node.items():
-                                if _k == "text" and isinstance(_v, str) and _v.strip():
-                                    _texts.append(_v)
-                                else:
-                                    _collect_step_texts(_v)
-                        elif isinstance(node, list):
-                            for _item in node:
-                                _collect_step_texts(_item)
-                    for _step in (_data.get("steps") or []):
-                        if isinstance(_step, dict) and _step.get("type") != "user_input":
-                            _collect_step_texts(_step)
-                    if _texts:
-                        shared["report_buf"] = (chr(10) + chr(10)).join(_texts)
+                    _harvested = _ma_harvest_interaction_report(_data)
+                    if _harvested:
+                        shared["report_buf"] = _harvested
                     else:
-                        # Diagnostic: log the STRUCTURE only (never content - it
-                        # could include the task message / token).
-                        try:
-                            import logging as _l
-                            _shape = []
-                            for _step in (_data.get("steps") or []):
-                                if isinstance(_step, dict):
-                                    _ctypes = [(_c.get("type", "?") if isinstance(_c, dict) else "?") for _c in (_step.get("content") or [])]
-                                    _shape.append(str(_step.get("type", "?")) + ":" + ",".join(_ctypes))
-                            _l.getLogger("managed_agent").warning(
-                                "poll harvest found NO text; interaction step shapes: %s", "; ".join(_shape)[:800])
-                        except Exception:
-                            pass
+                        _ma_log_empty_harvest_shape(_data)
                     shared["completed"] = True
                     return
                 if _status in ("failed", "cancelled"):
@@ -3078,6 +3100,7 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
             return
         _ref = _fs.collection(_demo_id + "_task_executions").document(task_id)
         _log = ""
+        _mon_start = _t.monotonic()
         while not shared.get("done"):
             _t.sleep(12)
             try:
@@ -3090,10 +3113,23 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
                 _log = _log + "[" + _now + "] SANDBOX: " + _snippet + chr(10)
                 if len(_log) > 1500:
                     _log = _log[-1500:]
-                _pct = max(10, min(90, 10 + int(shared.get("events", 0) / 3)))
-                # interaction_id is mirrored for diagnosability: it lets operators
-                # inspect the live interaction via GET .../interactions/<id>.
-                _ref.update({"progress_pct": _pct, "log_tail": _log, "interaction_id": shared.get("interaction_id", "")})
+                # Honest-ish progress (v11.32): the old events/3 estimate hit the
+                # 90 cap ~12 min into chatty runs, reading as "stuck at 90%".
+                # Blend in a wall-clock ramp (2 pct/min -> reaches the cap only
+                # after ~40 min, the typical long-task duration) and take the
+                # LOWER of the two so neither signal alone can saturate early.
+                # 90 stays a hard cap: 100 is reserved for actual completion.
+                _event_pct = 10 + int(shared.get("events", 0) / 3)
+                _time_pct = 10 + int((_t.monotonic() - _mon_start) / 30)
+                _pct = max(10, min(90, _event_pct, _time_pct))
+                # interaction_id is mirrored for diagnosability AND recovery: it
+                # lets operators inspect the live interaction and lets
+                # _ma_recover_orphaned_task finalize the doc if this monitor
+                # process dies (instance recycle). updated_at is the heartbeat
+                # that recovery uses to tell a live monitor from a dead one.
+                _ref.update({"progress_pct": _pct, "log_tail": _log,
+                             "interaction_id": shared.get("interaction_id", ""),
+                             "updated_at": _dt.datetime.now(_dt.timezone.utc).isoformat()})
             except Exception:
                 pass
         try:
@@ -3125,6 +3161,150 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
             _ma_finalize_interaction_record(shared)
         except Exception:
             pass
+
+    def _ma_parse_iso_utc(value):
+        import datetime as _dt
+        try:
+            _parsed = _dt.datetime.fromisoformat(str(value))
+            if _parsed.tzinfo is None:
+                _parsed = _parsed.replace(tzinfo=_dt.timezone.utc)
+            return _parsed
+        except Exception:
+            return None
+
+    def _ma_recover_orphaned_task(ref, doc, mark_reported):
+        """Pull-based recovery (v11.32) for an autonomous task whose in-process
+        monitor died. Cloud Run recycles instances at will (observed live
+        2026-07-22: SIGTERM 16 min into a task); the daemon threads that stream
+        the interaction and finalize the Firestore doc die with the process,
+        freezing the doc at status 'working' / 90% forever while the sandbox
+        interaction finishes server-side unobserved. This reads the live
+        interaction via the interaction_id the monitor mirrored into the doc and
+        finalizes the doc from it.
+
+        mark_reported=True is for get_autonomous_task_status (the recovered
+        report is presented in the same turn); the _inject_completed_tasks sweep
+        passes False so the normal completed-task injection announces it.
+
+        Returns the updated doc dict when the doc was finalized, else None."""
+        import datetime as _dt
+        import httpx
+        if doc.get("status") != "working":
+            return None
+        _iid = doc.get("interaction_id", "")
+        if not _iid:
+            return None
+        # Heartbeat gate: a live monitor rewrites the doc every ~12s (updated_at,
+        # v11.32). Docs from older builds lack updated_at: for those, only recover
+        # after the full monitoring window has passed, so a healthy monitor is
+        # never raced.
+        _now = _dt.datetime.now(_dt.timezone.utc)
+        _beat = _ma_parse_iso_utc(doc.get("updated_at"))
+        if _beat is not None:
+            if (_now - _beat).total_seconds() < _MA_MONITOR_STALE_S:
+                return None
+        else:
+            _started = _ma_parse_iso_utc(doc.get("started_at"))
+            if _started is None or (_now - _started).total_seconds() < (_MA_MAX_RUNTIME_S + _MA_POLL_EXTRA_S):
+                return None
+        try:
+            _headers = {
+                "Authorization": "Bearer " + _ma_get_access_token(),
+                "Api-Revision": _INTERACTIONS_API_REVISION,
+            }
+            _resp = httpx.get(_ma_interactions_url() + "/" + _iid, headers=_headers, timeout=30.0)
+            _code = _resp.status_code
+            _data = _resp.json() if _code == 200 else {}
+        except Exception:
+            return None  # transient lookup failure - the next turn retries
+        _now_iso = _now.isoformat()
+        _deliver_tid = doc.get("deliver_tid") or doc.get("task_id", "")
+        _status = _data.get("status", "")
+        if _code == 200 and _status == "completed":
+            _report = _ma_harvest_interaction_report(_data).strip()
+            if not _report:
+                _ma_log_empty_harvest_shape(_data)
+                _report = ("The autonomous agent finished this task server-side, but its monitor was "
+                           "interrupted by a server restart and the original text report could not be "
+                           "recovered from the persisted steps. Any uploaded deliverable files are "
+                           "linked below; the step-by-step activity log is in the Data Viewer Tasks tab.")
+            _links = _ma_collect_deliverables(_deliver_tid)
+            if _links:
+                _report = _report + chr(10) + chr(10) + _MA_DL_MARKER + chr(10) + chr(10).join(_links)
+            else:
+                _report = _report + chr(10) + chr(10) + _MA_NO_UPLOAD_NOTE
+            _update = {
+                "status": "completed",
+                "result_summary": _report,
+                "progress_pct": 100,
+                "completed_at": _now_iso,
+            }
+        elif _code == 200 and _status in ("failed", "cancelled"):
+            _update = {
+                "status": "failed",
+                "result_summary": "Autonomous task ended server-side with status: " + _status
+                                  + " (recovered after its monitor was lost to a server restart).",
+                "completed_at": _now_iso,
+            }
+        elif _code == 404:
+            # Monitor dead AND interaction record gone (expired or already
+            # deleted): nothing is left to wait on. Uploaded deliverables may
+            # still prove the task finished.
+            _links = _ma_collect_deliverables(_deliver_tid)
+            if _links:
+                _report = ("The autonomous task finished, but its monitor was interrupted by a server "
+                           "restart and the sandbox interaction record is no longer available. The "
+                           "uploaded deliverable files are linked below."
+                           + chr(10) + chr(10) + _MA_DL_MARKER + chr(10) + chr(10).join(_links))
+                _update = {
+                    "status": "completed",
+                    "result_summary": _report,
+                    "progress_pct": 100,
+                    "completed_at": _now_iso,
+                }
+            else:
+                _update = {
+                    "status": "failed",
+                    "result_summary": "Autonomous task orphaned: its monitor died (server restart) and the "
+                                      "sandbox interaction record is no longer available. Re-delegate the "
+                                      "task if the result is still needed.",
+                    "completed_at": _now_iso,
+                }
+        else:
+            # Interaction genuinely still running server-side, just unobserved.
+            # Refresh the heartbeat + log so (a) users see live truth instead of
+            # a frozen log, and (b) the next recovery attempt waits a full
+            # staleness window instead of re-polling every turn.
+            try:
+                _tail = ((doc.get("log_tail", "") or "")
+                         + "[" + _now.strftime("%H:%M:%S") + "] RECOVERY: monitor lost (server restart); "
+                         "interaction still running server-side - tracked via direct polling." + chr(10))
+                ref.update({"updated_at": _now_iso, "log_tail": _tail[-1500:]})
+            except Exception:
+                pass
+            return None
+        _update["updated_at"] = _now_iso
+        if mark_reported:
+            _update["reported_to_user"] = True
+        try:
+            ref.update(_update)
+        except Exception:
+            return None
+        if _update.get("status") == "completed" and _code == 200:
+            # Same post-completion hygiene as the monitor path: persists sandbox
+            # continuity and deletes token-bearing interaction records.
+            try:
+                _ma_finalize_interaction_record({
+                    "interaction_id": _iid,
+                    "environment_id": _data.get("environment_id", ""),
+                    "token_embedded": bool(doc.get("token_embedded")),
+                    "task_id": doc.get("task_id", ""),
+                })
+            except Exception:
+                pass
+        _merged = dict(doc)
+        _merged.update(_update)
+        return _merged
 
     def _ma_build_task_message(task_description, input_data, upload_urls):
         _msg = task_description.strip()
@@ -3276,6 +3456,7 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
                             + "WORKSPACE ACCESS (handle with care):" + chr(10)
                             + "- Before any Google Workspace operation, run: export GOOGLE_WORKSPACE_CLI_TOKEN=" + _ws_auth[7:] + chr(10)
                             + "- This user access token expires in about an hour: do Workspace operations EARLY in the task." + chr(10)
+                            + "- ADMIN LIMITS: this token carries USER-level scopes only. Admin SDK APIs (Directory, Reports / audit logs, license management) and org-wide admin exports WILL fail with 401/403 - that is expected, not an error to fix. Do NOT retry, poll, or grind on them: derive what you can from user-level APIs (Drive / Gmail / Calendar data this user can see), state the limitation clearly in your report, and continue with the rest of the task." + chr(10)
                             + "- Use the gws CLI for ALL Workspace reads/writes (see the gws-* skills under /.agent/skills). It is usually pre-installed at $HOME/bin/gws - call it by that absolute path. If missing: mkdir -p $HOME/bin && curl -sL https://github.com/googleworkspace/cli/releases/latest/download/google-workspace-cli-x86_64-unknown-linux-musl.tar.gz | tar xz -C $HOME/bin ./gws && chmod +x $HOME/bin/gws (do NOT use npm - its Linux binary needs GLIBC 2.39 which this sandbox lacks)." + chr(10)
                             + "- GUARDRAILS: NEVER send email - create Gmail drafts only, unless the task explicitly says to send. NEVER delete anything in Workspace. Post Chat messages ONLY to spaces the task explicitly names - and if the named space does not exist yet, CREATE it with that exact name first, then post (expected in demo environments; mention the creation in your report). Create Calendar events only when the task asks for them." + chr(10)
                             + "- Non-ASCII email headers (Subject etc.) MUST be RFC 2047 MIME-encoded; read the draft back to verify the subject is not garbled, and recreate it if needed." + chr(10)
@@ -3318,6 +3499,12 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
                     "started_at": _now_iso,
                     "completed_at": "",
                     "reported_to_user": False,
+                    # Persisted for _ma_recover_orphaned_task (v11.32): recovery
+                    # runs in a fresh process where the in-memory shared dict of
+                    # the original delegation no longer exists.
+                    "updated_at": _now_iso,
+                    "deliver_tid": _deliver_tid,
+                    "token_embedded": _ws_token_embedded,
                 })
                 _docs_created = True
             except Exception:
@@ -3455,12 +3642,41 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
             if not _snap.exists:
                 return {"status": "not_found", "message": "No autonomous task with ticket-id " + task_id}
             _d = _snap.to_dict()
+            if _d.get("status") == "working":
+                # Self-heal (v11.32): if the in-process monitor died (Cloud Run
+                # instance recycle), finalize directly from the persisted
+                # interaction instead of reporting a frozen 'working' doc forever.
+                # mark_reported=True: the recovered report is presented right now.
+                try:
+                    _recovered = _ma_recover_orphaned_task(_snap.reference, _d, True)
+                    if _recovered:
+                        _d = _recovered
+                except Exception:
+                    pass  # status reporting must never fail on recovery
             _out = {
                 "status": _d.get("status", ""),
                 "progress_pct": _d.get("progress_pct", 0),
                 "recent_activity": _d.get("log_tail", ""),
                 "interaction_id": _d.get("interaction_id", ""),
             }
+            if _d.get("status") == "working":
+                # Honest progress (v11.32): progress_pct is an activity heartbeat
+                # CAPPED at 90 by design, so users read long tasks as "stuck at
+                # 90%". Give the model real signals to phrase progress with.
+                import datetime as _dt
+                _now = _dt.datetime.now(_dt.timezone.utc)
+                _started_at = _ma_parse_iso_utc(_d.get("started_at"))
+                if _started_at is not None:
+                    _out["elapsed_minutes"] = int((_now - _started_at).total_seconds() / 60)
+                _beat = _ma_parse_iso_utc(_d.get("updated_at"))
+                if _beat is not None:
+                    _out["last_activity_minutes_ago"] = int((_now - _beat).total_seconds() / 60)
+                _out["progress_note"] = (
+                    "progress_pct is a rough activity-based estimate CAPPED at 90 - it is NOT a "
+                    "completion fraction, and long tasks legitimately sit at 90 until they finish. "
+                    "When telling the user about progress, lead with elapsed_minutes and the latest "
+                    "concrete activity from recent_activity; never phrase the percentage as "
+                    "'almost done'.")
             if _d.get("status") in ("completed", "failed"):
                 _out["report"] = _d.get("result_summary", "")
                 _out["_MANDATORY_ACTION"] = ("Present the report as formatted markdown text, verbatim, "

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -1199,7 +1199,15 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
     # =====================================================================
     _CU_VIEWPORT_W = 1440
     _CU_VIEWPORT_H = 900
-    _CU_MAX_STEPS = 40
+    # Step/wall budgets (v11.37): env-tunable per demo via
+    # 'gcloud run services update --update-env-vars' so a demo needing deeper
+    # browsing does not require a code redeploy. Inline runs must finish inside
+    # GE's chat render window; background runs are bounded by the /execute_task
+    # request (Cloud Run --timeout 1800).
+    _CU_MAX_STEPS = int(os.environ.get("COMPUTER_USE_MAX_STEPS", "80"))
+    _CU_WALL_S = int(os.environ.get("COMPUTER_USE_WALL_S", "1200"))
+    _CU_INLINE_MAX_STEPS = int(os.environ.get("COMPUTER_USE_INLINE_MAX_STEPS", "30"))
+    _CU_INLINE_WALL_S = int(os.environ.get("COMPUTER_USE_INLINE_WALL_S", "240"))
     _CU_KEEP_SHOTS = 3
     _CU_STEP_TIMEOUT_MS = 15000
     _CU_MAX_CHAT_SHOTS = 6
@@ -1524,8 +1532,8 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
         # Inline calls must finish inside GE's chat render window, so cap steps and
         # wall-clock tightly; background calls (via a task) can run much longer.
         import time as _time
-        _max_steps = 20 if _is_inline else _CU_MAX_STEPS
-        _wall_budget = 240.0 if _is_inline else 600.0
+        _max_steps = _CU_INLINE_MAX_STEPS if _is_inline else _CU_MAX_STEPS
+        _wall_budget = float(_CU_INLINE_WALL_S) if _is_inline else float(_CU_WALL_S)
         _deadline = _time.monotonic() + _wall_budget
 
         _shots_for_chat = []
@@ -1553,6 +1561,18 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
             _start = start_url or "https://duckduckgo.com/"
             if "://" not in _start:
                 _start = "https://" + _start
+            # Google search hard-blocks headless Chrome with a CAPTCHA wall, burning
+            # steps before the run even starts (v11.37). Rewrite any google search
+            # start_url to the automation-friendly DuckDuckGo html results page
+            # carrying the same query.
+            try:
+                from urllib.parse import urlparse as _cu_up, parse_qs as _cu_pq, quote_plus as _cu_qp
+                _pu = _cu_up(_start)
+                if "google." in (_pu.netloc or "").lower():
+                    _gq = (_cu_pq(_pu.query or "").get("q") or [""])[0]
+                    _start = ("https://duckduckgo.com/html/?q=" + _cu_qp(_gq)) if _gq else "https://duckduckgo.com/html/"
+            except Exception:
+                pass
             try:
                 await page.goto(_start, wait_until="load", timeout=_CU_STEP_TIMEOUT_MS)
             except Exception:
@@ -1561,8 +1581,22 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
             _shot = await page.screenshot(type="png")
             _jpg = await page.screenshot(type="jpeg", quality=60)
             await _cu_publish(session_id, 0, "Opened " + _start, page.url, "working", base64.b64encode(_jpg).decode("ascii"))
+            # The browsing policy must travel WITH the goal: the computer-use model
+            # inside this loop never sees the root agent's instruction, so without
+            # this preamble it happily opens google.com and burns the step budget
+            # on the bot wall (observed live 2026-07-24).
+            _policy = (
+                "Browsing policy (follow strictly - every action costs one step from a budget of " + str(_max_steps) + "):" + chr(10)
+                + "- NEVER navigate to google.com: it shows a CAPTCHA wall to automated browsers. To search the web, "
+                "navigate directly to https://duckduckgo.com/html/?q=<url-encoded terms>." + chr(10)
+                + "- If a page shows a CAPTCHA / bot check / 'unusual traffic' message, do not fight it: switch ONCE to "
+                "duckduckgo html results or another authoritative source and continue." + chr(10)
+                + "- Prefer navigating straight to the most authoritative page for the goal over searching." + chr(10)
+                + "- Be economical: no re-visits, no exploratory clicks. Once the goal is met - or the budget is nearly "
+                "spent - stop and summarize what you have."
+            )
             history = [types.Content(role="user", parts=[
-                types.Part.from_text(text="Goal: " + (goal or "") + chr(10) + "Complete this task in the browser. When finished, summarize what you found or did."),
+                types.Part.from_text(text="Goal: " + (goal or "") + chr(10) + _policy + chr(10) + "Complete this task in the browser. When finished, summarize what you found or did."),
                 types.Part.from_bytes(data=_shot, mime_type="image/png"),
             ])]
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -2553,6 +2553,7 @@ def save_document_to_db(
 
 # --- Managed Agent (Antigravity) autonomous delegation (ENABLE_MANAGED_AGENT) ---
 if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
+
     # =============================================================================
     # Managed Autonomous Agent (Antigravity) delegation - v11.0
     # The setup script provisions a managed agent (Agents API, Pre-GA) that runs in
@@ -3306,6 +3307,53 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
         _merged.update(_update)
         return _merged
 
+    if os.environ.get("ENABLE_WORKSPACE_MCP") == "1" or os.environ.get("ENABLE_WORKSPACE_AUTH") == "1":
+        def _ma_refresh_token_object(_tid, _tok):
+            # Rotating token object: the sandbox re-fetches the CURRENT user
+            # token from a pre-signed URL when its snapshot expires. Kept fresh
+            # by fast_api_app on every user turn (best-effort).
+            _bkt = os.environ.get("DASHBOARDS_BUCKET", "").strip()
+            if not _bkt or not _tok:
+                return
+            try:
+                from google.cloud import storage as _st
+                _st.Client().bucket(_bkt).blob("autonomous/" + _tid + "/.wstoken").upload_from_string(_tok, content_type="text/plain")
+            except Exception:
+                pass
+
+    def _ma_append_workspace_access(message, task_id, ws_auth):
+        if os.environ.get("ENABLE_WORKSPACE_MCP") == "1" or os.environ.get("ENABLE_WORKSPACE_AUTH") == "1":
+            """Appends the WORKSPACE ACCESS section (user token + guardrails + rotating
+            token refresh URL) to a task message. Shared by the live delegation tool
+            and the scheduled-autonomous fire path (v11.33). Returns
+            (message, token_embedded)."""
+            if not str(ws_auth or "").startswith("Bearer "):
+                return message, False
+            message = (message + chr(10) + chr(10)
+                       + "WORKSPACE ACCESS (handle with care):" + chr(10)
+                       + "- Before any Google Workspace operation, run: export GOOGLE_WORKSPACE_CLI_TOKEN=" + ws_auth[7:] + chr(10)
+                       + "- This user access token expires in about an hour: do Workspace operations EARLY in the task." + chr(10)
+                       + "- ADMIN LIMITS: this token carries USER-level scopes only. Admin SDK APIs (Directory, Reports / audit logs, license management) and org-wide admin exports WILL fail with 401/403 - that is expected, not an error to fix. Do NOT retry, poll, or grind on them: derive what you can from user-level APIs (Drive / Gmail / Calendar data this user can see), state the limitation clearly in your report, and continue with the rest of the task." + chr(10)
+                       + "- Use the gws CLI for ALL Workspace reads/writes (see the gws-* skills under /.agent/skills). It is usually pre-installed at $HOME/bin/gws - call it by that absolute path. If missing: mkdir -p $HOME/bin && curl -sL https://github.com/googleworkspace/cli/releases/latest/download/google-workspace-cli-x86_64-unknown-linux-musl.tar.gz | tar xz -C $HOME/bin ./gws && chmod +x $HOME/bin/gws (do NOT use npm - its Linux binary needs GLIBC 2.39 which this sandbox lacks)." + chr(10)
+                       + "- GUARDRAILS: NEVER send email - create Gmail drafts only, unless the task explicitly says to send. NEVER delete anything in Workspace. Post Chat messages ONLY to spaces the task explicitly names - and if the named space does not exist yet, CREATE it with that exact name first, then post (expected in demo environments; mention the creation in your report). Create Calendar events only when the task asks for them." + chr(10)
+                       + "- Non-ASCII email headers (Subject etc.) MUST be RFC 2047 MIME-encoded; read the draft back to verify the subject is not garbled, and recreate it if needed." + chr(10)
+                       + "- Report created drafts as ALREADY EXISTING in Gmail (subject + link https://mail.google.com/mail/u/0/#drafts), never as text to copy manually." + chr(10)
+                       + "- NEVER write this token into your report, logs, code, or any file.")
+            _ma_refresh_token_object(task_id, ws_auth[7:])
+            try:
+                _ws_refresh_url = _generate_v4_signed_url(
+                    os.environ.get("DASHBOARDS_BUCKET", "").strip(),
+                    "autonomous/" + task_id + "/.wstoken", "text/plain", 7)
+                message = (message + chr(10)
+                           + "- TOKEN REFRESH: if a Workspace call fails with 401 / invalid credentials, fetch the CURRENT token with: curl -s " + chr(34) + _ws_refresh_url + chr(34)
+                           + " then re-export GOOGLE_WORKSPACE_CLI_TOKEN with the response body and retry. A fresh token appears there whenever the user talks to the assistant; if it is still expired, note that in your report and continue with the non-Workspace parts of the task.")
+            except Exception:
+                pass
+            return message, True
+        else:
+            # Workspace integration disabled for this demo: never embed tokens.
+            return message, False
+
     def _ma_build_task_message(task_description, input_data, upload_urls):
         _msg = task_description.strip()
         if input_data and input_data.strip():
@@ -3434,46 +3482,13 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
         # (it expires in about an hour); token-bearing interactions are DELETED
         # from the store right after their result is harvested.
         _ws_token_embedded = False
+        _ws_auth = ""
         if os.environ.get("ENABLE_WORKSPACE_MCP") == "1" or os.environ.get("ENABLE_WORKSPACE_AUTH") == "1":
-            def _ma_refresh_token_object(_tid, _tok):
-                # Rotating token object: the sandbox re-fetches the CURRENT user
-                # token from a pre-signed URL when its snapshot expires. Kept fresh
-                # by fast_api_app on every user turn (best-effort).
-                _bkt = os.environ.get("DASHBOARDS_BUCKET", "").strip()
-                if not _bkt or not _tok:
-                    return
-                try:
-                    from google.cloud import storage as _st
-                    _st.Client().bucket(_bkt).blob("autonomous/" + _tid + "/.wstoken").upload_from_string(_tok, content_type="text/plain")
-                except Exception:
-                    pass
             try:
                 _ws_auth = (_workspace_header_provider(tool_context) or {}).get("Authorization", "")
             except Exception:
                 _ws_auth = ""
-            if _ws_auth.startswith("Bearer "):
-                _message = (_message + chr(10) + chr(10)
-                            + "WORKSPACE ACCESS (handle with care):" + chr(10)
-                            + "- Before any Google Workspace operation, run: export GOOGLE_WORKSPACE_CLI_TOKEN=" + _ws_auth[7:] + chr(10)
-                            + "- This user access token expires in about an hour: do Workspace operations EARLY in the task." + chr(10)
-                            + "- ADMIN LIMITS: this token carries USER-level scopes only. Admin SDK APIs (Directory, Reports / audit logs, license management) and org-wide admin exports WILL fail with 401/403 - that is expected, not an error to fix. Do NOT retry, poll, or grind on them: derive what you can from user-level APIs (Drive / Gmail / Calendar data this user can see), state the limitation clearly in your report, and continue with the rest of the task." + chr(10)
-                            + "- Use the gws CLI for ALL Workspace reads/writes (see the gws-* skills under /.agent/skills). It is usually pre-installed at $HOME/bin/gws - call it by that absolute path. If missing: mkdir -p $HOME/bin && curl -sL https://github.com/googleworkspace/cli/releases/latest/download/google-workspace-cli-x86_64-unknown-linux-musl.tar.gz | tar xz -C $HOME/bin ./gws && chmod +x $HOME/bin/gws (do NOT use npm - its Linux binary needs GLIBC 2.39 which this sandbox lacks)." + chr(10)
-                            + "- GUARDRAILS: NEVER send email - create Gmail drafts only, unless the task explicitly says to send. NEVER delete anything in Workspace. Post Chat messages ONLY to spaces the task explicitly names - and if the named space does not exist yet, CREATE it with that exact name first, then post (expected in demo environments; mention the creation in your report). Create Calendar events only when the task asks for them." + chr(10)
-                            + "- Non-ASCII email headers (Subject etc.) MUST be RFC 2047 MIME-encoded; read the draft back to verify the subject is not garbled, and recreate it if needed." + chr(10)
-                            + "- Report created drafts as ALREADY EXISTING in Gmail (subject + link https://mail.google.com/mail/u/0/#drafts), never as text to copy manually." + chr(10)
-                            + "- NEVER write this token into your report, logs, code, or any file.")
-                _ws_token_embedded = True
-                _ma_refresh_token_object(_task_id, _ws_auth[7:])
-                try:
-                    _ws_refresh_url = _generate_v4_signed_url(
-                        os.environ.get("DASHBOARDS_BUCKET", "").strip(),
-                        "autonomous/" + _task_id + "/.wstoken", "text/plain", 7)
-                    _message = (_message + chr(10)
-                                + "- TOKEN REFRESH: if a Workspace call fails with 401 / invalid credentials, fetch the CURRENT token with: curl -s " + chr(34) + _ws_refresh_url + chr(34)
-                                + " then re-export GOOGLE_WORKSPACE_CLI_TOKEN with the response body and retry. A fresh token appears there whenever the user talks to the assistant; if it is still expired, note that in your report and continue with the non-Workspace parts of the task.")
-                except Exception:
-                    pass
-
+        _message, _ws_token_embedded = _ma_append_workspace_access(_message, _task_id, _ws_auth)
 
         # Task docs are created UP FRONT (not only on background handoff) so the
         # Data Viewer Tasks tab shows the sandbox working live from second zero.
@@ -3690,10 +3705,222 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
         except Exception as _err:
             return {"status": "error", "message": "Status lookup failed: " + str(_err)[:200]}
 
+    def _ma_fire_scheduled_autonomous(sched_def, fire_msg_id):
+        """Fires ONE run of a scheduled autonomous task (v11.33). Called by the
+        /execute_task worker when Cloud Scheduler triggers a definition with
+        task_type 'scheduled_autonomous' - this is NOT a registered tool. It
+        creates a normal per-fire autonomous ticket (own definition + execution
+        docs) and hands off immediately (no sync wait: nobody is watching a
+        scheduler fire), so the existing monitor, orphan recovery, completion
+        injection, and Data Viewer flows all apply unchanged - including the
+        'announce status on the user's next message' behavior.
 
-    # Drive handoff requires BOTH the Managed Agent and Workspace auth
-    # (inside the Managed Agent guard, so this equals the drive-handoff condition).
+        Workspace access: a scheduled fire has no live user turn, so the token
+        embedded is the one captured on the LAST user turn (builtins global) -
+        possibly expired. That is the accepted degrade path: fast_api_app
+        re-uploads a fresh token to the rotating .wstoken object for ACTIVE
+        autonomous tasks on every user turn, so the sandbox regains Workspace
+        access as soon as the user talks while the run is active; until then it
+        follows the documented fallback (report the limitation, continue with
+        the non-Workspace parts).
+
+        Returns a dict with status and ticket-id."""
+        import builtins
+        import threading as _threading
+        import datetime as _dt
+        import uuid as _uuid
+        if not _MANAGED_AGENT_ID:
+            return {"status": "unavailable", "message": "The autonomous agent is not provisioned."}
+        _fs = getattr(builtins, "_firestore_client", None)
+        _demo_id = os.environ.get("DEMO_ID", "")
+        if not _fs or not _demo_id:
+            return {"status": "error", "message": "Task backend unavailable."}
+        _sched_id = sched_def.get("task_id", "")
+        _name = sched_def.get("task_name", "scheduled_autonomous")
+        _description = sched_def.get("task_description", "") or sched_def.get("task_prompt", "")
+        _input_data = sched_def.get("input_data", "")
+        # Overlap guard: skip this fire while the previous run of the SAME
+        # schedule is still active (long sandbox runs can outlast the interval).
+        try:
+            _actives = _fs.collection(_demo_id + "_task_executions").where(
+                "status", "in", ["submitted", "working"]).stream()
+            for _edoc in _actives:
+                _edata = _edoc.to_dict()
+                if _edata.get("scheduled_by") == _sched_id:
+                    return {"status": "skipped_overlap",
+                            "ticket-id": _edata.get("task_id", ""),
+                            "message": "Previous scheduled run still active - this fire was skipped."}
+        except Exception:
+            pass
+        _task_id = str(_uuid.uuid4())[:8]
+        _upload_urls = _ma_mint_upload_urls(_task_id)
+        _now = _dt.datetime.now(_dt.timezone.utc)
+        _message = _ma_build_task_message(_description, _input_data, _upload_urls)
+        _message = (_message + chr(10) + chr(10)
+                    + "SCHEDULED RUN: this task was fired automatically by its schedule at "
+                    + _now.strftime("%Y-%m-%d %H:%M UTC")
+                    + " (no live user turn). State in your report that this was an automatic scheduled run.")
+        _ws_auth = str(getattr(builtins, "_workspace_oauth_token", "") or "")
+        if _ws_auth and not _ws_auth.startswith("Bearer "):
+            _ws_auth = "Bearer " + _ws_auth
+        _message, _ws_token_embedded = _ma_append_workspace_access(_message, _task_id, _ws_auth)
+        _now_iso = _now.isoformat()
+        try:
+            _fs.collection(_demo_id + "_task_definitions").document(_task_id).set({
+                "task_id": _task_id,
+                "task_name": _name,
+                "task_description": _description,
+                "task_prompt": _message,
+                "task_type": "autonomous",
+                "scheduled_by": _sched_id,
+                "created_at": _now_iso,
+            })
+            _fs.collection(_demo_id + "_task_executions").document(_task_id).set({
+                "task_id": _task_id,
+                "definition_id": _task_id,
+                "scheduled_by": _sched_id,
+                "status": "working",
+                "progress_pct": 10,
+                "log_tail": "Scheduled fire (" + str(fire_msg_id or "manual") + ") - delegated to the autonomous sandbox agent." + chr(10),
+                "result_summary": "",
+                "started_at": _now_iso,
+                "completed_at": "",
+                "reported_to_user": False,
+                "updated_at": _now_iso,
+                "deliver_tid": _task_id,
+                "token_embedded": _ws_token_embedded,
+            })
+        except Exception as _doc_err:
+            return {"status": "error", "message": "Could not create task docs: " + str(_doc_err)[:200]}
+        _session = _ma_read_session_state()
+        _env_value = _session.get("environment_id") or os.environ.get("MANAGED_AGENT_ENV_ID", "").strip() or _ma_fresh_environment()
+        _payload = {
+            "agent": _MANAGED_AGENT_ID,
+            "stream": True,
+            "background": True,
+            "store": True,
+            "environment": _env_value,
+            "input": [{"type": "user_input", "content": [{"type": "text", "text": _message}]}],
+            "tools": _ma_override_tools(True),
+        }
+        # No previous_interaction_id: scheduled fires are independent runs and
+        # must not chain onto (or corrupt) the conversational sandbox thread.
+        _shared = {"handoff": True, "token_embedded": _ws_token_embedded,
+                   "task_id": _task_id, "deliver_tid": _task_id}
+        _threading.Thread(target=_ma_monitor_task, args=(_task_id, _shared), daemon=True).start()
+        _threading.Thread(target=_ma_run_interaction, args=(_payload, _shared), daemon=True).start()
+        return {"status": "working_in_background", "ticket-id": _task_id, "task_name": _name}
+
+    def register_scheduled_autonomous_task(
+        task_name: str,
+        task_description: str,
+        schedule_cron: str,
+        input_data: str = "",
+        tool_context: ToolContext = None,
+    ) -> dict:
+        """Registers a RECURRING schedule that automatically delegates a task to
+        the fully autonomous cloud sandbox agent at the given cron times - even
+        while the user is offline. Each fire creates a normal autonomous ticket;
+        its progress and completion (with deliverable download links) are
+        announced automatically the next time the user sends a message.
+
+        USE FOR: recurring autonomous work - e.g. a daily audit dashboard,
+        weekly web-research digest, scheduled report/deck generation.
+        DO NOT USE FOR: recurring demo-DB batch workflows (use
+        register_scheduled_task) or one-shot work (use delegate_autonomous_task).
+
+        NOTE on Workspace: at fire time there may be no fresh Workspace token;
+        Workspace parts of the task then degrade gracefully (the sandbox reports
+        the limitation and completes the rest, and regains Workspace access as
+        soon as the user talks while the run is still active).
+
+        Args:
+            task_name: Short identifier (e.g. 'daily_audit_dashboard').
+            task_description: COMPLETE, self-contained instruction in the USER'S
+                language - same rules as delegate_autonomous_task: describe
+                OUTCOMES only, never this agent's own tool names.
+            schedule_cron: Cron expression, Asia/Tokyo timezone (e.g. '0 8 * * 1-5').
+            input_data: Optional data to embed verbatim into every fire.
+
+        Returns:
+            dict with schedule_id, schedule, and job_name.
+        """
+        import builtins, json as _json, logging as _logging
+        if not _MANAGED_AGENT_ID:
+            return {"status": "unavailable",
+                    "message": "The autonomous agent is not provisioned in this project, so autonomous "
+                               "schedules cannot be created. Offer a scheduled background task instead."}
+        if tool_context is not None and getattr(tool_context, "user_id", "") == "background-worker":
+            return {"status": "blocked",
+                    "message": "Background workers must not register autonomous schedules."}
+        _fs = getattr(builtins, "_firestore_client", None)
+        _demo_id = os.environ.get("DEMO_ID", "")
+        _project_id = os.environ.get("GOOGLE_CLOUD_PROJECT", "")
+        _region = os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1")
+        if _region == "global":
+            _region = "us-central1"
+        if not _fs or not _demo_id:
+            return {"status": "error", "message": "Task backend unavailable."}
+        _sched_id = str(_task_uuid.uuid4())[:8]
+        _now = _task_dt.datetime.now(_task_dt.timezone.utc).isoformat()
+        _fs.collection(_demo_id + "_task_definitions").document(_sched_id).set({
+            "task_id": _sched_id,
+            "task_name": task_name,
+            "task_description": task_description,
+            "task_prompt": task_description,
+            "input_data": input_data,
+            "task_type": "scheduled_autonomous",
+            "schedule_cron": schedule_cron,
+            "created_at": _now,
+        })
+        # The schedule's own execution doc stays status 'scheduled'; per-fire
+        # tickets get their own docs. Cancelling THIS doc stops future fires
+        # (the /execute_task guard skips cancelled non-refire tasks).
+        _fs.collection(_demo_id + "_task_executions").document(_sched_id).set({
+            "task_id": _sched_id,
+            "definition_id": _sched_id,
+            "status": "scheduled",
+            "progress_pct": 0,
+            "log_tail": "",
+            "result_summary": "",
+            "started_at": "",
+            "completed_at": "",
+            "reported_to_user": False,
+        })
+        _job_name = ""
+        try:
+            from google.cloud import scheduler_v1
+            _sched_client = scheduler_v1.CloudSchedulerClient()
+            _parent = "projects/" + _project_id + "/locations/" + _region
+            _job_id = _demo_id + "-sched-" + _sched_id
+            _payload = _json.dumps({"task_id": _sched_id, "demo_id": _demo_id}).encode("utf-8")
+            _topic_path = "projects/" + _project_id + "/topics/" + _demo_id + "-sched-tasks"
+            _job = scheduler_v1.Job(
+                name=_parent + "/jobs/" + _job_id,
+                schedule=schedule_cron,
+                time_zone="Asia/Tokyo",
+                pubsub_target=scheduler_v1.PubsubTarget(topic_name=_topic_path, data=_payload),
+            )
+            _created = _sched_client.create_job(parent=_parent, job=_job)
+            _job_name = _created.name
+            _logging.warning("Created Cloud Scheduler job for autonomous schedule: " + _job_name)
+        except Exception as _e:
+            _logging.error("Failed to create autonomous scheduler job: " + str(_e))
+            return {"status": "partial", "schedule_id": _sched_id,
+                    "error": "Definition saved but scheduler creation failed: " + str(_e)[:200]}
+        return {
+            "status": "scheduled",
+            "schedule_id": _sched_id,
+            "task_name": task_name,
+            "schedule": schedule_cron,
+            "job_name": _job_name,
+            "message": "Autonomous schedule registered (timezone Asia/Tokyo). Each fire runs in the sandbox "
+                       "even while the user is offline; progress and completion are announced automatically "
+                       "on the user's next message. Tell the user this, including the schedule in plain words.",
+        }
+
     if os.environ.get("ENABLE_WORKSPACE_MCP") == "1" or os.environ.get("ENABLE_WORKSPACE_AUTH") == "1":
+
         # =============================================================================
         # Google Drive handoff for Managed Agent deliverables (v11.0)
         # Requires BOTH Workspace MCP (user OAuth with drive.file scope via the GE
@@ -3856,4 +4083,3 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
             if _errors:
                 _out["problems"] = _errors
             return _out
-

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.31-public',
+  APP_VERSION: 'v11.32-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2205,6 +2205,7 @@ function buildManagedAgentInstruction_(businessInstruction, datasetId, fsCollect
     '- DRIVE SAVES: when the task asks for a file in the user\'s Google Drive (or as Google Slides / Docs / Sheets), upload it yourself with the gws CLI using an import-conversion to the native Google format (pptx to Google Slides, docx to Google Docs, xlsx to Google Sheets), then include the returned Drive webViewLink in your report. ALSO upload the original office file to the matching deliverable upload URL as a backup.' + nl +
     '- Do Workspace operations EARLY in the task: the token expires after about an hour.' + nl +
     '- HARD GUARDRAILS: never SEND email (drafts only, unless the task explicitly says to send); never delete anything in Workspace; post Chat messages only to spaces the task explicitly names; never write the token into your report, logs, code, or files.' + nl +
+    '- ADMIN LIMITS: the provided token always carries USER-level scopes only - Admin SDK APIs (Directory, Reports / audit logs, license management) and org-wide admin operations fail with 401/403 by design, and no admin credentials will ever be provided. Never retry or loop on these calls: report the limitation clearly and complete the task from data the user-level APIs can see (for example the user\'s own Drive file metadata and sharing settings).' + nl +
     '- CHAT SPACES: when the task names a Chat space, search for it first; if no space with that name exists, CREATE the space with that exact name via the gws CLI and then post there (demo environments often lack the space - creating it is expected, not an error). State in your report that you created it. If creation fails (e.g. missing permission), report the failure instead of posting elsewhere.' + nl +
     '- EMAIL ENCODING: non-ASCII email headers (Subject, display names) MUST be RFC 2047 MIME-encoded (for example =?UTF-8?B?...?=). After creating a draft, read it back and verify the subject decodes correctly; delete and recreate it if it is garbled.' + nl +
     '- REPORTING DRAFTS: when you create a Gmail draft, your report must state it ALREADY EXISTS in the user Gmail Drafts folder, with the draft subject and this link: https://mail.google.com/mail/u/0/#drafts - never paste the full email body into the report for manual copying.' + nl +

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.32-public',
+  APP_VERSION: 'v11.35-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2409,7 +2409,11 @@ function generateSetupScript(params) {
   bqCommands += `SCHEMA=\$3\n`;
   bqCommands += `DATASET=\$4\n`;
   bqCommands += `echo "📥 Loading \$TABLE..."\n`;
-  bqCommands += `if bq load --source_format=CSV --skip_leading_rows=1 --allow_quoted_newlines --null_marker="" --quote='"' --encoding=UTF-8 --max_bad_records=5 --location=US "\$DATASET.\$TABLE" "\$CSV" "\$SCHEMA"; then\n`;
+  // --replace (v11.35): a re-run of the same setup script must not APPEND the
+  // same rows again (observed live: every full re-run doubled every table).
+  // The CSVs are embedded in this script, so replacing the table is always
+  // the correct idempotent behavior.
+  bqCommands += `if bq load --replace --source_format=CSV --skip_leading_rows=1 --allow_quoted_newlines --null_marker="" --quote='"' --encoding=UTF-8 --max_bad_records=5 --location=US "\$DATASET.\$TABLE" "\$CSV" "\$SCHEMA"; then\n`;
   bqCommands += `  echo "    ✅ Loaded table: \$TABLE"\n`;
   bqCommands += `else\n`;
   bqCommands += `  echo "    ⚠️  ERROR: Failed to load table: \$TABLE"\n`;
@@ -2557,9 +2561,16 @@ Requirements:
     firestoreCommands += `cp "$GE_TPL/viewer_app/requirements.txt" ${dirName}/viewer_app/requirements.txt\n`;
 
     firestoreCommands += `echo "🌐 Checking/Deploying Real-time Data Viewer Web App..."\n`;
+    // v11.35: ALWAYS deploy. The old exists->skip fast path meant viewer code
+    // updates never reached a re-deployed demo (Cloud Run agent updated, viewer
+    // stale). gcloud functions deploy is an idempotent update-in-place for an
+    // existing function, so re-running is safe - it just costs the build time.
     firestoreCommands += `if gcloud functions describe ${dirName}-viewer --gen2 --region=us-central1 --project="$PROJECT_ID" >/dev/null 2>&1; then\n`;
-    firestoreCommands += `  echo "    ✅ Cloud Run Function already exists."\n`;
+    firestoreCommands += `  echo "    ♻️  Function exists - redeploying to apply the latest viewer code (update-in-place)..."\n`;
     firestoreCommands += `else\n`;
+    firestoreCommands += `  echo "    🚀 Deploying new Data Viewer function..."\n`;
+    firestoreCommands += `fi\n`;
+    firestoreCommands += `if true; then\n`;
     firestoreCommands += `  VIEWER_LOG=\$(mktemp /tmp/viewer-deploy-XXXXXX.log)\n`;
     // v11.12: --no-allow-unauthenticated + IAP (see the IAP block below). Never
     // grants allUsers, so the deploy works under Domain Restricted Sharing org
@@ -2572,12 +2583,14 @@ Requirements:
     firestoreCommands += `    sleep 5\n`;
     firestoreCommands += `  done\n`;
     firestoreCommands += `  echo ""\n`;
-    firestoreCommands += `  wait \$VIEWER_PID || true\n`;
-    // NOTE: don't trust the exit code here — the deploy runs in the background and
-    // `wait ... || true` always yields 0. Verify the function actually exists instead
-    // (same source of truth as the final summary), so we never print a false success.
-    firestoreCommands += `  if gcloud functions describe ${dirName}-viewer --gen2 --region=us-central1 --project="$PROJECT_ID" >/dev/null 2>&1; then\n`;
-    firestoreCommands += `    echo "    ✅ Cloud Run Function deployed."\n`;
+    firestoreCommands += `  VIEWER_RC=0\n`;
+    firestoreCommands += `  wait \$VIEWER_PID || VIEWER_RC=\$?\n`;
+    // v11.35: wait's status IS the deploy's exit code - required now that
+    // re-runs redeploy an EXISTING function (describe alone would report a
+    // false success when the update failed but the old function remains).
+    // The describe check stays as the fresh-deploy source of truth.
+    firestoreCommands += `  if [ "\$VIEWER_RC" = "0" ] && gcloud functions describe ${dirName}-viewer --gen2 --region=us-central1 --project="$PROJECT_ID" >/dev/null 2>&1; then\n`;
+    firestoreCommands += `    echo "    ✅ Data Viewer deployed (latest viewer code active)."\n`;
     firestoreCommands += `  else\n`;
     firestoreCommands += `    echo "    ⚠️ WARNING: Failed to deploy Firestore Data Viewer. Build log:"\n`;
     firestoreCommands += `    cat "\$VIEWER_LOG"\n`;
@@ -3079,15 +3092,42 @@ else
   echo "   If Chat posts fail with a permission/configuration error, open 'Configuration' there and set it up (App name: '${enableWorkspaceMcp ? 'Chat MCP' : 'GE Demo Agent'}')."
 fi
 
-# Create authorization resource in Gemini Enterprise
+# Create or UPDATE (v11.35) the authorization resource in Gemini Enterprise.
+# A re-run previously hit a silent 409 and kept the OLD resource, so OAuth
+# scope additions never reached overwrite-deployed demos (stale scopes
+# surface later as confusing 403s in Workspace tools). PATCH keeps the
+# scopes in sync with THIS script version; the resource NAME is unchanged,
+# so the agent binding survives (verified live 2026-07-23).
 AUTH_ID="${dirName}-auth"
-echo "🔐 Creating authorization resource in Gemini Enterprise..."
-curl -X POST \
+AUTH_PAYLOAD='{ "name": "projects/'"\$PROJECT_ID"'/locations/global/authorizations/'"\$AUTH_ID"'", "serverSideOauth2": { "clientId": "'"\$OAUTH_CLIENT_ID"'", "clientSecret": "'"\$OAUTH_CLIENT_SECRET"'", "authorizationUri": "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.compose%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.calendarlist.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.freebusy%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.spaces.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.memberships.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.create%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.users.readstate.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdirectory.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcontacts.readonly&client_id='"\$OAUTH_CLIENT_ID"'&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Foauth-redirect", "tokenUri": "https://oauth2.googleapis.com/token" } }'
+echo "🔐 Creating/updating authorization resource in Gemini Enterprise..."
+AUTH_RESP=\$(mktemp /tmp/auth-resp-XXXXXX.json)
+AUTH_HTTP=\$(curl -s -o "\$AUTH_RESP" -w "%{http_code}" -X POST \
   -H "Authorization: Bearer \$TOKEN" \
   -H "Content-Type: application/json" \
   -H "X-Goog-User-Project: \$PROJECT_ID" \
   "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/authorizations?authorizationId=\$AUTH_ID" \
-  -d '{ "name": "projects/'"\$PROJECT_ID"'/locations/global/authorizations/'"\$AUTH_ID"'", "serverSideOauth2": { "clientId": "'"\$OAUTH_CLIENT_ID"'", "clientSecret": "'"\$OAUTH_CLIENT_SECRET"'", "authorizationUri": "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.compose%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.calendarlist.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.freebusy%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.spaces.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.memberships.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.create%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.users.readstate.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdirectory.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcontacts.readonly&client_id='"\$OAUTH_CLIENT_ID"'&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Foauth-redirect", "tokenUri": "https://oauth2.googleapis.com/token" } }'
+  -d "\$AUTH_PAYLOAD")
+if [ "\$AUTH_HTTP" = "200" ]; then
+  echo "    ✅ Authorization resource created."
+elif [ "\$AUTH_HTTP" = "409" ]; then
+  AUTH_HTTP=\$(curl -s -o "\$AUTH_RESP" -w "%{http_code}" -X PATCH \
+    -H "Authorization: Bearer \$TOKEN" \
+    -H "Content-Type: application/json" \
+    -H "X-Goog-User-Project: \$PROJECT_ID" \
+    "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/authorizations/\$AUTH_ID" \
+    -d "\$AUTH_PAYLOAD")
+  if [ "\$AUTH_HTTP" = "200" ]; then
+    echo "    ♻️  Authorization already existed - updated in place (OAuth scopes refreshed)."
+  else
+    echo "    ⚠️  Authorization update failed (HTTP \$AUTH_HTTP) - keeping the existing resource:"
+    cat "\$AUTH_RESP"
+  fi
+else
+  echo "    ⚠️  Authorization creation failed (HTTP \$AUTH_HTTP):"
+  cat "\$AUTH_RESP"
+fi
+rm -f "\$AUTH_RESP"
 
 `;
   }
@@ -5015,26 +5055,71 @@ if auth_id:
         data["authorizationConfig"] = { "agentAuthorization": auth_id }
     else:
         data["authorizationConfig"] = { "agentAuthorization": f"projects/{project_id}/locations/{location}/authorizations/{auth_id}" }
+auth_path = data.get("authorizationConfig", {}).get("agentAuthorization", "")
 
-req = urllib.request.Request(url, data=json.dumps(data).encode("utf-8"), headers=headers)
-try:
-    with urllib.request.urlopen(req) as response:
-        resp_data = json.loads(response.read().decode("utf-8"))
-        print("Successfully registered agent:")
-        print(json.dumps(resp_data, indent=2))
-        agent_name = resp_data.get("name", "")
-        agent_id = agent_name.split("/")[-1]
-        print(f"AGENT_ID:{agent_id}")
+def call(method, call_url, payload=None):
+    body = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(call_url, data=body, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req) as response:
+            return response.getcode(), json.loads(response.read().decode("utf-8") or "{}")
+    except urllib.error.HTTPError as e:
+        return e.code, {"error": e.read().decode("utf-8", "replace")[:500]}
+    except Exception as e:
+        return 0, {"error": str(e)[:500]}
 
+# Idempotent overwrite (v11.34): re-running the setup script for the SAME
+# demo must UPDATE the existing registration (display name, description,
+# agent card, auth binding) instead of failing with FAILED_PRECONDITION
+# "authorization ... is used by another agent". Match by the agent card's
+# internal name (the unique demo dirName - same matching the cleanup script
+# uses); fall back to whichever agent holds this demo's authorization.
+existing = ""
+list_code, listing = call("GET", url + "?pageSize=100")
+if list_code == 200:
+    for a in listing.get("agents", []):
+        try:
+            card = json.loads((a.get("a2aAgentDefinition") or {}).get("jsonAgentCard") or "{}")
+        except Exception:
+            card = {}
+        if card.get("name") == agent_name:
+            existing = a.get("name", "")
+            break
+    if not existing and auth_path:
+        for a in listing.get("agents", []):
+            if (a.get("authorizationConfig") or {}).get("agentAuthorization", "") == auth_path:
+                existing = a.get("name", "")
+                break
 
+def print_agent_id(resource_name):
+    print("AGENT_ID:" + resource_name.split("/")[-1])
 
-except urllib.error.HTTPError as e:
-    print(f"Error registering agent: {e}", file=sys.stderr)
-    print(e.read().decode("utf-8"), file=sys.stderr)
-    sys.exit(1)
-except Exception as e:
-    print(f"Unexpected error: {e}", file=sys.stderr)
-    sys.exit(1)
+if existing:
+    patch_body = dict(data)
+    patch_body["name"] = existing
+    patch_code, resp = call("PATCH", f"https://{endpoint}/v1alpha/{existing}", patch_body)
+    if patch_code == 200:
+        print("Updated the existing agent registration (overwrite deploy):")
+        print(json.dumps(resp, indent=2))
+        print_agent_id(resp.get("name", "") or existing)
+        sys.exit(0)
+    # PATCH semantics on this v1alpha surface are not guaranteed - fall back
+    # to delete+create. NOTE: this changes the agent resource id (pinned
+    # agents / conversation-thread association in the GE UI may reset).
+    print(f"PATCH failed ({patch_code}): {resp.get('error', '')} - falling back to delete+create", file=sys.stderr)
+    del_code, del_resp = call("DELETE", f"https://{endpoint}/v1alpha/{existing}")
+    if del_code not in (200, 204):
+        print(f"DELETE of the existing agent also failed ({del_code}): {del_resp.get('error', '')}", file=sys.stderr)
+        sys.exit(1)
+
+create_code, resp = call("POST", url, data)
+if create_code == 200:
+    print("Successfully registered agent:")
+    print(json.dumps(resp, indent=2))
+    print_agent_id(resp.get("name", ""))
+    sys.exit(0)
+print(f"Error registering agent ({create_code}): {resp.get('error', '')}", file=sys.stderr)
+sys.exit(1)
 EOF
 
   if [ "$APP_COUNT" = "1" ]; then
@@ -5042,11 +5127,16 @@ EOF
     SELECTED_LOC="\${APP_LOCS[0]}"
     echo "✅ Found exactly one Gemini Enterprise app ($SELECTED_APP_ID). Automating registration..."
 
-    REG_OUTPUT=$(python3 register_agent.py "$SELECTED_LOC" "$PROJECT_NUMBER" "$SELECTED_LOC" "$SELECTED_APP_ID" "$TOKEN" "${dirName}" "$SERVICE_URL/a2a/app" "\$AGENT_DISPLAY_NAME" '${safeSummary}' "$AUTH_ID")
+    REG_OUTPUT=$(python3 register_agent.py "$SELECTED_LOC" "$PROJECT_NUMBER" "$SELECTED_LOC" "$SELECTED_APP_ID" "$TOKEN" "${dirName}" "$SERVICE_URL/a2a/app" "\$AGENT_DISPLAY_NAME" '${safeSummary}' "$AUTH_ID" 2>&1) || true
     echo "$REG_OUTPUT"
     AGENT_ID=$(echo "$REG_OUTPUT" | grep "AGENT_ID:" | cut -d':' -f2)
     rm register_agent.py
-    
+    if [ -z "\$AGENT_ID" ]; then
+      echo "⚠️  Gemini Enterprise registration failed, but the Cloud Run deployment itself is COMPLETE."
+      echo "    An existing registration of this demo (if any) keeps working against the new deployment."
+      echo "    To (re)register manually: Gemini Enterprise > Agents > Add, URL: $SERVICE_URL/a2a/app"
+    fi
+
   else
     if [ "$APP_COUNT" = "0" ]; then
       echo "⚠️ No Gemini Enterprise apps found in 'global', 'us', or 'eu'. You might need to create one first."
@@ -5071,10 +5161,15 @@ EOF
       
       echo "✅ Selected app: \${APP_DISPLAY_NAMES[\$CHOICE]}. Automating registration..."
       
-      REG_OUTPUT=$(python3 register_agent.py "\$SELECTED_LOC" "\$PROJECT_NUMBER" "\$SELECTED_LOC" "\$SELECTED_APP_ID" "\$TOKEN" "${dirName}" "\$SERVICE_URL/a2a/app" "\$AGENT_DISPLAY_NAME" '${safeSummary}' "\$AUTH_ID")
+      REG_OUTPUT=$(python3 register_agent.py "\$SELECTED_LOC" "\$PROJECT_NUMBER" "\$SELECTED_LOC" "\$SELECTED_APP_ID" "\$TOKEN" "${dirName}" "\$SERVICE_URL/a2a/app" "\$AGENT_DISPLAY_NAME" '${safeSummary}' "\$AUTH_ID" 2>&1) || true
       echo "\$REG_OUTPUT"
       AGENT_ID=$(echo "\$REG_OUTPUT" | grep "AGENT_ID:" | cut -d':' -f2)
       rm register_agent.py
+      if [ -z "\$AGENT_ID" ]; then
+        echo "⚠️  Gemini Enterprise registration failed, but the Cloud Run deployment itself is COMPLETE."
+        echo "    An existing registration of this demo (if any) keeps working against the new deployment."
+        echo "    To (re)register manually: Gemini Enterprise > Agents > Add, URL: \$SERVICE_URL/a2a/app"
+      fi
     fi
   fi
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.35-public',
+  APP_VERSION: 'v11.37-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -847,7 +847,7 @@ function planAndGenerateData(userGoal, options) {
     - You MUST leverage this capability when generating the 'businessInstruction' and 'demoGuide' (prompts).
     - In 'businessInstruction', mention that the agent can hand off deep autonomous work (research, building deliverables, iterative code work) to a managed autonomous agent and deliver finished files back to the user.
     - You MUST design at least TWO prompts (out of the 7 required) in the 'demoGuide' that showcase the autonomous agent, following BOTH patterns below:
-      - **Pattern A (WEB RESEARCH + INTERNAL DATA SYNTHESIS)**: one prompt MUST require researching CURRENT external information on the public web (industry trends, competitor moves, market prices, regulations) AND combining it with the demo's own BigQuery data into a substantial written analysis. Phrase it so the answer is impossible without live web research (e.g. "Research the latest <industry> trends online and produce a competitive analysis against our own sales data").${ options.enableComputerUse ? ` Because the browser agent is ALSO enabled, Pattern A MAY additionally name ONE specific external page or portal to check interactively (e.g. a competitor's public pricing page) - the assistant will then operate its real browser live in the chat BEFORE handing off to the autonomous agent, which makes a strong combined showcase. Keep it to a single, quickly checkable page; the deep multi-source research still belongs to the autonomous agent.` : ''}
+      - **Pattern A (WEB RESEARCH + INTERNAL DATA SYNTHESIS)**: one prompt MUST require researching CURRENT external information on the public web (industry trends, competitor moves, market prices, regulations) AND combining it with the demo's own BigQuery data into a substantial written analysis. Phrase it so the answer is impossible without live web research (e.g. "Research the latest <industry> trends online and produce a competitive analysis against our own sales data").${ options.enableComputerUse ? ` Because the browser agent is ALSO enabled, Pattern A MUST name ONE specific external page or portal to check interactively (e.g. a competitor's public pricing page or an official statistics portal) AND phrase that part as an explicit browse request (e.g. "browse <site> live for the latest ..."), so the assistant operates its real browser live in the chat BEFORE handing off to the autonomous agent - a strong combined showcase. Keep it to a single, quickly checkable page; the deep multi-source research still belongs to the autonomous agent.` : ''}
       - **Pattern B (COMPLEX LONG-HORIZON DELIVERABLE)**: one prompt MUST ask for finished, downloadable business output whose production requires SEQUENTIALLY DEPENDENT phases (real quantitative analysis of the internal data -> charts built from that analysis -> professional assembly), so the request genuinely deserves tens of minutes of autonomous work. Make it one of these two shapes, whichever fits the scenario better: (1) TWO complementary formats built from the same analysis - e.g. a board presentation deck PLUS a 2-page summary PDF for the field team, or a formal proposal document PLUS a one-page web briefing; or (2) a WORKING INTERACTIVE TOOL - a self-contained web app the user opens in a browser (e.g. a pricing / capacity / what-if simulator) whose coefficients come from the actual data analysis, plus a short document explaining the model. The prompt should sound like a real executive request and SHOULD state 1-2 explicit quality conditions in natural business language (e.g. "lead with the conclusion on the first page", "every number must be sourced from our data or a cited reference") - these conditions make the agent's self-review-and-rebuild loop visible in the demo. Patterns A and B MUST use DIFFERENT deliverable formats so the demo shows variety.${ crossOrgEnabled_() ? '\n      - **CROSS-DEPARTMENTAL DELIVERABLE (MANDATORY)**: the delegated mission MUST synthesize data owned by at least two departments and address its deliverable to the department (or executive) that owns the decision - framed as the journey summary of the demo narrative: what happened in each department, where the process stalled, and what was resolved. Because the Pattern A prompt occupies the final core slot, ITS deliverable also carries the NARRATIVE ARC finale duty: it MUST close with the quantified process outcomes of the demo narrative (before/after cycle time or lead time, items resolved, hand-offs completed).' : '' }${ (options.enableWorkspaceMcp || options.enableWorkspaceAuth) ? `
       - **MANDATORY WORKSPACE COMBINATION**: Google Workspace access is ALSO enabled for this demo, and the autonomous agent can act on the user's Workspace (save files to Drive as native Google Slides/Docs/Sheets, draft Gmail messages, post to named Google Chat spaces, create Calendar events). At least ONE of the two autonomous prompts MUST chain a Workspace action onto the deliverable so the demo showcases BOTH capabilities together, e.g.: "Research the latest industry trends, build the executive deck, save it to my Drive as Google Slides, and draft an email to the leadership team summarizing it" or "...and post the summary with the document link to the <team> Chat space, then set up a 30-minute review meeting on my calendar". Keep the Workspace actions realistic for the persona, and prefer DRAFT email wording (the agent creates drafts, it does not send unless explicitly told).` : ''}
     - 🎯 SLOT ASSIGNMENT (overrides the base 7-prompt distribution): put Pattern B in the Prompt 5 slot, REPLACING the large-scope background workflow prompt (the autonomous delegation itself runs in the background and demonstrates background execution plus completion announcements, so that story is preserved). Weave Pattern A into the Prompt 7 slot (End-to-End Strategic Automation): its web research + internal data synthesis IS the end-to-end showcase${ (options.enableWorkspaceMcp || options.enableWorkspaceAuth) ? ', and the MANDATORY WORKSPACE COMBINATION chain belongs there' : ''}. Do NOT merge Patterns A and B into a single prompt - the demo needs TWO distinct autonomous moments. Because slots 5 and 7 are now autonomous, fold the MANDATORY INTERACTIVE DASHBOARD prompt into slot 1 or 2 (make one of the foundation prompts ask for the browser-openable interactive overview dashboard, keeping its explicit open-in-browser signal) - the dashboard prompt must NOT displace slot 5 or 7 and must NOT be dropped.
@@ -2373,6 +2373,18 @@ function generateSetupScript(params) {
     // generate_content computer_use tool config.
     playwright: 'playwright==1.55.0',
     genaiComputerUse: 'google-genai>=2.7.0',
+    // (v11.36) google-genai>=2.7.0 is only satisfiable with recent
+    // google-cloud-aiplatform releases (older ones cap google-genai<2.0.0),
+    // and those releases depend on Google Cloud OTel packages whose satisfying
+    // versions are pre-releases (1.12.0a0). uv ignores pre-release markers
+    // on TRANSITIVE deps, so without these direct floors the resolver
+    // rejects every aiplatform that allows genai 2.x and the build fails
+    // ("pre-releases weren't enabled"). Declaring them as direct deps with
+    // explicit pre-release floors scopes pre-release resolution to exactly
+    // these two packages (unlike --prerelease=allow, which would also pull
+    // mcp/pydantic pre-releases).
+    cuOtelGcpLogging: 'opentelemetry-exporter-gcp-logging>=1.12.0a0',
+    cuOtelGcpResourceDetector: 'opentelemetry-resourcedetector-gcp>=1.12.0a0',
   };
 
   
@@ -4268,7 +4280,7 @@ ${PINNED_DEPS.pubsub}
 ${PINNED_DEPS.firestore}
 ${PINNED_DEPS.logging}
 ${PINNED_DEPS.otel}
-${ enableComputerUse ? `${PINNED_DEPS.playwright}\n${PINNED_DEPS.genaiComputerUse}` : '' }
+${ enableComputerUse ? `${PINNED_DEPS.playwright}\n${PINNED_DEPS.genaiComputerUse}\n${PINNED_DEPS.cuOtelGcpLogging}\n${PINNED_DEPS.cuOtelGcpResourceDetector}` : '' }
 __REQ_EOF__
 
 # Generate pyproject.toml required for adk project type


### PR DESCRIPTION
# Description

Update for `search/gemini-enterprise/ge-demo-generator` (APP_VERSION `v11.32-public`), continuing #3001.

## What's changed

The Managed Agent's monitor threads live inside a Cloud Run instance; when that instance is recycled mid-task, the delegated task froze at its last progress line forever — indistinguishable from a hung sandbox.

- **Orphan recovery**: delegations persist the interaction id early, and status checks now detect an orphaned RUNNING task (no live monitor in the current instance) and pull the interaction state directly from the Interactions API — completing, failing, or resuming the ticket with fresh progress instead of reporting a stale snapshot.
- **Monitor hardening** around the poll phase.
- **ADMIN LIMITS briefing**: the Workspace-auth token briefing now states that the token carries user-level scopes only, so the sandbox never grinds on Admin SDK 401/403s (derive from user-level APIs, report the limitation, move on).

Runtime template changes (`tools.py` Managed-Agent block, `agent.py` delegation guidance) are copied verbatim from the internal reference implementation; the ADMIN LIMITS fragment sits inside the existing Workspace-auth guard. No pinning changes needed (#2986).

## Verification

- Mock-import equivalence test: every LlmAgent instruction string byte-equal to the internal reference across 6 flag combinations.
- Generated setup scripts across the feature matrix: `bash -n` clean; all shared emitted file bodies byte-equal to the internal reference.
- `python3 validate_examples.py` — 33/33; `node --check` on all Apps Script files.