### PR TITLE
fix(ge-demo-generator): report the real cause of a template-fetch failure

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1897,6 +1897,7 @@ Ukiyo
 ulaw
 ulmoides
 ultrawide
+unadvertised
 und
 undst
 unigram

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -471,7 +471,23 @@ When you are done with the demo, see [Section 12: Cleanup](#12-cleanup) for inst
 ---
  
 ### Need Help?
-Refer to the sections above for comprehensive documentation, system architecture, and the developer guide.
+
+The sections above cover the documentation, the system architecture, and the developer guide. If they do not answer your question, use the table below.
+
+**Before you report a failing setup script:** the script prints the underlying error immediately _above_ the ❌ summary line. Those lines usually identify the cause on their own, so always include them.
+
+| What you need | Where to go |
+| --- | --- |
+| A bug or a question about **this sample** | [Open an issue](https://github.com/GoogleCloudPlatform/generative-ai/issues/new?template=bug-report.yml) in this repository. Enter `AGENTS.md` in the **File Name** field so the issue is routed to the owner of this sample automatically, and prefix the title with `[ge-demo-generator]`. |
+| A **Google Cloud product** problem (Gemini Enterprise, Cloud Run, BigQuery) | [Google Cloud Support](https://cloud.google.com/support). If you have a support contract, this is faster than GitHub. |
+| An **Agent Platform API** defect | [Google Issue Tracker](https://issuetracker.google.com/issues/new?component=1130925) |
+
+When you open an issue, please include:
+
+- the `Version:` line printed at the end of the setup script (for example, `v11.45-public`)
+- the agent-template ref the script printed (`📥 Fetching agent template (ref ...)`)
+- the output of `git --version`
+- whether you ran the script in **Cloud Shell**, which is the supported environment for the setup script
 
 ---
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -82,7 +82,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.44-public',
+  APP_VERSION: 'v11.45-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -3376,6 +3376,16 @@ for tool in jq curl gcloud bq make uv git python3; do
   fi
 done
 
+# git must also be recent enough for the pinned agent-template fetch further
+# down: "git sparse-checkout" arrived in 2.25 and partial clone needs 2.19.
+# Without this gate an old git fails much later, inside the template fetch,
+# where the error is far harder to read.
+if ! git --version | awk '{split(\$3, gv, "."); exit !(gv[1] > 2 || (gv[1] == 2 && gv[2] >= 25))}'; then
+  echo "❌ Error: git \$(git --version | awk '{print \$3}') is too old; 2.25 or newer is required."
+  echo "   Cloud Shell is the supported environment for this script and ships a recent git."
+  exit 1
+fi
+
 # --- Network resiliency for package installation ---
 echo "⚙️  Configuring robust network timeouts for package resolution..."
 export UV_HTTP_TIMEOUT=600
@@ -4232,13 +4242,40 @@ GE_TPL_ROOT="$(pwd)/_ge_template"
 rm -rf "$GE_TPL_ROOT"
 git init -q "$GE_TPL_ROOT"
 git -C "$GE_TPL_ROOT" remote add origin "${CONFIG.TEMPLATE_REPO}"
-git -C "$GE_TPL_ROOT" sparse-checkout set --cone "${CONFIG.TEMPLATE_SUBDIR}" 2>/dev/null || true
-if ! git -C "$GE_TPL_ROOT" fetch -q --depth 1 --filter=blob:none origin "${templateRef}"; then
-  echo "❌ Could not fetch agent template ref '${templateRef}'"
-  echo "   from ${CONFIG.TEMPLATE_REPO}."
-  echo "   The pinned template version is unreachable. Ask the demo creator to"
-  echo "   regenerate this script (the app's TEMPLATE_REF may need updating)."
-  exit 1
+git -C "$GE_TPL_ROOT" sparse-checkout set --cone "${CONFIG.TEMPLATE_SUBDIR}"
+# The fetch runs in two tiers and keeps git's own message. A blob:none partial
+# clone is only an optimization, so a client or proxy that cannot do one falls
+# back to a plain shallow fetch instead of failing the whole setup. Keeping the
+# error output lets a real failure report what actually went wrong: every
+# non-zero exit here used to be reported as an unreachable pinned ref, which
+# sent users off to regenerate a script whose pin was perfectly fine.
+if ! GE_TPL_ERR=$(git -C "$GE_TPL_ROOT" fetch --depth 1 --filter=blob:none origin "${templateRef}" 2>&1); then
+  if ! GE_TPL_ERR=$(git -C "$GE_TPL_ROOT" fetch --depth 1 origin "${templateRef}" 2>&1); then
+    echo "❌ Could not fetch the agent template from ${CONFIG.TEMPLATE_REPO}"
+    echo "   at ref '${templateRef}'. git reported:"
+    echo "$GE_TPL_ERR" | sed 's/^/     /'
+    case "$GE_TPL_ERR" in
+      *"not our ref"*|*"couldn't find remote ref"*|*"unadvertised"*)
+        echo "   → That template version no longer exists in the repository."
+        echo "     Ask the demo creator to regenerate this script."
+        ;;
+      *"Could not resolve host"*|*"Failed to connect"*|*"Connection timed out"*|*"SSL"*|*"certificate"*|*"proxy"*)
+        echo "   → github.com is not reachable from this machine (network policy,"
+        echo "     proxy, or TLS interception). Run this script in Cloud Shell,"
+        echo "     which is the supported environment."
+        ;;
+      *"No space left"*)
+        echo "   → The disk is full. Free up space in $HOME and re-run."
+        ;;
+      *)
+        echo "   → Re-run this script in Cloud Shell, which is the supported"
+        echo "     environment. If it fails there too, please report the git"
+        echo "     output above."
+        ;;
+    esac
+    exit 1
+  fi
+  echo "    ⚠️  Partial clone is unsupported here; used a plain shallow fetch."
 fi
 git -C "$GE_TPL_ROOT" -c advice.detachedHead=false checkout -q FETCH_HEAD
 GE_TPL="$GE_TPL_ROOT/${CONFIG.TEMPLATE_SUBDIR}"


