### PR TITLE
GE Demo Generator: dependency caps, a build-time import smoke test, and constrained third-party installs

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1837,6 +1837,7 @@ Unimicron
 Uniquify
 unlabel
 unmarshal
+unparseable
 unrtf
 unsloth
 Unsloth

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -850,6 +850,7 @@ ipynb
 ipywebrtc
 IRAs
 isa
+isdir
 isess
 itable
 itables
@@ -1145,6 +1146,7 @@ MSGSEND
 msmarco
 msr
 MTL
+multiline
 multitool
 mundo
 Mvar
@@ -1310,6 +1312,7 @@ parseable
 passwort
 pastiched
 Pastra
+pathlib
 payslip
 paystub
 PBA
@@ -1380,6 +1383,7 @@ Pranav
 praw
 prcntg
 PRD
+proc
 Pré
 PREBROWSE
 preds
@@ -1412,6 +1416,7 @@ PYINK
 pymupdf
 pyo
 pypdf
+pypi
 pyplot
 pysftp
 pytorch
@@ -1490,6 +1495,7 @@ resil
 Resona
 retriable
 retryable
+returncode
 ribeye
 ricc
 ringspun
@@ -1640,6 +1646,7 @@ Sparkline
 spearmanr
 SPII
 SPLADE
+splitlines
 sqkm
 sqm
 SRE
@@ -1671,6 +1678,8 @@ stt
 stuffie
 subclip
 SUBLANG
+submodule
+subprocess
 subviews
 subword
 suis
@@ -1717,6 +1726,7 @@ tcd
 TCEHY
 telework
 tema
+tempfile
 tencel
 Tencent
 terabyte
@@ -1830,6 +1840,7 @@ unmarshal
 unrtf
 unsloth
 Unsloth
+unterminated
 upsamples
 upsell
 Upserting

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -211,7 +211,69 @@ branch tip). Delete both properties after the upstream merge.
 ## 7. Verification
 
 - `python3 validate_examples.py` — template JSON + Python compile checks.
+- `python3 check_deps.py` — dependency cap audit (see section 8).
 - `bash -n` any generated setup script before running it.
 - After deploy: Cloud Run startup logs, `✅ N/N MCP sidecars ready`,
   `/.well-known/agent.json` responds, model name shows in the thinking
   accordion.
