### PR TITLE
fix(ge-demo-generator): stop the Gemini Enterprise re-authorization loop (v11.38)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1384,6 +1384,7 @@ Pré
 PREBROWSE
 preds
 pregel
+preflight
 produc
 programar
 projectid

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -192,6 +192,21 @@ branch tip). Delete both properties after the upstream merge.
 - **Modify files with byte-exact tools**: when scripting edits to Code.gs or
   the templates, operate on raw bytes/strings, not on regex replacements with
   `\n` in the replacement text (Python `re` interprets them).
+- **`authorizations.patch` silently no-ops without `updateMask`**: a full-body
+  PATCH to the Discovery Engine authorization endpoint returns **HTTP 200 and
+  changes nothing**. Pass `?updateMask=serverSideOauth2`, and never treat the
+  200 as proof — read the resource back and check it actually changed.
+- **Authorization resources always live in `global`**: they are created at
+  `projects/<id>/locations/global/authorizations/<id>` regardless of where the
+  Gemini Enterprise app itself lives. Binding an agent to
+  `locations/<app-location>/...` points a `us`/`eu` app at a resource that does
+  not exist, which reproduces the endless re-authorization prompt.
+- **A failed OAuth token exchange is invisible**: Gemini Enterprise performs
+  the code-to-token exchange server-side after consent and surfaces nothing
+  when it fails — no UI error, no Cloud Run log, no agent-side signal. Probe
+  `https://oauth2.googleapis.com/token` with a throwaway code to tell the
+  cases apart: `invalid_grant` means the credentials are fine, `invalid_client`
+  means the stored secret is stale.
 
 ## 7. Verification
 

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -448,6 +448,12 @@ If sub-agents fail to modify Firestore or pull from BigQuery:
   - `roles/bigquery.dataViewer` & `roles/bigquery.jobUser`
   - `roles/aiplatform.user`
  
+#### 6. Endless "The agent requires additional authorization" Prompt
+If every message comes back with the Gemini Enterprise authorization card, you complete consent, and the very next turn asks again — with no error anywhere in the UI, in Cloud Run, or in the agent logs:
+- **Cause**: Consent only validates the `client_id` and the redirect URI, so it succeeds even when the code-to-token exchange that Gemini Enterprise performs afterwards fails. The usual reason is a stored OAuth client secret that no longer matches the client (rotated or deleted). Because every demo in a project shares one OAuth client, this breaks **all** Workspace-authorization demos at once.
+- **Detection**: The setup script now probes the token endpoint with a throwaway code before wiring the credentials into Gemini Enterprise. `invalid_grant` means the credentials are good (only the fake code was rejected); `invalid_client` means the secret is stale.
+- **Fix**: Add a **new secret to the existing OAuth client** (the `client_id` and redirect URI stay valid) at `https://console.cloud.google.com/auth/clients`, then re-run the setup script — it prompts for the new secret, verifies it, stores it as a new Secret Manager version, and refreshes the authorization resource.
+ 
 ---
  
 ### 13.3 Cleanup

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.37-public',
+  APP_VERSION: 'v11.38-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -3104,12 +3104,57 @@ else
   echo "   If Chat posts fail with a permission/configuration error, open 'Configuration' there and set it up (App name: '${enableWorkspaceMcp ? 'Chat MCP' : 'GE Demo Agent'}')."
 fi
 
