### PR TITLE
fix(ge-demo-generator): accept a GitHub browse URL in TEMPLATE_REPO, and stop the docs from inviting one

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -205,7 +205,11 @@ Safety nets — keep all three working:
 
 Pre-merge testing: point the `TEMPLATE_REPO` / `TEMPLATE_REF` Script
 Properties at the fork/branch under review (resolution then pins the fork
-branch tip). Delete both properties after the upstream merge.
+branch tip). `TEMPLATE_REPO` is the clone URL of the fork
+(`https://github.com/OWNER/generative-ai.git`), never the browse URL of the
+template directory — the latter is a web page and every script generated while
+it is set dies at the template fetch. Delete both properties after the upstream
+merge; a stale `TEMPLATE_REPO` keeps every generated script pointed at the fork.
 
 ## 5. Release checklist
 

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -189,7 +189,7 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 |---|---|---|
 | `LOCATION` | `global` | Vertex AI Agent Platform API location (e.g., `us-central1`, `global`) |
 | `MODEL` | `gemini-3.6-flash` | Gemini model name for data generation |
-| `TEMPLATE_REPO` | this repository | Git **clone** URL the generated setup script fetches `agent_template/` from at run time, e.g. `https://github.com/GoogleCloudPlatform/generative-ai.git`. A GitHub browse URL (one containing `/tree/` or `/blob/`) is a web page, not a repository; such a value is reduced to the clone URL of the same repo |
+| `TEMPLATE_REPO` | this repository | Git **clone** URL (ending in `.git`) the generated setup script fetches `agent_template/` from at run time — see the note below |
 | `TEMPLATE_REF` | `main` | Branch, tag, or commit SHA of the agent template. A branch/tag is resolved to a concrete commit SHA at script-generation time (each generated script is pinned to that SHA); set a 40-hex SHA to hard-pin |
 | `TEMPLATE_SUBDIR` | `search/gemini-enterprise/ge-demo-generator/agent_template` | Repo path of the template directory |
 | `GITHUB_TOKEN` | (unset) | GitHub personal access token used for GitHub API calls when importing custom MCP servers from a repository URL. Only needed for private repos or to avoid unauthenticated rate limits |
@@ -198,7 +198,21 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 > **Note**: The three `TEMPLATE_*` properties override the defaults baked into
 > `Code.gs`. Setting them lets a deployed app switch template sources (for
 > example to a fork during development, or to this repository's latest release
-> commit) without redeploying the Apps Script code.
+> commit) without redeploying the Apps Script code. Leaving all three unset is
+> the normal configuration.
+
+`TEMPLATE_REPO` is a git **clone** URL — the string you would hand to
+`git clone`, ending in `.git`. Browsing to `agent_template/` on github.com
+gives you a different kind of URL: it contains `/tree/`, it already includes
+the path that belongs in `TEMPLATE_SUBDIR`, and git cannot fetch from it. An
+app configured that way still generates scripts, but they fail with
+`repository ... not found` for whoever runs them. A complete, correct set:
+
+```text
+TEMPLATE_REPO    https://github.com/GoogleCloudPlatform/generative-ai.git
+TEMPLATE_REF     main
+TEMPLATE_SUBDIR  search/gemini-enterprise/ge-demo-generator/agent_template
+```
 
 ### 6.3 Setting Properties
 

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -189,7 +189,7 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 |---|---|---|
 | `LOCATION` | `global` | Vertex AI Agent Platform API location (e.g., `us-central1`, `global`) |
 | `MODEL` | `gemini-3.6-flash` | Gemini model name for data generation |
-| `TEMPLATE_REPO` | this repository | Git URL the generated setup script fetches `agent_template/` from at run time |
+| `TEMPLATE_REPO` | this repository | Git **clone** URL the generated setup script fetches `agent_template/` from at run time, e.g. `https://github.com/GoogleCloudPlatform/generative-ai.git`. A GitHub browse URL (one containing `/tree/` or `/blob/`) is a web page, not a repository; such a value is reduced to the clone URL of the same repo |
 | `TEMPLATE_REF` | `main` | Branch, tag, or commit SHA of the agent template. A branch/tag is resolved to a concrete commit SHA at script-generation time (each generated script is pinned to that SHA); set a 40-hex SHA to hard-pin |
 | `TEMPLATE_SUBDIR` | `search/gemini-enterprise/ge-demo-generator/agent_template` | Repo path of the template directory |
 | `GITHUB_TOKEN` | (unset) | GitHub personal access token used for GitHub API calls when importing custom MCP servers from a repository URL. Only needed for private repos or to avoid unauthenticated rate limits |

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -174,6 +174,8 @@ These are already declared in `appsscript.json` and will be auto-enabled when th
 
 This codebase contains **no hardcoded parameters**. All configuration is managed via **Script Properties**.
 