+
+## 8. Dependency policy
+
+These demos are built live, often minutes before a customer meeting, from
+whatever the resolver picks that day. Two rules keep an upstream release from
+turning that into a failed demo.
+
+### 8.1 Every pip requirement carries a major cap
+
+`PINNED_DEPS` in `app/Code.gs` is the single source of every pip requirement
+the generated script emits. Each entry has an upper bound at the next major.
+
+The floor-only policy this replaced is what let `mcp` 2.0.0 into builds on the
+day it shipped: 2.0.0 removed `mcp.shared.session`, which `google-adk` still
+imports, so every generated container died at import. `google-adk` does declare
+`mcp<2,>=1.24` — but only under its `mcp`/`all`/`test` extras, and we install
+`google-adk[a2a]`, so that cap never applied.
+
+Two things to know before editing a requirement:
+
+- **Cap at the next major above the currently RESOLVED version, not above the
+  floor.** Several bands deliberately span two majors (`google-adk` 1→2,
+  `google-genai` 1→2, `google-cloud-storage` 2→3) because the resolver needs
+  that room to backtrack.
+- **A cap can be a silent downgrade.** `a2a-sdk<1.0.0` looks like containment,
+  but `a2a-sdk` already resolves to 1.1.2 under current ADK — that cap would
+  have pulled it back to 0.3.26.
+
+`agent_template/pyproject.toml` repeats four of these requirements verbatim and
+is copied into the build context, so it must carry the same caps.
+`check_deps.py` fails if it drifts.
+
+### 8.2 The build fails on a broken import, not the container
+
+The generated `dep_smoke_test.py` runs as a Docker build step. It walks the
+generated `adk_agent/` package with `ast`, collects every third-party module
+and symbol the code imports, and resolves each one; imports inside `try/except`
+are treated as optional and skipped. Because it derives its targets from the
+generated sources, it needs no maintenance as feature flags change.
+
+This exists because the failure mode it catches is nearly impossible to
+diagnose at run time: a `ModuleNotFoundError` at import surfaces only as a Cloud Run
+startup probe retrying forever, and the setup script appears to hang at
+"Deploying Main Agent to Cloud Run via Source". Replayed against the `mcp`
+2.0.0 incident, the smoke test names two breaks — the runtime traceback only
+ever reached the first. `uv pip freeze` runs immediately before it so the
+installed versions are in the build log when it fails.
+
+### 8.3 Auditing
+
+`python3 check_deps.py` resolves all three requirement variants (agent,
+agent + computer use, viewer) with the pinned `uv` and reports floor / cap /
+resolved / latest per requirement:
+
+- **MISSING CAP** — a requirement has no upper bound. Policy violation, exit 1.
+- **PYPROJECT** — `agent_template/pyproject.toml` disagrees. Exit 1.
+- **STALE CAP** — a newer major shipped above the cap. Not an error; evaluate
+  it, smoke-deploy, then either raise the cap or record why it stays.
+- **FLOOR DRIFT** — informational, the band spans two majors on purpose.
+
+Add `--offline` to skip the PyPI latest-version lookups.

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -67,6 +67,10 @@ Keep that pattern — do not reintroduce generation-time code selection.
 Dockerfile assembly, deployment). Inside those JS template literals:
 
 - Emit a literal bash `${VAR}` as `\${VAR}`; a literal backtick as `` \` ``.
+  This applies to *prose* inside an emitted Python heredoc too — a comment
+  written in Markdown style ends the enclosing template literal, and the
+  resulting `SyntaxError` points at whatever token follows, never at the
+  backtick. Reword rather than escape.
 - `\` + newline inside a JS template literal is a line continuation (the
   newline disappears from the output). Use it only intentionally.
 - Quoted heredocs (`cat <<'X'`) pass content through verbatim; unquoted
@@ -237,16 +241,35 @@ imports, so every generated container died at import. `google-adk` does declare
 Two things to know before editing a requirement:
 
 - **Cap at the next major above the currently RESOLVED version, not above the
-  floor.** Several bands deliberately span two majors (`google-adk` 1→2,
-  `google-genai` 1→2, `google-cloud-storage` 2→3) because the resolver needs
-  that room to backtrack.
-- **A cap can be a silent downgrade.** `a2a-sdk<1.0.0` looks like containment,
-  but `a2a-sdk` already resolves to 1.1.2 under current ADK — that cap would
-  have pulled it back to 0.3.26.
+  floor** — unless the resolved version is known not to work. Several bands
+  deliberately span two majors (`google-adk` 1→2, `google-genai` 1→2,
+  `google-cloud-storage` 2→3) because the resolver needs that room to
+  backtrack.
+- **What the resolver picks is not evidence that it works.** `a2a-sdk` is
+  capped at `<0.4.0`, below what resolves. `google-adk` 2.5.0 widened its own
+  bound from `a2a-sdk<0.4` to `a2a-sdk<2`, which let 1.x in for the first time;
+  1.x removed `a2a.types.DataPart`, `a2a.server.apps` and
+  `a2a.utils.constants.EXTENDED_AGENT_CARD_PATH`, breaking the a2ui interface
+  check and `fast_api_app.py` at once. ADK 2.5.0 runs fine on 0.3.26, so the
+  cap contains `a2a-sdk` without holding ADK back. Only a build that passes
+  justifies a bound.
 
 `agent_template/pyproject.toml` repeats four of these requirements verbatim and
 is copied into the build context, so it must carry the same caps.
 `check_deps.py` fails if it drifts.
+
+A cap in `requirements.txt` only binds the install *we* issue. When a demo
+imports a custom MCP server, the Dockerfile clones that repo and runs its own
+`uv pip install` into the same site-packages — with bounds we did not write. So
+the script also emits a `constraints.txt` (upper bounds only, derived from the
+same `PINNED_DEPS`) and passes `-c /app/constraints.txt` to both branches of
+that install. Upper bounds only is deliberate: a floor in a constraints file
+can force an *upgrade* inside a resolution we are not steering, including into
+a pre-release; a cap can only ever prevent one. Constraint files may not carry
+extras or direct references, so `[a2a]` / `[agent_engines]` are stripped and
+the a2ui git pin is excluded. Duplicate names are a hard error for pip, which
+is why dropping the floors usefully collapses the two `google-genai` entries
+into one line.
 
 ### 8.2 The build fails on a broken import, not the container
 
@@ -263,6 +286,15 @@ startup probe retrying forever, and the setup script appears to hang at
 2.0.0 incident, the smoke test names two breaks — the runtime traceback only
 ever reached the first. `uv pip freeze` runs immediately before it so the
 installed versions are in the build log when it fails.
+
+**This test must never be the reason a build fails.** It has failed builds on
+its own bugs twice, and both presented as the same endless "Deploying…" as a
+real dependency break — strictly worse than not having the test. A file it
+cannot parse is warned about and skipped, not raised. Its import pairs are
+sorted with `key=lambda pair: (pair[0], pair[1] or "")`, because a plain import
+yields `None` for the symbol and a from-import yields a string; the default
+tuple ordering compares those two against each other the moment both forms
+exist for one module, which is every real agent.
 
 ### 8.3 Auditing
 

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -453,7 +453,8 @@ If sub-agents fail to modify Firestore or pull from BigQuery:
 If the deploy step never returns, the container is almost certainly crashing at import and Cloud Run is retrying the startup probe forever — which produces no obvious error in the script output.
 - **Cause**: a dependency changed its module layout in a new release. Every pip requirement is capped at the next major in `PINNED_DEPS` (`app/Code.gs`) precisely to prevent this, but a package can still break within a major.
 - **Detection**: the Docker build runs `dep_smoke_test.py`, which resolves every third-party module and symbol the generated code imports and **fails the build** naming the offending one. Check the Cloud Build log for `FAIL: dependency import smoke test`; the `uv pip freeze` output printed just above it shows the versions actually installed.
-- **Fix**: cap the offending package below the breaking release in `PINNED_DEPS` and re-run. `python3 check_deps.py` shows the current floor / cap / resolved / latest for every requirement.
+- **Fix**: cap the offending package below the breaking release in `PINNED_DEPS` and re-run. `python3 check_deps.py` shows the current floor / cap / resolved / latest for every requirement. Note that a cap belongs below the last version that is known to *work*, which is not always the newest one the resolver can reach -- `a2a-sdk` is held at `<0.4.0` for exactly this reason.
+- **Imported MCP servers**: cloned MCP server repos install their own dependencies into the same image. The build passes them a generated `constraints.txt` so a third-party requirement cannot upgrade past these caps.
  
 #### 7. Endless "The agent requires additional authorization" Prompt
 If every message comes back with the Gemini Enterprise authorization card, you complete consent, and the very next turn asks again — with no error anywhere in the UI, in Cloud Run, or in the agent logs:

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -302,6 +302,7 @@ ge-demo-generator/
 ├── AGENTS.md                # AI agent development guide
 ├── deploy.sh                # Clasp deployment orchestrator script
 ├── validate_examples.py     # Validates agent_template JSON + Python files
+├── check_deps.py            # Audits the PINNED_DEPS major caps (AGENTS.md 8)
 ├── ge-demo-generator-lite/  # (Subproject) GE Demo Generator Lite — Workspace
 │                            #  demo-data generator for Gemini Enterprise
 │                            #  editions without custom-agent support
@@ -448,7 +449,13 @@ If sub-agents fail to modify Firestore or pull from BigQuery:
   - `roles/bigquery.dataViewer` & `roles/bigquery.jobUser`
   - `roles/aiplatform.user`
  
-#### 6. Endless "The agent requires additional authorization" Prompt
+#### 6. Setup Appears to Hang at "Deploying Main Agent to Cloud Run via Source"
+If the deploy step never returns, the container is almost certainly crashing at import and Cloud Run is retrying the startup probe forever — which produces no obvious error in the script output.
+- **Cause**: a dependency changed its module layout in a new release. Every pip requirement is capped at the next major in `PINNED_DEPS` (`app/Code.gs`) precisely to prevent this, but a package can still break within a major.
+- **Detection**: the Docker build runs `dep_smoke_test.py`, which resolves every third-party module and symbol the generated code imports and **fails the build** naming the offending one. Check the Cloud Build log for `FAIL: dependency import smoke test`; the `uv pip freeze` output printed just above it shows the versions actually installed.
+- **Fix**: cap the offending package below the breaking release in `PINNED_DEPS` and re-run. `python3 check_deps.py` shows the current floor / cap / resolved / latest for every requirement.
+ 
+#### 7. Endless "The agent requires additional authorization" Prompt
 If every message comes back with the Gemini Enterprise authorization card, you complete consent, and the very next turn asks again — with no error anywhere in the UI, in Cloud Run, or in the agent logs:
 - **Cause**: Consent only validates the `client_id` and the redirect URI, so it succeeds even when the code-to-token exchange that Gemini Enterprise performs afterwards fails. The usual reason is a stored OAuth client secret that no longer matches the client (rotated or deleted). Because every demo in a project shares one OAuth client, this breaks **all** Workspace-authorization demos at once.
 - **Detection**: The setup script now probes the token endpoint with a throwaway code before wiring the credentials into Gemini Enterprise. `invalid_grant` means the credentials are good (only the fake code was rejected); `invalid_client` means the secret is stale.

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/pyproject.toml
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/pyproject.toml
@@ -1,7 +1,11 @@
 [project]
 name = "mcp-agent"
 version = "0.1.0"
-dependencies = ["google-adk[a2a]>=1.31.1", "mcp>=1.24.0", "google-genai>=1.27.0", "google-cloud-storage>=2.14.0"]
+# Keep these in sync with PINNED_DEPS in app/Code.gs (adk / mcp / genai /
+# storage). `python3 check_deps.py` fails when they drift apart: a cap only
+# protects the build if BOTH the generated requirements.txt and this file carry
+# it. See AGENTS.md section 8.
+dependencies = ["google-adk[a2a]>=1.31.1,<3.0.0", "mcp>=1.24.0,<2.0.0", "google-genai>=1.27.0,<3.0.0", "google-cloud-storage>=2.14.0,<4.0.0"]
 requires-python = ">=3.10,<3.13"
 [tool.adk]
 project_type = "agent"

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.38-public',
+  APP_VERSION: 'v11.39-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2335,25 +2335,49 @@ function generateSetupScript(params) {
     //   Constraint: a2ui@ade478f requires google-genai>=1.27.0, google-adk>=1.28.1
     a2ui: 'a2ui-agent-sdk @ git+https://github.com/google/A2UI.git@ade478faf8dcad611b5efb6b864dcbfbc4a51f68#subdirectory=agent_sdks/python',
 
-    // Python SDKs -- floor-only (>=) to avoid pip resolution conflicts
-    // Upper bounds are NOT set unless a package has caused a breaking change.
-    adk: 'google-adk[a2a]>=1.31.1',
-    mcp: 'mcp>=1.24.0',
-    genai: 'google-genai>=1.27.0',
-    a2a: 'a2a-sdk>=0.2.0,<1.0.0',
+    // == MAJOR-CAP POLICY (v11.39) ==
+    // EVERY pip requirement below carries an upper bound at the next major.
+    // The old policy ("upper bounds are NOT set unless a package has caused a
+    // breaking change") is what let mcp 2.0.0 into a build the day it shipped
+    // and crash every container at import -- see AGENTS.md section 8.
+    // Rationale: these demos are built live, minutes before a customer meeting.
+    // A cap turns an unpredictable upstream break into a predictable freeze we
+    // lift on our own schedule. Never remove a cap without a full smoke deploy.
+    //
+    // Caps are placed at the next major ABOVE THE CURRENTLY RESOLVED version,
+    // not above the floor. Where the two differ (adk 1->2, genai 1->2,
+    // storage 2->3) the band deliberately spans both majors: the resolver
+    // needs that room to backtrack, which is load-bearing for the non-
+    // computer-use build path (see the cuOtelGcp* comment below).
+    //
+    // Run `python3 check_deps.py` to see floor / cap / resolved / latest and
+    // which caps have gone stale.
+    adk: 'google-adk[a2a]>=1.31.1,<3.0.0',
+    // mcp <2.0.0 cap (v11.39): mcp 2.0.0 (2026-07-28) removed mcp.shared.session,
+    // which google-adk still imports (mcp_toolset.py: from mcp.shared.session
+    // import ProgressFnT) -> container crashes at import with ModuleNotFoundError.
+    // google-adk declares mcp<2,>=1.24 itself, but only under the mcp/all/test
+    // extras -- we install google-adk[a2a], so that cap never applies and our
+    // floor-only line resolved to 2.0.0. Keep the cap until ADK supports mcp 2.x.
+    mcp: 'mcp>=1.24.0,<2.0.0',
+    genai: 'google-genai>=1.27.0,<3.0.0',
+    // <2.0.0, not <1.0.0: a2a-sdk already resolves to 1.1.2 under adk 2.5.0, so
+    // a 1.x cap would be a silent DOWNGRADE to 0.3.26, not containment.
+    a2a: 'a2a-sdk>=0.2.0,<2.0.0',
 
-    // Google Cloud SDKs -- stable, floor-only
-    aiplatform: 'google-cloud-aiplatform[agent_engines]>=1.112.0',
-    storage: 'google-cloud-storage>=2.14.0',
-    scheduler: 'google-cloud-scheduler>=2.0.0',
-    pubsub: 'google-cloud-pubsub>=2.0.0',
-    firestore: 'google-cloud-firestore>=2.16.0',
-    logging: 'google-cloud-logging>=3.0.0',
+    // Google Cloud SDKs -- stable, but majors do land (storage crossed 2.x -> 3.x
+    // unnoticed under the old floor-only policy).
+    aiplatform: 'google-cloud-aiplatform[agent_engines]>=1.112.0,<2.0.0',
+    storage: 'google-cloud-storage>=2.14.0,<4.0.0',
+    scheduler: 'google-cloud-scheduler>=2.0.0,<3.0.0',
+    pubsub: 'google-cloud-pubsub>=2.0.0,<3.0.0',
+    firestore: 'google-cloud-firestore>=2.16.0,<3.0.0',
+    logging: 'google-cloud-logging>=3.0.0,<4.0.0',
 
-    // Utilities -- floor-only
-    dotenv: 'python-dotenv>=1.0.0',
-    dbDtypes: 'db-dtypes>=1.0.0',
-    otel: 'opentelemetry-api>=1.20.0',
+    // Utilities
+    dotenv: 'python-dotenv>=1.0.0,<2.0.0',
+    dbDtypes: 'db-dtypes>=1.0.0,<2.0.0',
+    otel: 'opentelemetry-api>=1.20.0,<2.0.0',
 
     // Build tools -- exact pin (infrastructure, not pip-resolved)
     pythonImage: 'python:3.11.12-slim',
@@ -2361,10 +2385,10 @@ function generateSetupScript(params) {
     uvVersion: '0.11.17',
     supergateway: 'supergateway@3.4.3',
 
-    // Viewer app -- floor-only
-    viewerFunctionsFramework: 'functions-framework>=3.5.0',
-    viewerFlask: 'flask>=3.0.3',
-    viewerFirestore: 'google-cloud-firestore>=2.16.0',
+    // Viewer app
+    viewerFunctionsFramework: 'functions-framework>=3.5.0,<4.0.0',
+    viewerFlask: 'flask>=3.0.3,<4.0.0',
+    viewerFirestore: 'google-cloud-firestore>=2.16.0,<3.0.0',
 
     // Computer Use (browser agent) -- only added when enableComputerUse is set.
     // playwright pin matches the official reference impl
@@ -2372,7 +2396,7 @@ function generateSetupScript(params) {
     // to the version exposing types.ComputerUse/types.Environment for the
     // generate_content computer_use tool config.
     playwright: 'playwright==1.55.0',
-    genaiComputerUse: 'google-genai>=2.7.0',
+    genaiComputerUse: 'google-genai>=2.7.0,<3.0.0',
     // (v11.36) google-genai>=2.7.0 is only satisfiable with recent
     // google-cloud-aiplatform releases (older ones cap google-genai<2.0.0),
     // and those releases depend on Google Cloud OTel packages whose satisfying
@@ -2383,8 +2407,8 @@ function generateSetupScript(params) {
     // explicit pre-release floors scopes pre-release resolution to exactly
     // these two packages (unlike --prerelease=allow, which would also pull
     // mcp/pydantic pre-releases).
-    cuOtelGcpLogging: 'opentelemetry-exporter-gcp-logging>=1.12.0a0',
-    cuOtelGcpResourceDetector: 'opentelemetry-resourcedetector-gcp>=1.12.0a0',
+    cuOtelGcpLogging: 'opentelemetry-exporter-gcp-logging>=1.12.0a0,<2.0.0',
+    cuOtelGcpResourceDetector: 'opentelemetry-resourcedetector-gcp>=1.12.0a0,<2.0.0',
   };
 
   
@@ -2514,7 +2538,7 @@ if __name__ == '__main__':
     init_data()
 __PY_EOF__\n`;
 