### PR DESCRIPTION
# Description

The generated setup script fetches the pinned `agent_template/` from this repository at run time. Until now **every** non-zero exit from that `git fetch` produced the same message:

```
❌ Could not fetch agent template ref '<sha>'
   The pinned template version is unreachable. Ask the demo creator to
   regenerate this script (the app's TEMPLATE_REF may need updating).
```

A user hit this with a ref that was the current tip of `main`. Regenerating the script could never have helped — the fetch had failed for an environment reason (an old `git`, a proxy blocking github.com, or a full disk), and the message sent them chasing a pin that was perfectly fine.

## Changes

- **Two-tier fetch.** A `blob:none` partial clone is only an optimization, so a client or proxy that cannot do one now falls back to a plain shallow fetch instead of failing the whole setup.
- **Keep git's message.** The failure path prints git's own output followed by a cause-specific hint. "Ask the demo creator to regenerate this script" is now shown only when git actually reports a missing ref.
- **Check the git version, not just its presence.** The template fetch needs `git sparse-checkout` (2.25) and partial clone (2.19). An old `git` used to fail deep inside the fetch with an obscure error; it now fails in the prerequisite check with a clear one.
- **Stop discarding `sparse-checkout`'s exit status.** On a `git` older than 2.25 the subcommand does not exist, and the suppressed failure silently materialized the entire repository instead of the one subdirectory.
- **README "Need Help?"** previously pointed only back at the documentation. It now routes sample bugs to this repository's issue tracker, Google Cloud product problems to Cloud Support, and API defects to the issue tracker, and lists the details worth attaching to a report.

`APP_VERSION` moves to `v11.45-public`. No change to `agent_template/`, so the `TEMPLATE_REF`-resolves-to-`main` contract is unaffected.

## Testing

Setup scripts were generated from this `Code.gs` (base and all-features variants) and are `bash -n` clean. The emitted fetch block was then run against three inputs, each taking its intended branch:

| Input | Result |
| --- | --- |
| live ref | `✅ Agent template ready.` |
| dead 40-hex pin | `fatal: remote error: upload-pack: not our ref …` → "no longer exists, ask the demo creator to regenerate" |
| unresolvable host | `fatal: unable to access … Could not resolve host` → "github.com is not reachable … run in Cloud Shell" |

The version gate was exercised with a stubbed `git --version` of `1.8.3.1` (rejected) and with the real binary (accepted).