+# ── OAuth credential pre-flight (v11.38) ──────────────────────────────────
+# A rotated or deleted client secret is the #1 cause of the Gemini Enterprise
+# "The agent requires additional authorization for: <demo>-auth" loop. The
+# consent step still succeeds (Google only validates client_id and the
+# redirect URI there), but GE's code->token exchange fails with
+# invalid_client, no token is ever persisted, and every following turn
+# re-prompts - with no error surfaced anywhere in the GE UI.
+# Probing the token endpoint with a throwaway code separates the two cases:
+#   invalid_grant  -> credentials are GOOD (only the fake code was rejected)
+#   invalid_client -> the stored secret no longer matches the OAuth client
+probe_oauth_client() {
+  curl -s -X POST "https://oauth2.googleapis.com/token" \
+    -d client_id="\$OAUTH_CLIENT_ID" \
+    -d client_secret="\$OAUTH_CLIENT_SECRET" \
+    -d code="preflight-probe-not-a-real-code" \
+    -d grant_type="authorization_code" \
+    -d redirect_uri="https://vertexaisearch.cloud.google.com/oauth-redirect"
+}
+echo "🩺 Verifying the OAuth client credentials before wiring them into Gemini Enterprise..."
+if probe_oauth_client | grep -q '"invalid_client"'; then
+  echo "    ❌ Google rejected this client_id/secret pair (invalid_client)."
+  echo "       The stored secret no longer matches the OAuth client - it was rotated or deleted."
+  echo "       Add a NEW secret to the EXISTING client (the client_id and redirect URI stay valid):"
+  echo "       https://console.cloud.google.com/auth/clients/\$OAUTH_CLIENT_ID?project=\$PROJECT_ID"
+  if [ -t 0 ]; then
+    read -s -p "    Paste the NEW OAuth Client Secret (or press [Enter] to skip): " NEW_OAUTH_SECRET
+    echo ""
+    if [ -n "\$NEW_OAUTH_SECRET" ]; then
+      OAUTH_CLIENT_SECRET="\$NEW_OAUTH_SECRET"
+      if probe_oauth_client | grep -q '"invalid_client"'; then
+        echo "    ⚠️  The new secret was rejected too - continuing, but Workspace tools will not work."
+      else
+        echo -n "\$OAUTH_CLIENT_SECRET" | gcloud secrets versions add \$CLIENT_SECRET_SECRET --data-file=- --project="\$PROJECT_ID" >/dev/null
+        echo "    ✅ New secret verified and stored as a new Secret Manager version."
+      fi
+    else
+      echo "    ⚠️  Skipped - Workspace authorization will loop until the secret is fixed."
+    fi
+  else
+    echo "    ⚠️  Non-interactive run - continuing, but Workspace authorization will loop."
+  fi
+else
+  echo "    ✅ OAuth client credentials accepted by Google."
+fi
+
 # Create or UPDATE (v11.35) the authorization resource in Gemini Enterprise.
 # A re-run previously hit a silent 409 and kept the OLD resource, so OAuth
 # scope additions never reached overwrite-deployed demos (stale scopes
 # surface later as confusing 403s in Workspace tools). PATCH keeps the
 # scopes in sync with THIS script version; the resource NAME is unchanged,
-# so the agent binding survives (verified live 2026-07-23).
+# so the agent binding survives.
 AUTH_ID="${dirName}-auth"
 AUTH_PAYLOAD='{ "name": "projects/'"\$PROJECT_ID"'/locations/global/authorizations/'"\$AUTH_ID"'", "serverSideOauth2": { "clientId": "'"\$OAUTH_CLIENT_ID"'", "clientSecret": "'"\$OAUTH_CLIENT_SECRET"'", "authorizationUri": "https://accounts.google.com/o/oauth2/v2/auth?access_type=offline&prompt=consent&response_type=code&scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.compose%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fgmail.modify%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.calendarlist.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.freebusy%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcalendar.events%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.spaces.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.memberships.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.messages.create%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fchat.users.readstate.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdirectory.readonly%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fuserinfo.profile%20https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fcontacts.readonly&client_id='"\$OAUTH_CLIENT_ID"'&redirect_uri=https%3A%2F%2Fvertexaisearch.cloud.google.com%2Foauth-redirect", "tokenUri": "https://oauth2.googleapis.com/token" } }'
 echo "🔐 Creating/updating authorization resource in Gemini Enterprise..."