-    firestoreCommands += `uv run --with google-cloud-firestore python setup_fs.py\n`;
+    firestoreCommands += `uv run --no-project --with "${PINNED_DEPS.firestore}" python setup_fs.py\n`;
     firestoreCommands += `rm setup_fs.py\n\n`;
 
     firestoreCommands += `echo "🌐 Deploying Real-time Data Viewer Web App (Cloud Run Functions)..."\n`;
@@ -3471,7 +3495,7 @@ ${ enableManagedAgent ? `
     echo ""
     echo "🔥 Deleting Firestore Collection: ${fsCollection}..."
     if command -v uv >/dev/null 2>&1; then
-      GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --with google-cloud-firestore python3 -c "from google.cloud import firestore; db=firestore.Client(); [d.reference.delete() for d in db.collection('${fsCollection}').stream()]" 2>/dev/null && echo "   ✅ Firestore documents in collection deleted." || echo "   ⚠️  Could not clear Firestore collection automatically."
+      GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" python3 -c "from google.cloud import firestore; db=firestore.Client(); [d.reference.delete() for d in db.collection('${fsCollection}').stream()]" 2>/dev/null && echo "   ✅ Firestore documents in collection deleted." || echo "   ⚠️  Could not clear Firestore collection automatically."
     fi
 
     echo ""
@@ -3627,7 +3651,7 @@ ${ enableManagedAgent ? `
 
     echo ""
     echo "📁 Deleting Firestore task collections..."
-    GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with google-cloud-firestore python3 -c "
+    GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" python3 -c "
 from google.cloud import firestore
 db = firestore.Client()
 for coll_name in ['${dirName}_task_definitions', '${dirName}_task_executions', '${dirName}_task_push_configs']:
@@ -4359,6 +4383,103 @@ COPY requirements.txt pyproject.toml ./
 RUN uv pip install --system -r requirements.txt
 __DOCKER_EOF__
 
+# Generate the build-time dependency import smoke test (v11.39).
+# Self-maintaining: it derives what to check from the generated sources, so it
+# stays correct for every feature-flag combination without being updated.
+cat <<'__DEP_SMOKE_EOF__' > dep_smoke_test.py
+"""Dependency import smoke test, executed during the Docker build.
+
+Walks the generated agent package, collects every third-party module and
+symbol the code imports, and resolves each one. When a dependency changes its
+module layout under us -- e.g. mcp 2.0.0 removing mcp.shared.session, which
+google-adk imports -- the BUILD fails here naming the offending module,
+instead of the container dying on import and surfacing only as a Cloud Run
+startup probe that retries forever. See AGENTS.md section 8.
+
+Imports inside a try/except are treated as optional and skipped, so genuinely
+optional integrations do not break the build.
+"""
+import ast
+import importlib
+import os
+import sys
+
+PKG_ROOT = 'adk_agent'
+LOCAL_ROOTS = ('adk_agent', 'app')
+
+
+def collect(path):
+    """Return (module, symbol_or_None) pairs for non-optional third-party imports."""
+    with open(path, 'r', encoding='utf-8') as handle:
+        tree = ast.parse(handle.read(), filename=path)
+
+    optional = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for inner in ast.walk(node):
+                if isinstance(inner, (ast.Import, ast.ImportFrom)):
+                    optional.add(id(inner))
+
+    found = set()
+    for node in ast.walk(tree):
+        if id(node) in optional:
+            continue
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                found.add((alias.name, None))
+        elif isinstance(node, ast.ImportFrom):
+            # level > 0 is a relative import of our own package
+            if node.level or not node.module:
+                continue
+            for alias in node.names:
+                symbol = None if alias.name == '*' else alias.name
+                found.add((node.module, symbol))
+    return set(p for p in found if p[0].split('.')[0] not in LOCAL_ROOTS)
+
+
+def resolve(module, symbol):
+    obj = importlib.import_module(module)
+    if symbol is None or hasattr(obj, symbol):
+        return
+    # Submodule that has not been imported yet is not an attribute yet.
+    importlib.import_module(module + '.' + symbol)
+
+
+def main():
+    if not os.path.isdir(PKG_ROOT):
+        print('Dep smoke test SKIPPED: no ' + PKG_ROOT + ' directory')
+        return 0
+
+    pairs = set()
+    for root, _dirs, files in os.walk(PKG_ROOT):
+        for name in files:
+            if name.endswith('.py'):
+                pairs |= collect(os.path.join(root, name))
+
+    failures = []
+    for module, symbol in sorted(pairs):
+        try:
+            resolve(module, symbol)
+        except Exception as exc:
+            target = module if symbol is None else module + '.' + symbol
+            failures.append(target + ' -> ' + type(exc).__name__ + ': ' + str(exc))
+
+    if failures:
+        print('FAIL: dependency import smoke test (' + str(len(failures)) + ' broken)')
+        for line in failures:
+            print('  ' + line)
+        print('A dependency changed its module layout. Check PINNED_DEPS caps')
+        print('in Code.gs against the installed versions in /app/.dep-versions.')
+        return 1
+
+    print('Dep smoke test OK (' + str(len(pairs)) + ' imports resolved)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+__DEP_SMOKE_EOF__
+
 ${ enableComputerUse ? `
 # -- Computer Use: install Chromium + OS libs for headless Playwright browsing --
 cat <<'__DOCKER_CU_EOF__' >> Dockerfile
@@ -4500,10 +4621,15 @@ __DOCKER_START_EOF__`;
 
 cat <<'__DOCKER_TAIL_EOF__' >> Dockerfile
 COPY . .
-# Dependency smoke test: fail build if critical interface missing
-RUN python -c "from a2ui.a2a.parts import create_a2ui_part; import inspect; assert 'version' in inspect.signature(create_a2ui_part).parameters, 'FAIL: a2ui version param missing'; print('Dep smoke test OK')"
-# Record installed versions for debugging
+# Record installed versions FIRST so they are in the build log even when the
+# smoke test below fails -- that pairing is what makes a break easy to trace.
 RUN uv pip freeze | grep -iE "^(google-adk|a2ui|mcp|google-genai|a2a-sdk)" | tee /app/.dep-versions
+# Dependency import smoke test (v11.39): resolves every third-party module and
+# symbol the generated code imports. Catches an upstream module-layout change
+# at BUILD time instead of as a stalled Cloud Run startup probe. AGENTS.md 8.
+RUN python dep_smoke_test.py
+# a2ui interface check: module import alone cannot see a dropped parameter.
+RUN python -c "from a2ui.a2a.parts import create_a2ui_part; import inspect; assert 'version' in inspect.signature(create_a2ui_part).parameters, 'FAIL: a2ui version param missing'; print('a2ui interface OK')"
 ENV PORT 8080
 ENV GOOGLE_GENAI_USE_VERTEXAI=1
 ENV PYTHONUNBUFFERED=1
@@ -4568,7 +4694,7 @@ export SANDBOX_OUT="/tmp/sandbox_result_$$.txt"
 # If Dockerfile/MCP files exist in CWD, the SDK tries to build them → hang.
 SANDBOX_TMPDIR=$(mktemp -d)
 pushd "$SANDBOX_TMPDIR" > /dev/null
-GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "google-cloud-aiplatform[agent_engines]>=1.112.0" python3 << '__SANDBOX_PROVISION_EOF__'
+GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.aiplatform}" python3 << '__SANDBOX_PROVISION_EOF__'
 import sys, os, warnings, time, vertexai
 from vertexai import types
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.39-public',
+  APP_VERSION: 'v11.41-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2361,9 +2361,25 @@ function generateSetupScript(params) {
     // floor-only line resolved to 2.0.0. Keep the cap until ADK supports mcp 2.x.
     mcp: 'mcp>=1.24.0,<2.0.0',
     genai: 'google-genai>=1.27.0,<3.0.0',
-    // <2.0.0, not <1.0.0: a2a-sdk already resolves to 1.1.2 under adk 2.5.0, so
-    // a 1.x cap would be a silent DOWNGRADE to 0.3.26, not containment.
-    a2a: 'a2a-sdk>=0.2.0,<2.0.0',
+    // a2a-sdk <0.4.0 (v11.41). google-adk 2.5.0 (2026-07-16) widened its own
+    // bound from `a2a-sdk<0.4` to `a2a-sdk<2`, which let a2a-sdk 1.x into the
+    // build for the first time. a2a-sdk 1.x is not backward compatible and
+    // breaks three things at once:
+    //   a2a.types.DataPart                    removed -> a2ui@ade478f fails to
+    //                                         import (the Dockerfile's a2ui
+    //                                         interface check catches this)
+    //   a2a.server.apps                       removed -> fast_api_app.py cannot
+    //                                         import A2AFastAPIApplication
+    //   a2a.utils.constants.EXTENDED_AGENT_CARD_PATH  removed
+    // Verified 2026-07-29 against a2a-sdk 1.1.2. adk 2.5.0 still runs fine on
+    // a2a-sdk 0.3.26, so the cap contains a2a without holding back adk.
+    //
+    // v11.39 wrote <2.0.0 here on the reasoning that 1.1.2 was already
+    // resolving and a 1.x cap would be a "silent downgrade". That was backwards:
+    // the downgrade to 0.3.26 is the CORRECT outcome, because 1.x does not work
+    // at all. "Already resolving" is not evidence that a version works -- only
+    // a build that passes is. See AGENTS.md section 8.1.
+    a2a: 'a2a-sdk>=0.3.4,<0.4.0',
 
     // Google Cloud SDKs -- stable, but majors do land (storage crossed 2.x -> 3.x
     // unnoticed under the old floor-only policy).
@@ -2411,7 +2427,50 @@ function generateSetupScript(params) {
     cuOtelGcpResourceDetector: 'opentelemetry-resourcedetector-gcp>=1.12.0a0,<2.0.0',
   };
 
-  
+  // == constraints.txt (v11.40) ==
+  // Caps in requirements.txt only bind the install WE issue. Cloned custom MCP
+  // server repos run their own `uv pip install` inside the same image (see the
+  // __DOCKER_MCP_INSTALL_*__ layers), and a vendored `mcp>=2` in someone else's
+  // requirements.txt would upgrade straight past our cap and reintroduce the
+  // exact ModuleNotFoundError the cap exists to prevent -- in a layer we do not
+  // control and did not write. Passing -c makes the caps apply image-wide.
+  //
+  // UPPER BOUNDS ONLY. A floor in a constraints file can force an upgrade --
+  // including into a pre-release, the trap the cuOtelGcp* comment above
+  // describes -- inside a resolution we are not steering. A cap can only ever
+  // prevent one, so the file is purely protective and cannot make a
+  // third-party install fail in a way our own build would not. Dropping the
+  // floors also collapses the two
+  // google-genai entries (>=1.27.0 and the computer-use >=2.7.0) to one line;
+  // duplicate names in a constraints file are a hard error for pip.
+  //
+  // Constraint files may not carry extras or direct references, so the a2ui git
+  // pin is excluded and `[a2a]` / `[agent_engines]` are stripped. A constraint
+  // on a package that is never installed is a no-op, so listing the
+  // computer-use entries unconditionally is safe and keeps the file identical
+  // across feature-flag combinations.
+  const CONSTRAINT_KEYS = [
+    'adk', 'mcp', 'genai', 'a2a', 'aiplatform', 'storage', 'scheduler',
+    'pubsub', 'firestore', 'logging', 'dotenv', 'dbDtypes', 'otel',
+    'playwright', 'genaiComputerUse', 'cuOtelGcpLogging', 'cuOtelGcpResourceDetector',
+  ];
+  const constraintLines = [];
+  CONSTRAINT_KEYS.forEach(key => {
+    const spec = PINNED_DEPS[key];
+    if (!spec || spec.indexOf(' @ ') !== -1) return;
+    const parsed = spec.match(/^([A-Za-z0-9._-]+)(?:\[[^\]]*\])?(.*)$/);
+    if (!parsed) return;
+    const name = parsed[1];
+    const bounds = (parsed[2] || '').split(',')
+      .map(part => part.trim())
+      .filter(part => part.charAt(0) === '<' || part.substring(0, 2) === '==');
+    if (!bounds.length) return;
+    if (constraintLines.some(line => line.name === name)) return;
+    constraintLines.push({ name: name, text: name + bounds.join(',') });
+  });
+  const constraintsTxt = constraintLines.map(line => line.text).join('\n');
+
+
   const escapedInstruction = systemInstruction
     .replace(/\\/g, '\\\\\\\\')
     .replace(/'/g, "'\\''")
@@ -4364,6 +4423,12 @@ ${PINNED_DEPS.otel}
 ${ enableComputerUse ? `${PINNED_DEPS.playwright}\n${PINNED_DEPS.genaiComputerUse}\n${PINNED_DEPS.cuOtelGcpLogging}\n${PINNED_DEPS.cuOtelGcpResourceDetector}` : '' }
 __REQ_EOF__
 
+# Generate constraints.txt -- applied to third-party installs inside the image
+# (cloned MCP server repos) so their own requirements cannot break our caps.
+cat <<'__CONSTRAINTS_EOF__' > constraints.txt
+${constraintsTxt}
+__CONSTRAINTS_EOF__
+
 # Generate pyproject.toml required for adk project type
 cp "$GE_TPL/pyproject.toml" pyproject.toml
 
@@ -4379,7 +4444,7 @@ FROM ${PINNED_DEPS.pythonImage}
 COPY --from=${PINNED_DEPS.uvImage} /uv /uvx /bin/
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY requirements.txt pyproject.toml ./
+COPY requirements.txt constraints.txt pyproject.toml ./
 RUN uv pip install --system -r requirements.txt
 __DOCKER_EOF__
 
@@ -4411,7 +4476,14 @@ LOCAL_ROOTS = ('adk_agent', 'app')
 def collect(path):
     """Return (module, symbol_or_None) pairs for non-optional third-party imports."""
     with open(path, 'r', encoding='utf-8') as handle:
-        tree = ast.parse(handle.read(), filename=path)
+        source = handle.read()
+    try:
+        tree = ast.parse(source, filename=path)
+    except SyntaxError as exc:
+        # A file we cannot parse is not a dependency problem. Warn and move on:
+        # this test must never be the reason a build fails.
+        print('  ! skipped ' + path + ' (unparseable: ' + str(exc) + ')')
+        return set()
 
     optional = set()
     for node in ast.walk(tree):
@@ -4457,7 +4529,10 @@ def main():
                 pairs |= collect(os.path.join(root, name))
 
     failures = []
-    for module, symbol in sorted(pairs):
+    # Sort on (module, symbol or '') -- a plain import yields symbol None and a
+    # from-import yields a str, and the default tuple ordering compares the two
+    # against each other the moment both forms exist for one module.
+    for module, symbol in sorted(pairs, key=lambda pair: (pair[0], pair[1] or '')):
         try:
             resolve(module, symbol)
         except Exception as exc:
@@ -4513,7 +4588,11 @@ RUN git clone ${mcp.github_url} ${mcpDir}
 __DOCKER_MCP_CLONE_${idx}_EOF__
 `;
     let installStep;
-    const pipCmd = `(if [ -f pyproject.toml ] || [ -f setup.py ]; then uv pip install --system . 2>/dev/null || true; elif [ -f requirements.txt ]; then uv pip install --system -r requirements.txt; fi)`;
+    // -c /app/constraints.txt (v11.40): this installs a repo we did not write,
+    // with dependency bounds we did not choose, into the same site-packages the
+    // agent imports from. Without the constraints file a vendored `mcp>=2` here
+    // silently upgrades past our cap and the container dies at import.
+    const pipCmd = `(if [ -f pyproject.toml ] || [ -f setup.py ]; then uv pip install --system -c /app/constraints.txt . 2>/dev/null || true; elif [ -f requirements.txt ]; then uv pip install --system -c /app/constraints.txt -r requirements.txt; fi)`;
     const npmCmd = `(npm install && npm run build 2>/dev/null || true)`;
     const ign = mcp.npm_ignore_scripts ? 'ENV NPM_CONFIG_IGNORE_SCRIPTS=true\n' : '';
     if (isNodejs) {

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -2430,7 +2430,7 @@ function generateSetupScript(params) {
   // == constraints.txt (v11.40) ==
   // Caps in requirements.txt only bind the install WE issue. Cloned custom MCP
   // server repos run their own `uv pip install` inside the same image (see the
-  // __DOCKER_MCP_INSTALL_*__ layers), and a vendored `mcp>=2` in someone else's
+  // __DOCKER_MCP_INSTALL_*__ layers), and an `mcp>=2` pinned in someone else's
   // requirements.txt would upgrade straight past our cap and reintroduce the
   // exact ModuleNotFoundError the cap exists to prevent -- in a layer we do not
   // control and did not write. Passing -c makes the caps apply image-wide.
@@ -4590,8 +4590,8 @@ __DOCKER_MCP_CLONE_${idx}_EOF__
     let installStep;
     // -c /app/constraints.txt (v11.40): this installs a repo we did not write,
     // with dependency bounds we did not choose, into the same site-packages the
-    // agent imports from. Without the constraints file a vendored `mcp>=2` here
-    // silently upgrades past our cap and the container dies at import.
+    // agent imports from. Without the constraints file an `mcp>=2` pinned in
+    // that repo upgrades past our cap and the container dies at import.
     const pipCmd = `(if [ -f pyproject.toml ] || [ -f setup.py ]; then uv pip install --system -c /app/constraints.txt . 2>/dev/null || true; elif [ -f requirements.txt ]; then uv pip install --system -c /app/constraints.txt -r requirements.txt; fi)`;
     const npmCmd = `(npm install && npm run build 2>/dev/null || true)`;
     const ign = mcp.npm_ignore_scripts ? 'ENV NPM_CONFIG_IGNORE_SCRIPTS=true\n' : '';

--- a/search/gemini-enterprise/ge-demo-generator/check_deps.py
+++ b/search/gemini-enterprise/ge-demo-generator/check_deps.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dependency cap audit for PINNED_DEPS in Code.gs.
+
+The major-cap policy (AGENTS.md section 8) says every pip requirement in
+PINNED_DEPS carries an upper bound at the next major. Caps stop an upstream
+release from breaking a live demo build, but they are also freezes: without
+something that reports them, they rot silently. `a2a-sdk<1.0.0` sat on 0.3.26
+while 1.x shipped and nobody noticed.
+
+This script reconstructs the generated requirements.txt (both the plain and the
+computer-use variant), resolves each with the pinned uv, and reports:
+
+  MISSING CAP   a requirement has no upper bound        -> policy violation, exit 1
+  STALE CAP     a newer major exists above the cap      -> review, smoke deploy
+  DRIFT         floor is a major behind what resolves   -> informational
+  PYPROJECT     agent_template/pyproject.toml disagrees        -> exit 1
+
+Usage:
+    python3 check_deps.py            # audit
+    python3 check_deps.py --offline  # skip PyPI, resolve + cap check only
+"""
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).parent
+CODE_GS = HERE / "app" / "Code.gs"
+# The agent template ships a static pyproject.toml that repeats four of the
+# PINNED_DEPS requirements; a cap only protects the build if both carry it.
+PYPROJECT = HERE / "agent_template" / "pyproject.toml"
+# PINNED_DEPS key -> the requirement pyproject.toml must repeat verbatim.
+PYPROJECT_KEYS = ("adk", "mcp", "genai", "storage")
+
+# PINNED_DEPS keys that are not pip requirements.
+NON_PIP_KEYS = {"pythonImage", "uvImage", "uvVersion", "supergateway"}
+# Keys emitted only in the enableComputerUse branch of the requirements heredoc.
+COMPUTER_USE_KEYS = {
+    "playwright",
+    "genaiComputerUse",
+    "cuOtelGcpLogging",
+    "cuOtelGcpResourceDetector",
+}
+# Keys that go into the separate viewer_app/requirements.txt, not the agent's.
+VIEWER_KEYS = {"viewerFunctionsFramework", "viewerFlask", "viewerFirestore"}
+
+REQ_SPEC = re.compile(
+    r"^(?P<name>[A-Za-z0-9._-]+)"
+    r"(?P<extras>\[[^\]]*\])?"
+    r"(?P<spec>.*)$"
+)
+
+
+def parse_pinned_deps(text):
+    """Extract PINNED_DEPS as an ordered list of (key, value) pairs."""
+    start = text.index("const PINNED_DEPS = {")
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                body = text[start : i + 1]
+                break
+    else:
+        raise SystemExit("check_deps: could not find the end of PINNED_DEPS")
+
+    body = re.sub(r"^\s*//.*$", "", body, flags=re.MULTILINE)
+    pairs = re.findall(r"^\s*([A-Za-z][A-Za-z0-9]*)\s*:\s*'([^']*)'", body, re.MULTILINE)
+    if not pairs:
+        raise SystemExit("check_deps: PINNED_DEPS parsed but no entries found")
+    return pairs
+
+
+def split_spec(value):
+    """Return (name, floor, cap, exact) for a pip requirement string."""
+    if " @ " in value:  # direct URL / git reference
+        return value.split(" @ ", 1)[0].strip(), None, None, False
+    match = REQ_SPEC.match(value.strip())
+    name = match.group("name")
+    spec = match.group("spec")
+    floor = None
+    cap = None
+    exact = False
+    for part in spec.split(","):
+        part = part.strip()
+        if part.startswith(">="):
+            floor = part[2:]
+        elif part.startswith("=="):
+            floor = cap = part[2:]
+            exact = True
+        elif part.startswith("<="):
+            cap = part[2:]
+        elif part.startswith("<"):
+            cap = part[1:]
+    return name, floor, cap, exact
+
+
+def major(version):
+    if not version:
+        return None
+    head = re.match(r"(\d+)", version)
+    return int(head.group(1)) if head else None
+
+
+def pinned_uv(uv_version):
+    """Prefer the uv version the Docker build uses, so resolutions match."""
+    candidate = ["uvx", "uv@" + uv_version, "pip", "compile"]
+    try:
+        probe = subprocess.run(
+            ["uvx", "uv@" + uv_version, "--version"],
+            capture_output=True, text=True, timeout=180,
+        )
+        if probe.returncode == 0:
+            return candidate, uv_version
+    except (OSError, subprocess.SubprocessError):
+        pass
+    try:
+        local = subprocess.run(["uv", "--version"], capture_output=True, text=True, timeout=60)
+        local_v = local.stdout.strip().split()[1] if local.returncode == 0 else "unknown"
+    except (OSError, subprocess.SubprocessError, IndexError):
+        raise SystemExit("check_deps: uv is not installed (https://docs.astral.sh/uv/)")
+    print("  ! uv " + uv_version + " unavailable; falling back to local uv " + local_v)
+    print("    Resolutions may differ from the Docker build.")
+    return ["uv", "pip", "compile"], local_v
+
+
+def resolve(requirements, uv_cmd):
+    """Run uv pip compile and return {name: version}, or None if it failed."""
+    with tempfile.TemporaryDirectory() as tmp:
+        req = Path(tmp) / "requirements.txt"
+        req.write_text("\n".join(requirements) + "\n", encoding="utf-8")
+        out = Path(tmp) / "out.txt"
+        proc = subprocess.run(
+            uv_cmd + ["--quiet", "--python-version", "3.11", str(req), "-o", str(out)],
+            capture_output=True, text=True, timeout=900,
+        )
+        if proc.returncode != 0:
+            return None, proc.stderr.strip()
+        resolved = {}
+        for line in out.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            if "==" in line:
+                name, _, version = line.partition("==")
+                resolved[name.strip().lower()] = version.strip()
+        return resolved, None
+
+
+def pypi_latest(name):
+    url = "https://pypi.org/pypi/" + name + "/json"
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            return json.load(response)["info"]["version"]
+    except (urllib.error.URLError, KeyError, ValueError, TimeoutError):
+        return None
+
+
+def check_pyproject(values):
+    """agent_template/pyproject.toml repeats four PINNED_DEPS requirements.
+
+    The generated requirements.txt is built from PINNED_DEPS, but pyproject.toml
+    is a static template file that is copied verbatim into the build context. If
+    the two disagree, a cap that looks applied in Code.gs is not actually
+    protecting the ADK project install. Fail loudly rather than let them rot.
+    """
+    if not PYPROJECT.is_file():
+        return ["missing " + str(PYPROJECT)]
+    text = PYPROJECT.read_text(encoding="utf-8")
+    match = re.search(r"^dependencies\s*=\s*\[", text, re.MULTILINE)
+    if not match:
+        return ["could not parse the dependencies list in " + PYPROJECT.name]
+    # Scan for the closing bracket by depth: requirement strings contain their
+    # own brackets (google-adk[a2a]), so a non-greedy .*?\] stops too early.
+    depth = 0
+    end = None
+    for i in range(match.end() - 1, len(text)):
+        if text[i] == "[":
+            depth += 1
+        elif text[i] == "]":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    if end is None:
+        return ["unterminated dependencies list in " + PYPROJECT.name]
+    declared = set(re.findall(r'"([^"]+)"', text[match.end():end]))
+    problems = []
+    for key in PYPROJECT_KEYS:
+        expected = values.get(key)
+        if expected and expected not in declared:
+            problems.append(PYPROJECT.name + " is missing " + expected)
+    return problems
+
+
+def main():
+    offline = "--offline" in sys.argv
+    text = CODE_GS.read_text(encoding="utf-8")
+    pairs = parse_pinned_deps(text)
+    values = dict(pairs)
+
+    uv_cmd, uv_used = pinned_uv(values.get("uvVersion", "0.11.17"))
+    print("Resolving with uv " + uv_used + " (Dockerfile pins " + values.get("uvVersion", "?") + ")")
+
+    agent_keys = [k for k, _ in pairs if k not in NON_PIP_KEYS and k not in VIEWER_KEYS]
+    base_keys = [k for k in agent_keys if k not in COMPUTER_USE_KEYS]
+
+    variants = {
+        "agent": [values[k] for k in base_keys],
+        "agent+computer-use": [values[k] for k in agent_keys],
+        "viewer": [values[k] for k in VIEWER_KEYS],
+    }
+
+    resolutions = {}
+    for label, requirements in variants.items():
+        resolved, error = resolve(requirements, uv_cmd)
+        if resolved is None:
+            print("\n  X " + label + " FAILED to resolve:\n" + (error or "")[:2000])
+            return 1
+        print("  - " + label + ": " + str(len(resolved)) + " packages resolved")
+        resolutions[label] = resolved
+
+    pyproject_problems = check_pyproject(values)
+
+    missing_cap = []
+    stale_cap = []
+    pin_lag = []
+    drift = []
+
+    print("")
+    header = "{:<38}{:<14}{:<10}{:<11}{:<11}{}".format(
+        "requirement", "floor", "cap", "resolved", "latest", "note"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for key, value in pairs:
+        if key in NON_PIP_KEYS:
+            continue
+        name, floor, cap, exact = split_spec(value)
+        if floor is None and cap is None and " @ " in value:
+            print("{:<38}{:<14}{:<10}{:<11}{:<11}{}".format(
+                name[:37], "(git pin)", "-", "-", "-", "commit-pinned, exempt"))
+            continue
+
+        resolved = "-"
+        for label, table in resolutions.items():
+            if name.lower() in table:
+                resolved = table[name.lower()]
+                break
+
+        latest = "-" if offline else (pypi_latest(name) or "?")
+        notes = []
+
+        if exact:
+            # An exact pin is a deliberate choice (matching a reference impl),
+            # not a cap. Report how far behind it has fallen, nothing more.
+            if latest not in ("-", "?", None) and latest != cap:
+                notes.append("exact pin, latest is " + latest)
+                pin_lag.append(name + "==" + str(cap) + " vs latest " + latest)
+            else:
+                notes.append("exact pin")
+        elif cap is None:
+            notes.append("MISSING CAP")
+            missing_cap.append(name)
+        elif latest not in ("-", "?", None):
+            if major(latest) is not None and major(cap) is not None and major(latest) >= major(cap):
+                notes.append("STALE CAP (latest " + latest + " is above the cap)")
+                stale_cap.append(name + " cap<" + cap + " vs latest " + latest)
+
+        if resolved != "-" and floor and major(resolved) != major(floor):
+            notes.append("floor is major " + str(major(floor)) + ", resolves to " + str(major(resolved)))
+            drift.append(name + " floor " + floor + " -> resolved " + resolved)
+
+        print("{:<38}{:<14}{:<10}{:<11}{:<11}{}".format(
+            name[:37], floor or "-", cap or "-", resolved, latest, "; ".join(notes)))
+
+    print("")
+    if missing_cap:
+        print("X POLICY VIOLATION: no upper bound on " + ", ".join(missing_cap))
+        print("  Every pip requirement in PINNED_DEPS must cap the next major.")
+        print("  See AGENTS.md section 8.")
+    if stale_cap:
+        print("! STALE CAPS (a cap is now freezing you below a released major):")
+        for item in stale_cap:
+            print("    " + item)
+        print("  Not an error. Evaluate with a full smoke deploy, then")
+        print("  either raise the cap or record why it stays.")
+    if pin_lag:
+        print("i EXACT PINS behind latest (deliberate; upgrade only on purpose):")
+        for item in pin_lag:
+            print("    " + item)
+    if drift:
+        print("i FLOOR DRIFT (informational -- the band spans two majors):")
+        for item in drift:
+            print("    " + item)
+    if pyproject_problems:
+        print("X DRIFT: agent_template/pyproject.toml disagrees with PINNED_DEPS:")
+        for item in pyproject_problems:
+            print("    " + item)
+        print("  Both files reach the build context; a cap in only one of them")
+        print("  does not protect the ADK project install.")
+    if not (missing_cap or stale_cap or pin_lag or drift or pyproject_problems):
+        print("OK All requirements capped and mirrored, no stale caps, no drift.")
+
+    return 1 if (missing_cap or pyproject_problems) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

A `mcp` 2.0.0 release moved `mcp.shared._httpx_utils`, which the ADK MCP toolset imports. Because every pip requirement in this sample was floor-only (`mcp>=1.24.0`), a fresh build silently picked up the new major and the container failed to import at startup. The only symptom was a Cloud Run startup probe retrying forever -- the setup script appeared to hang at "Deploying Main Agent to Cloud Run via Source", with no useful error in the deploy log.

Three commits' worth of fixes, all in this one PR.

### Major caps

Every requirement in `PINNED_DEPS` now carries an upper bound. Caps are placed above the currently *resolved* major, not the floor -- several bands legitimately span two majors (`google-adk>=1.31.1` resolves to 2.5.0 today), so capping at the floor's major would be a silent downgrade. Exact pins and commit-pinned git requirements are left alone. `agent_template/pyproject.toml` carries the same caps: a cap only protects the build if both the generated `requirements.txt` and the ADK project install have it.

One cap deliberately sits *below* what resolves. `google-adk` 2.5.0 widened its own bound from `a2a-sdk<0.4` to `a2a-sdk<2`, letting a2a-sdk 1.x into the resolution for the first time. 1.x removes `a2a.types.DataPart` (the a2ui interface check fails), `a2a.server.apps` (`fast_api_app.py` cannot import `A2AFastAPIApplication`) and `a2a.utils.constants.EXTENDED_AGENT_CARD_PATH`. ADK 2.5.0 runs fine on 0.3.26, so `a2a-sdk>=0.3.4,<0.4.0` contains a2a-sdk without holding ADK back. What the resolver picks is not evidence that a version works.

### Build-time import smoke test

The generated Dockerfile now runs `dep_smoke_test.py`: it walks the agent sources with `ast`, collects every non-local import target, and imports each one. A moved or removed module fails the *build* with a named module instead of hanging the deployment. The `uv pip freeze` step that writes `/app/.dep-versions` was moved ahead of it so a failing build still reports what it resolved. Imports inside `try/except` are treated as optional; a file the test cannot parse is warned about and skipped, because this test must never be the reason a build fails.

### Constrained third-party installs

Caps in `requirements.txt` only bind the install we issue. When a demo imports a custom MCP server, the Dockerfile clones that repo and runs its own `uv pip install` into the same site-packages the agent imports from. Measured with the pinned uv, an unpinned `mcp` alongside `google-adk[a2a]` resolves to 2.0.0 -- so a third-party repo could reintroduce the same crash in a layer nobody reviews. The script now emits a `constraints.txt` (upper bounds only, derived from the same `PINNED_DEPS`), copies it into the image, and passes `-c /app/constraints.txt` to both branches of the cloned-repo install. Upper bounds only is deliberate: a floor in a constraints file can force an *upgrade* inside a resolution we are not steering, including into a pre-release; a cap can only ever prevent one.

### Tooling and docs

`check_deps.py` is a new maintainer tool. It resolves each requirement set with the uv version the Dockerfile pins and reports missing caps, caps that have fallen behind what actually resolves, and drift between `app/Code.gs` and `agent_template/pyproject.toml`.

`AGENTS.md` gains section 8 (dependency policy, the smoke test, the constraints file, how to audit); `README.md` gains a troubleshooting entry for the hanging deploy.

## Verification

- `python3 check_deps.py --offline` -> exit 0; the table shows the caps binding (`mcp` floor 1.24.0, cap 2.0.0, resolves 1.29.0; `a2a-sdk` floor 0.3.4, cap 0.4.0, resolves 0.3.26 with `google-adk` still at 2.5.0).
- Setup script generated across the full 9-way feature matrix: `bash -n` clean on all 9; every emitted Python heredoc byte-compiles; the emitted `constraints.txt` is identical across all feature-flag combinations, as intended.
- `dep_smoke_test.py`'s collector run against `agent_template/adk_agent`: 105 import targets, no local-package leakage, and it does reach `mcp.shared._httpx_utils` and `google.adk.tools.mcp_tool.mcp_toolset` -- the exact surface this break hit.
- `python3 validate_examples.py` -> 33/33 template files.