+A complete setup is **two properties**: `PROJECT_ID` and `LOG_SHEET_URL`. Everything in §6.2 has a working default and should be left unset.
+
 ### 6.1 Mandatory Properties
 
 | Property | Description |
@@ -184,6 +186,8 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 > **Important**: Both properties are checked at startup. If any are missing, the app displays a `SetupError.html` page with instructions instead of the main UI.
 
 ### 6.2 Optional Properties
+
+**You do not need to set any of these.** Every property below has a working default, and leaving it unset is the supported configuration — it is what a normal deployment looks like. Set one only when you specifically want the behaviour it describes, and remove it again once you no longer do.
 
 | Property | Default | Description |
 |---|---|---|
@@ -198,8 +202,7 @@ This codebase contains **no hardcoded parameters**. All configuration is managed
 > **Note**: The three `TEMPLATE_*` properties override the defaults baked into
 > `Code.gs`. Setting them lets a deployed app switch template sources (for
 > example to a fork during development, or to this repository's latest release
-> commit) without redeploying the Apps Script code. Leaving all three unset is
-> the normal configuration.
+> commit) without redeploying the Apps Script code.
 
 `TEMPLATE_REPO` is a git **clone** URL — the string you would hand to
 `git clone`, ending in `.git`. Browsing to `agent_template/` on github.com

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -41,9 +41,9 @@ The **GE Demo Generator** is a low-code web application built on Google Apps Scr
 - [3. Apps Script Project Setup](#3-apps-script-project-setup)
 - [4. Deploying Code to Apps Script](#4-deploying-code-to-apps-script)
 - [5. Google Cloud Project Setup](#5-google-cloud-project-setup)
-- [6. Script Properties (Zero Hardcoding)](#6-script-properties-zero-hardcoding)
-- [7. Manual API Authorization (Required Once)](#7-manual-api-authorization-required-once)
-- [8. Prepare the Usage Log Spreadsheet](#8-prepare-the-usage-log-spreadsheet)
+- [6. Prepare the Usage Log Spreadsheet](#6-prepare-the-usage-log-spreadsheet)
+- [7. Script Properties (Zero Hardcoding)](#7-script-properties-zero-hardcoding)
+- [8. Manual API Authorization (Required Once)](#8-manual-api-authorization-required-once)
 - [9. Web App Deployment](#9-web-app-deployment)
 - [10. How the Generated Demo Works](#10-how-the-generated-demo-works)
 - [11. Project Structure](#11-project-structure)
@@ -170,13 +170,27 @@ These are already declared in `appsscript.json` and will be auto-enabled when th
 
 ---
 
-## 6. Script Properties (Zero Hardcoding)
+## 6. Prepare the Usage Log Spreadsheet
+
+1. Create a new Google Spreadsheet (or use an existing one).
+2. Create a sheet named **`Usage_Logs`** with the following header row:
+
+   | Timestamp | User Email | User Goal | AI Summary | Dataset ID | MCP Servers | Generation Time (s) |
+   |---|---|---|---|---|---|---|
+
+   > **Note**: The headers are automatically synced on each log write by `ensureLogSheetHeaders()`. You only need to create the sheet — the function will overwrite row 1 with the correct headers.
+
+3. Copy the spreadsheet URL — you will set it as the `LOG_SHEET_URL` Script Property in the next section.
+
+---
+
+## 7. Script Properties (Zero Hardcoding)
 
 This codebase contains **no hardcoded parameters**. All configuration is managed via **Script Properties**.
 
-A complete setup is **two properties**: `PROJECT_ID` and `LOG_SHEET_URL`. Everything in §6.2 has a working default and should be left unset.
+A complete setup is **two properties**: `PROJECT_ID` and `LOG_SHEET_URL`. Everything in §7.2 has a working default and should be left unset.
 
-### 6.1 Mandatory Properties
+### 7.1 Mandatory Properties
 
 | Property | Description |
 |---|---|
@@ -185,18 +199,25 @@ A complete setup is **two properties**: `PROJECT_ID` and `LOG_SHEET_URL`. Everyt
 
 > **Important**: Both properties are checked at startup. If any are missing, the app displays a `SetupError.html` page with instructions instead of the main UI.
 
-### 6.2 Optional Properties
+### 7.2 Optional Properties
 
 **You do not need to set any of these.** Every property below has a working default, and leaving it unset is the supported configuration — it is what a normal deployment looks like. Set one only when you specifically want the behaviour it describes, and remove it again once you no longer do.
+
+**Tuning** — occasionally useful in a normal deployment:
 
 | Property | Default | Description |
 |---|---|---|
 | `LOCATION` | `global` | Vertex AI Agent Platform API location (e.g., `us-central1`, `global`) |
 | `MODEL` | `gemini-3.6-flash` | Gemini model name for data generation |
+| `GITHUB_TOKEN` | (unset) | GitHub personal access token used for GitHub API calls when importing custom MCP servers from a repository URL. Only needed for private repos or to avoid unauthenticated rate limits |
+
+**Development and administration** — for working on this sample, not for running it. If you are deploying the app to give demos, skip these entirely:
+
+| Property | Default | Description |
+|---|---|---|
 | `TEMPLATE_REPO` | this repository | Git **clone** URL (ending in `.git`) the generated setup script fetches `agent_template/` from at run time — see the note below |
 | `TEMPLATE_REF` | `main` | Branch, tag, or commit SHA of the agent template. A branch/tag is resolved to a concrete commit SHA at script-generation time (each generated script is pinned to that SHA); set a 40-hex SHA to hard-pin |
 | `TEMPLATE_SUBDIR` | `search/gemini-enterprise/ge-demo-generator/agent_template` | Repo path of the template directory |
-| `GITHUB_TOKEN` | (unset) | GitHub personal access token used for GitHub API calls when importing custom MCP servers from a repository URL. Only needed for private repos or to avoid unauthenticated rate limits |
 | `DISABLE_CROSSORG_PACK` | (unset) | Set to `1` to disable every cross-departmental prompt insertion (persona anchor, cross-department scenario fabric, process-state rules) at once — an admin rollback lever, not a user-facing option |
 
 > **Note**: The three `TEMPLATE_*` properties override the defaults baked into
@@ -217,7 +238,7 @@ TEMPLATE_REF     main
 TEMPLATE_SUBDIR  search/gemini-enterprise/ge-demo-generator/agent_template
 ```
 
-### 6.3 Setting Properties
+### 7.3 Setting Properties
 
 **Option A: Via Script Editor (Recommended for first-time setup)**
 
@@ -237,7 +258,7 @@ TEMPLATE_SUBDIR  search/gemini-enterprise/ge-demo-generator/agent_template
 
 ---
 
-## 7. Manual API Authorization (Required Once)
+## 8. Manual API Authorization (Required Once)
 
 Even with correct scopes in `appsscript.json`, you **must** manually authorize the script to access your data.
 
@@ -247,20 +268,6 @@ Even with correct scopes in `appsscript.json`, you **must** manually authorize t
    - You may need to click **"Advanced" → "Go to [project name] (unsafe)"** if prompted with an "unverified app" warning.
 
 > **Note**: The `forceAuthorizeSpreadsheet` function explicitly triggers authorization for Spreadsheet scopes by performing a safe read test.
-
----
-
-## 8. Prepare the Usage Log Spreadsheet
-
-1. Create a new Google Spreadsheet (or use an existing one).
-2. Create a sheet named **`Usage_Logs`** with the following header row:
-
-   | Timestamp | User Email | User Goal | AI Summary | Dataset ID | MCP Servers | Generation Time (s) |
-   |---|---|---|---|---|---|---|
-
-   > **Note**: The headers are automatically synced on each log write by `ensureLogSheetHeaders()`. You only need to create the sheet — the function will overwrite row 1 with the correct headers.
-
-3. Copy the spreadsheet URL and set it as the `LOG_SHEET_URL` Script Property.
 
 ---
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -74,6 +74,25 @@ function forceAuthorize() {
   return '✅ Authorization verified. Refresh the browser and try generating a demo!';
 }
 
+/**
+ * Reduces a GitHub URL to the clone URL that git can actually fetch from.
+ *
+ * TEMPLATE_REPO is set by hand in the Script Properties, and the URL a person
+ * has on screen at that moment is the browse URL of the template directory
+ * (https://github.com/OWNER/REPO/tree/main/path/to/agent_template). That is not
+ * a git remote: the fetch in the generated setup script dies with "repository
+ * not found" long after generation, on someone else's machine. Everything after
+ * OWNER/REPO is dropped so both forms work. Non-GitHub and SSH remotes are
+ * returned untouched.
+ */
+function normalizeGitRemoteUrl_(url) {
+  if (!url) return url;
+  const trimmed = String(url).trim();
+  const match = trimmed.match(
+    /^https?:\/\/(?:www\.)?github\.com\/([^\/\s]+)\/([^\/\s#?]+?)(?:\.git)?(?:[\/#?].*)?$/i);
+  return match ? 'https://github.com/' + match[1] + '/' + match[2] + '.git' : trimmed;
+}
+
 const SCRIPT_PROPS = PropertiesService.getScriptProperties();
 const CONFIG = {
   PROJECT_ID: SCRIPT_PROPS.getProperty('PROJECT_ID'),
@@ -82,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.45-public',
+  APP_VERSION: 'v11.46-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -90,8 +109,9 @@ const CONFIG = {
   // each generated script, so scripts stay reproducible without this file
   // ever committing its own merge SHA. Set the TEMPLATE_REF Script Property
   // to a 40-hex SHA to hard-pin, or point TEMPLATE_REPO/TEMPLATE_REF at a
-  // fork/branch for pre-merge testing.
-  TEMPLATE_REPO: SCRIPT_PROPS.getProperty('TEMPLATE_REPO') || 'https://github.com/GoogleCloudPlatform/generative-ai.git',
+  // fork/branch for pre-merge testing. TEMPLATE_REPO is normalized to a clone
+  // URL so that pasting a GitHub browse URL still produces a working script.
+  TEMPLATE_REPO: normalizeGitRemoteUrl_(SCRIPT_PROPS.getProperty('TEMPLATE_REPO')) || 'https://github.com/GoogleCloudPlatform/generative-ai.git',
   TEMPLATE_REF: SCRIPT_PROPS.getProperty('TEMPLATE_REF') || 'main',
   TEMPLATE_SUBDIR: SCRIPT_PROPS.getProperty('TEMPLATE_SUBDIR') || 'search/gemini-enterprise/ge-demo-generator/agent_template',
   LOG_SHEET_URL: SCRIPT_PROPS.getProperty('LOG_SHEET_URL')
@@ -4258,6 +4278,13 @@ if ! GE_TPL_ERR=$(git -C "$GE_TPL_ROOT" fetch --depth 1 --filter=blob:none origi
       *"not our ref"*|*"couldn't find remote ref"*|*"unadvertised"*)
         echo "   → That template version no longer exists in the repository."
         echo "     Ask the demo creator to regenerate this script."
+        ;;
+      *"not found"*|*"Authentication failed"*|*"could not read Username"*)
+        echo "   → That URL is not a git remote this machine can clone."
+        echo "     A GitHub browse URL (one containing /tree/ or /blob/) is a web"
+        echo "     page, not a repository; the clone URL ends in .git. Ask the demo"
+        echo "     creator to check the TEMPLATE_REPO Script Property of the app"
+        echo "     and regenerate this script."
         ;;
       *"Could not resolve host"*|*"Failed to connect"*|*"Connection timed out"*|*"SSL"*|*"certificate"*|*"proxy"*)
         echo "   → github.com is not reachable from this machine (network policy,"


### PR DESCRIPTION
## Problem

A partner running a generated setup script hit:

```
❌ Could not fetch agent template ref 'cb535bfa5b28348ac4a49f61746e6630b15e2ab1'
   from https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/agent_template.
   The pinned template version is unreachable. Ask the demo creator to
   regenerate this script (the app's TEMPLATE_REF may need updating).
```

The ref was fine — it was the tip of `main` at generation time. The repository
URL was not. The `TEMPLATE_REPO` Script Property of the app copy that generated
the script held the **browse** URL of the template directory, which is a web
page rather than a git remote:

```
$ git remote add origin "https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/agent_template"
$ git fetch --depth 1 --filter=blob:none origin cb535bfa...
fatal: repository '.../agent_template/' not found
```

The partner fixed it by replacing that URL with
`https://github.com/GoogleCloudPlatform/generative-ai.git` inside the generated
`.sh`, which is exactly right — but the script's message had sent them looking
at the pinned ref instead.

Nothing catches this at generation time either. The ref probe extracts
`OWNER/REPO` from `TEMPLATE_REPO` with `/github\.com[:\/]([^\/]+\/[^\/.]+)/`,
which matches the browse URL just as happily, so `main` resolves against the
real repository and a valid SHA is baked into a script that can never fetch it.
No banner, no warning — the failure surfaces later, on someone else's machine.

## Why that property was set at all

`TEMPLATE_REPO` is a development knob, and a deployment should never touch it.
The README did not say so. §6 opened into two tables, the seven-row second one
headed only "Optional", listing a template source and an admin rollback lever
beside `LOCATION` and `MODEL` as though they were peers. The `TEMPLATE_REPO`
row read "Git URL … fetches `agent_template/` from" with a default of "this
repository" and no example, directly above `TEMPLATE_SUBDIR` — "Repo path of
the template directory". Concatenating what those two rows describe gives you
the browse URL of `agent_template/`, which is also what the app's own "GitHub
Repository" link and `tutorial.md` put in front of you.

So the docs are fixed here alongside the code. While in that section, two
related problems: the properties section came before the section that creates
the spreadsheet its mandatory `LOG_SHEET_URL` points at (and authorization sat
between them, though `forceAuthorizeSpreadsheet()` opens that same URL), and
nothing stated that a complete setup is two properties.

## Changes

Code:

- `normalizeGitRemoteUrl_()` reduces any `github.com` URL to its
  `OWNER/REPO.git` clone URL, applied where `CONFIG.TEMPLATE_REPO` is read. A
  browse URL, a bare repo page, and a clone URL all now work; SSH remotes and
  non-GitHub hosts pass through untouched.
- The runtime fetch handler gets a `not found` / auth-failure branch that names
  the repository URL as the problem, instead of falling through to the generic
  "re-run in Cloud Shell" advice added in #3018.

Docs:

- The README states that a complete setup is `PROJECT_ID` and `LOG_SHEET_URL`,
  and that an unset optional property is the supported configuration rather
  than an omission to be filled in.
- The optional table is split into tuning (`LOCATION`, `MODEL`,
  `GITHUB_TOKEN`) and development/administration (`TEMPLATE_*`,
  `DISABLE_CROSSORG_PACK`), the latter marked skippable for anyone deploying
  the app to give demos.
- `TEMPLATE_REPO` now shows the expected value, a complete correct `TEMPLATE_*`
  set, and what the browse URL does to the people who run the generated
  scripts. AGENTS.md says the same for pre-merge testing and warns that a stale
  value keeps every generated script pointed at the fork.
- Setup sections reordered to spreadsheet → properties → authorization, the
  order the dependencies already required. Table of contents updated.

## Testing

- `normalizeGitRemoteUrl_` over 16 inputs — browse `/tree/`, `/blob/`, trailing
  slash, bare page, `.git`, `http`, `www.`, whitespace, a repo name containing a
  dot, a branch name containing a slash, SSH, GitLab, `null`, `""`.
- Setup scripts regenerated through a GAS harness with `TEMPLATE_REPO` set to
  the exact browse URL from the report: the emitted script now contains
  `remote add origin "https://github.com/GoogleCloudPlatform/generative-ai.git"`.
  Both the base and all-features variants pass `bash -n`.
- The generated `case` block was run against real git output for all five
  branches (repository-not-found, missing ref, DNS failure, disk full,
  unrecognized) and each routes to its own message.
- All 14 table-of-contents entries checked against the headings and their
  generated anchors after renumbering; the only remaining `Section N`
  references in the README (12 and 13) are unaffected.
- `python3 validate_examples.py` — 33 template files pass.