@@ -3123,14 +3168,26 @@ AUTH_HTTP=\$(curl -s -o "\$AUTH_RESP" -w "%{http_code}" -X POST \
 if [ "\$AUTH_HTTP" = "200" ]; then
   echo "    ✅ Authorization resource created."
 elif [ "\$AUTH_HTTP" = "409" ]; then
+  # updateMask is MANDATORY here (v11.38). Without it this endpoint accepts
+  # the request, answers HTTP 200, and silently changes NOTHING - so every
+  # re-run since v11.35 only *claimed* to refresh scopes and the secret
+  # (observed live 2026-07-27).
   AUTH_HTTP=\$(curl -s -o "\$AUTH_RESP" -w "%{http_code}" -X PATCH \
     -H "Authorization: Bearer \$TOKEN" \
     -H "Content-Type: application/json" \
     -H "X-Goog-User-Project: \$PROJECT_ID" \
-    "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/authorizations/\$AUTH_ID" \
+    "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/authorizations/\$AUTH_ID?updateMask=serverSideOauth2" \
     -d "\$AUTH_PAYLOAD")
   if [ "\$AUTH_HTTP" = "200" ]; then
-    echo "    ♻️  Authorization already existed - updated in place (OAuth scopes refreshed)."
+    # A 200 is not proof the write landed - read the resource back and check
+    # that the full authorizationUri (not a truncated legacy one) is present.
+    if curl -s -H "Authorization: Bearer \$TOKEN" -H "X-Goog-User-Project: \$PROJECT_ID" \
+         "https://discoveryengine.googleapis.com/v1alpha/projects/\$PROJECT_ID/locations/global/authorizations/\$AUTH_ID" \
+         | grep -q "vertexaisearch.cloud.google.com%2Foauth-redirect"; then
+      echo "    ♻️  Authorization already existed - updated in place and verified (OAuth scopes + secret refreshed)."
+    else
+      echo "    ⚠️  Authorization PATCH returned 200 but the resource did not change - re-authorization will loop."
+    fi
   else
     echo "    ⚠️  Authorization update failed (HTTP \$AUTH_HTTP) - keeping the existing resource:"
     cat "\$AUTH_RESP"
@@ -5066,7 +5123,12 @@ if auth_id:
     if auth_id.startswith("projects/"):
         data["authorizationConfig"] = { "agentAuthorization": auth_id }
     else:
-        data["authorizationConfig"] = { "agentAuthorization": f"projects/{project_id}/locations/{location}/authorizations/{auth_id}" }
+        # Authorization resources are ALWAYS created in "global" (see the
+        # setup script), regardless of where the GE app itself lives. Binding
+        # to locations/{location} pointed a "us"/"eu" app at a resource that
+        # does not exist, which reproduces the endless "requires additional
+        # authorization" prompt. Always bind to global. (v11.38)
+        data["authorizationConfig"] = { "agentAuthorization": f"projects/{project_id}/locations/global/authorizations/{auth_id}" }
 auth_path = data.get("authorizationConfig", {}).get("agentAuthorization", "")
 
 def call(method, call_url, payload=None):


### PR DESCRIPTION
## Problem

Demos that enable Workspace authorization could fall into an endless loop: every message came back with the Gemini Enterprise card *"The agent requires additional authorization for: `<demo>-auth`"*, the user completed consent, and the next turn asked again. **Nothing was logged anywhere** — not in the Gemini Enterprise UI, not in Cloud Run, not on the agent side (the card is produced entirely by Gemini Enterprise from the registered `authorizationConfig`).

The failure is always in the **code-to-token exchange**, which Gemini Enterprise performs server-side after consent. Consent itself only validates the `client_id` and the redirect URI, so it succeeds even when the exchange cannot.

## Fixes (all in the generated setup script)

1. **`authorizations.patch` silently no-ops without `updateMask`.** A full-body PATCH returns **HTTP 200 and changes nothing**, so the idempotent update-in-place added in an earlier version never refreshed scopes or the client secret on re-runs — while printing that it had. Now sends `?updateMask=serverSideOauth2` and reads the resource back, because a 200 is not proof the write landed.

2. **OAuth credential pre-flight.** Before wiring the client into Gemini Enterprise, the script probes `https://oauth2.googleapis.com/token` with a throwaway code. `invalid_grant` means the credentials are good (only the fake code was rejected); `invalid_client` means the stored secret was rotated or deleted. On `invalid_client` the script prints the console deep link, offers to re-prompt for a fresh secret, re-verifies it, and stores it as a new Secret Manager version. Non-interactive runs warn and continue.

3. **Authorization resources always live in `global`.** `register_agent.py` bound `locations/{app_location}/authorizations/{id}`, so a Gemini Enterprise app in `us` or `eu` pointed at a resource that does not exist — reproducing the same loop. Now hardcoded to `global`.

Because every demo in a project shares one OAuth client, a rotated secret breaks **all** Workspace-authorization demos at once, which is why the pre-flight matters more than the per-demo symptom suggests.

## Docs

- `README.md` 13.2 — new troubleshooting entry #6: symptom, cause, detection, and the "add a new secret to the existing client" recovery.
- `AGENTS.md` section 6 — the three underlying pitfalls as deployment anti-patterns.

## Verification

- Generated setup scripts for 9 feature-flag combinations (none / Workspace MCP / Workspace auth / computer use / managed agent / all): `bash -n` clean in all 9.
- The auth region of the generated script is **byte-identical** to the internal reference implementation.
- Every Python heredoc in the generated script compiles (`register_agent.py` included).
- `python3 validate_examples.py`: 33/33 template files.
- No `agent_template/` changes — this release is confined to the generation layer.