### PR TITLE
feat(gemini-ent-group-license): add support for sub_id

### DIFF
--- a/search/gemini-enterprise/group-licensing/cmd/job/main.go
+++ b/search/gemini-enterprise/group-licensing/cmd/job/main.go
@@ -41,17 +41,17 @@ func main() {
 	// Step 1: plain JSON logger for startup errors, before settings are loaded.
 	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
 
-	// Step 2: load entitlement config.
-	cfg, err := config.Load(models.ConfigFilePath)
-	if err != nil {
-		slog.Error("failed to load entitlement config", slog.Any("error", err))
-		os.Exit(1)
-	}
-
-	// Step 3: load job settings from Cloud Run Job environment variables.
+	// Step 2: load job settings from Cloud Run Job environment variables.
 	settings, err := config.LoadJobSettings()
 	if err != nil {
 		slog.Error("failed to load job settings", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	// Step 3: load entitlement config.
+	cfg, err := config.Load(models.ConfigFilePath, settings.DirectLaw)
+	if err != nil {
+		slog.Error("failed to load entitlement config", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -107,14 +107,14 @@ func main() {
 	// Step 7: run the workflow determined by JobType.
 	switch settings.JobType {
 	case models.WorkflowJoiner:
-		req := dto.SyncAddRequest{DryRun: &settings.DryRun}
+		req := dto.SyncAddRequest{DryRun: &settings.DryRun, DirectLaw: &settings.DirectLaw}
 		if _, err := services.NewJoinerService(idpAdapter, geminiAdapter, rmAdapter).Run(ctx, cfg, req); err != nil {
 			slog.Error("joiner workflow failed", slog.Any("error", err))
 			os.Exit(1)
 		}
 
 	case models.WorkflowGarbageCollection:
-		req := dto.SyncRemoveRequest{DryRun: &settings.DryRun}
+		req := dto.SyncRemoveRequest{DryRun: &settings.DryRun, DirectLaw: &settings.DirectLaw}
 		if _, err := services.NewGCService(idpAdapter, geminiAdapter).Run(ctx, cfg, req); err != nil {
 			slog.Error("garbage collection workflow failed", slog.Any("error", err))
 			os.Exit(1)

--- a/search/gemini-enterprise/group-licensing/internal/adapters/discoveryengine/adapter.go
+++ b/search/gemini-enterprise/group-licensing/internal/adapters/discoveryengine/adapter.go
@@ -198,7 +198,7 @@ func (a *Adapter) clientFor(ctx context.Context, location models.Location) (user
 // per-project licenseConfig resource path. The service layer calls this once
 // at the start of each run and resolves paths before issuing grant operations.
 // This endpoint is always global; no location-specific override is applied.
-func (a *Adapter) FetchLicenseConfigIndex(ctx context.Context, billingAccountID string) (models.LicenseConfigIndex, error) {
+func (a *Adapter) FetchLicenseConfigIndex(ctx context.Context, billingAccountID string, directLaw bool) (models.LicenseConfigIndex, error) {
 	svc, err := discoveryengineapi.NewService(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("creating discoveryengine REST client: %w", err)
@@ -209,7 +209,7 @@ func (a *Adapter) FetchLicenseConfigIndex(ctx context.Context, billingAccountID 
 
 	err = svc.BillingAccounts.BillingAccountLicenseConfigs.List(parent).Context(ctx).Pages(ctx,
 		func(resp *discoveryengineapi.GoogleCloudDiscoveryengineV1alphaListBillingAccountLicenseConfigsResponse) error {
-			accumulateLicenseConfigs(index, resp.BillingAccountLicenseConfigs)
+			accumulateLicenseConfigs(index, resp.BillingAccountLicenseConfigs, directLaw)
 			return nil
 		},
 	)
@@ -223,7 +223,7 @@ func (a *Adapter) FetchLicenseConfigIndex(ctx context.Context, billingAccountID 
 // accumulateLicenseConfigs appends active, valid billing account license config
 // entries into index. It is extracted from the pagination callback so that the
 // index-building logic can be tested without a live REST client.
-func accumulateLicenseConfigs(index models.LicenseConfigIndex, configs []*discoveryengineapi.GoogleCloudDiscoveryengineV1alphaBillingAccountLicenseConfig) {
+func accumulateLicenseConfigs(index models.LicenseConfigIndex, configs []*discoveryengineapi.GoogleCloudDiscoveryengineV1alphaBillingAccountLicenseConfig, directLaw bool) {
 	for _, c := range configs {
 		if c.State != "ACTIVE" {
 			continue
@@ -241,10 +241,19 @@ func accumulateLicenseConfigs(index models.LicenseConfigIndex, configs []*discov
 			if err != nil {
 				continue
 			}
+			// Default behavior is to index by SKU (automatic mode)
 			key := models.LicenseConfigKey{
 				SKU:           models.SKU(c.SubscriptionTier),
 				ProjectNumber: parts[1],
 				Location:      models.Location(parts[3]),
+			}
+			// If in direct_law mode, change to index by admin-specified SubscriptionID
+			if directLaw {
+				key = models.LicenseConfigKey{
+					SubscriptionID: parts[5],
+					ProjectNumber:  parts[1],
+					Location:       models.Location(parts[3]),
+				}
 			}
 			index[key] = append(index[key], models.LicenseConfigEntry{
 				Path:           licenseConfigPath,

--- a/search/gemini-enterprise/group-licensing/internal/adapters/discoveryengine/adapter_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/adapters/discoveryengine/adapter_test.go
@@ -665,7 +665,7 @@ func TestAccumulateLicenseConfigs_SingleActiveEntry(t *testing.T) {
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	key := models.LicenseConfigKey{SKU: models.SKUEnterprise, ProjectNumber: "123", Location: models.LocationGlobal}
 	require.Len(t, index[key], 1)
@@ -695,7 +695,7 @@ func TestAccumulateLicenseConfigs_TwoSubscriptionsSameSKUProjectLocation_BothAcc
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	key := models.LicenseConfigKey{SKU: models.SKUEnterprise, ProjectNumber: "123", Location: models.LocationGlobal}
 	require.Len(t, index[key], 2, "both subscription pools must appear in the slice")
@@ -717,7 +717,7 @@ func TestAccumulateLicenseConfigs_InactiveSubscription_Excluded(t *testing.T) {
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	assert.Empty(t, index, "inactive subscription must not appear in the index")
 }
@@ -734,7 +734,7 @@ func TestAccumulateLicenseConfigs_UnspecifiedTier_Excluded(t *testing.T) {
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	assert.Empty(t, index, "unspecified subscription tier must not appear in the index")
 }
@@ -751,7 +751,7 @@ func TestAccumulateLicenseConfigs_MalformedPath_Skipped(t *testing.T) {
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	assert.Empty(t, index, "malformed licenseConfig path must be skipped")
 }
@@ -768,7 +768,35 @@ func TestAccumulateLicenseConfigs_InvalidAllocatedCount_Skipped(t *testing.T) {
 		},
 	}
 
-	accumulateLicenseConfigs(index, configs)
+	accumulateLicenseConfigs(index, configs, false)
 
 	assert.Empty(t, index, "non-integer allocated count must be skipped")
+}
+
+func TestAccumulateLicenseConfigs_DirectLaw(t *testing.T) {
+	index := make(models.LicenseConfigIndex)
+	configs := []*discoveryengineapi.GoogleCloudDiscoveryengineV1alphaBillingAccountLicenseConfig{
+		{
+			State:            "ACTIVE",
+			SubscriptionTier: "SUBSCRIPTION_TIER_ENTERPRISE",
+			LicenseConfigDistributions: map[string]string{
+				"projects/123/locations/global/licenseConfigs/sub-uuid-abc-123": "100",
+			},
+		},
+	}
+
+	// Call accumulateLicenseConfigs with directLaw = true
+	accumulateLicenseConfigs(index, configs, true)
+
+	// The key MUST contain SubscriptionID = "sub-uuid-abc-123" and empty SKU
+	key := models.LicenseConfigKey{
+		SubscriptionID: "sub-uuid-abc-123",
+		ProjectNumber:  "123",
+		Location:       models.LocationGlobal,
+	}
+
+	require.Contains(t, index, key, "expected index key to map via subscription ID under direct_law mode")
+	require.Len(t, index[key], 1)
+	assert.Equal(t, "projects/123/locations/global/licenseConfigs/sub-uuid-abc-123", index[key][0].Path)
+	assert.Equal(t, int64(100), index[key][0].AllocatedCount)
 }

--- a/search/gemini-enterprise/group-licensing/internal/config/config.go
+++ b/search/gemini-enterprise/group-licensing/internal/config/config.go
@@ -39,6 +39,7 @@ var validEmail = regexp.MustCompile(`^[^@\s]+@[^@\s]+\.[^@\s]+$`)
 // a given GCP project.
 type ProjectEntry struct {
 	SubscriptionTier models.SKU      `json:"subscription_tier"`
+	SubscriptionID   *string         `json:"subscription_id"`
 	Location         models.Location `json:"location"`
 	Groups           []string        `json:"groups"`
 }
@@ -65,7 +66,7 @@ type EntitlementConfig struct {
 //
 // A StalenessThresholdDays of 0 means the staleness check is disabled entirely;
 // only the entitlement check will run during garbage collection.
-func Load(path string) (*EntitlementConfig, error) {
+func Load(path string, directLaw bool) (*EntitlementConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
@@ -79,7 +80,7 @@ func Load(path string) (*EntitlementConfig, error) {
 		return nil, fmt.Errorf("parsing config: %w", models.ErrConfigInvalid)
 	}
 
-	if err := validate(&cfg); err != nil {
+	if err := validate(&cfg, directLaw); err != nil {
 		return nil, err
 	}
 
@@ -88,7 +89,7 @@ func Load(path string) (*EntitlementConfig, error) {
 
 // validate enforces all structural and semantic constraints on the config.
 // It is read-only and does not mutate cfg.
-func validate(cfg *EntitlementConfig) error {
+func validate(cfg *EntitlementConfig, directLaw bool) error {
 	if cfg.BillingAccountID == "" {
 		return fmt.Errorf("config validation: billing_account_id is required: %w", models.ErrConfigInvalid)
 	}
@@ -107,6 +108,11 @@ func validate(cfg *EntitlementConfig) error {
 		}
 
 		for i, entry := range projectCfg {
+			if directLaw {
+				if entry.SubscriptionID == nil || *entry.SubscriptionID == "" {
+					return fmt.Errorf("project %q entry %d: subscription_id is required when direct_law is enabled: %w", projectID, i, models.ErrConfigInvalid)
+				}
+			}
 			if !entry.SubscriptionTier.IsValid() {
 				return fmt.Errorf("project %q entry %d contains unrecognized SKU %q: %w", projectID, i, entry.SubscriptionTier, models.ErrInvalidSKU)
 			}

--- a/search/gemini-enterprise/group-licensing/internal/config/config_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/config/config_test.go
@@ -58,7 +58,7 @@ func TestLoad_ValidConfig(t *testing.T) {
 		}
 	}`)
 
-	cfg, err := Load(path)
+	cfg, err := Load(path, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, "ABCDE-12345-FGHIJ", cfg.BillingAccountID)
@@ -118,7 +118,7 @@ func TestLoad_MultiProjectConfig(t *testing.T) {
 		}
 	}`)
 
-	cfg, err := Load(path)
+	cfg, err := Load(path, false)
 	require.NoError(t, err)
 
 	assert.Len(t, cfg.Projects, 3)
@@ -149,14 +149,14 @@ func TestLoad_StalenessThresholdZeroMeansDisabled(t *testing.T) {
 		}
 	}`)
 
-	cfg, err := Load(path)
+	cfg, err := Load(path, false)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, cfg.Settings.StalenessThresholdDays)
 }
 
 func TestLoad_FileNotFound(t *testing.T) {
-	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	_, err := Load(filepath.Join(t.TempDir(), "does-not-exist.json"), false)
 	assert.ErrorIs(t, err, models.ErrConfigNotFound)
 }
 
@@ -167,14 +167,14 @@ func TestLoad_FileUnreadable(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chmod(path, 0600) })
 
-	_, err := Load(path)
+	_, err := Load(path, false)
 	assert.ErrorIs(t, err, models.ErrConfigUnreadable)
 }
 
 func TestLoad_MalformedJSON(t *testing.T) {
 	path := writeFixture(t, `{ this is not valid json }`)
 
-	_, err := Load(path)
+	_, err := Load(path, false)
 	assert.ErrorIs(t, err, models.ErrConfigInvalid)
 }
 
@@ -276,8 +276,81 @@ func TestLoad_ValidationFailures(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			path := writeFixture(t, tc.json)
-			_, err := Load(path)
+			_, err := Load(path, false)
 			assert.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestLoad_ValidConfig_DirectLaw(t *testing.T) {
+	// A valid configuration under direct_law must contain a subscription_id
+	path := writeFixture(t, `{
+		"billing_account_id": "ABCDE-12345-FGHIJ",
+		"projects": {
+			"acme-prod": [
+				{
+					"subscription_tier": "SUBSCRIPTION_TIER_ENTERPRISE",
+					"subscription_id": "sub-uuid-abc-123",
+					"location": "global",
+					"groups": ["eng@acme.com"]
+				}
+			]
+		},
+		"settings": {
+			"staleness_threshold_days": 45
+		}
+	}`)
+
+	cfg, err := Load(path, true) // directLaw = true
+	require.NoError(t, err)
+	assert.Equal(t, "sub-uuid-abc-123", *cfg.Projects["acme-prod"][0].SubscriptionID)
+}
+
+func TestLoad_InvalidConfig_DirectLaw_MissingSubscriptionID(t *testing.T) {
+	// Under direct_law mode, if subscription_id is omitted or empty,
+	// it must fail validation with models.ErrConfigInvalid.
+	tests := []struct {
+		name string
+		json string
+	}{
+		{
+			name: "missing subscription_id key entirely",
+			json: `{
+				"billing_account_id": "ABCDE-12345-FGHIJ",
+				"projects": {
+					"acme-prod": [
+						{
+							"subscription_tier": "SUBSCRIPTION_TIER_ENTERPRISE",
+							"location": "global",
+							"groups": ["eng@acme.com"]
+						}
+					]
+				}
+			}`,
+		},
+		{
+			name: "empty subscription_id string value",
+			json: `{
+				"billing_account_id": "ABCDE-12345-FGHIJ",
+				"projects": {
+					"acme-prod": [
+						{
+							"subscription_tier": "SUBSCRIPTION_TIER_ENTERPRISE",
+							"subscription_id": "",
+							"location": "global",
+							"groups": ["eng@acme.com"]
+						}
+					]
+				}
+			}`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := writeFixture(t, tc.json)
+			_, err := Load(path, true) // directLaw = true
+			assert.ErrorIs(t, err, models.ErrConfigInvalid)
 		})
 	}
 }

--- a/search/gemini-enterprise/group-licensing/internal/config/job_settings.go
+++ b/search/gemini-enterprise/group-licensing/internal/config/job_settings.go
@@ -13,6 +13,7 @@ import (
 type JobSettings struct {
 	JobType   models.WorkflowType
 	DryRun    bool
+	DirectLaw bool
 	TaskIndex int
 	TaskCount int
 }
@@ -44,6 +45,16 @@ func LoadJobSettings() (*JobSettings, error) {
 		}
 	}
 
+	// DIRECT_LAW — optional, default false.
+	directLaw := false
+	if raw := os.Getenv("DIRECT_LAW"); raw != "" {
+		var err error
+		directLaw, err = strconv.ParseBool(raw)
+		if err != nil {
+			return nil, fmt.Errorf("DIRECT_LAW %q is not a valid boolean: %w", raw, models.ErrConfigInvalid)
+		}
+	}
+
 	// CLOUD_RUN_TASK_INDEX — optional, default 0.
 	taskIndex := 0
 	if raw := os.Getenv("CLOUD_RUN_TASK_INDEX"); raw != "" {
@@ -72,6 +83,7 @@ func LoadJobSettings() (*JobSettings, error) {
 	return &JobSettings{
 		JobType:   jobType,
 		DryRun:    dryRun,
+		DirectLaw: directLaw,
 		TaskIndex: taskIndex,
 		TaskCount: taskCount,
 	}, nil

--- a/search/gemini-enterprise/group-licensing/internal/config/job_settings_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/config/job_settings_test.go
@@ -44,6 +44,42 @@ func TestLoadJobSettings(t *testing.T) {
 			},
 		},
 		{
+			name: "happy path: DIRECT_LAW explicitly set to true",
+			env: map[string]string{
+				"JOB_TYPE":   "joiner",
+				"DIRECT_LAW": "true",
+			},
+			want: &JobSettings{
+				JobType:   models.WorkflowJoiner,
+				DryRun:    false,
+				DirectLaw: true,
+				TaskIndex: 0,
+				TaskCount: 1,
+			},
+		},
+		{
+			name: "happy path: DIRECT_LAW explicitly set to false",
+			env: map[string]string{
+				"JOB_TYPE":   "joiner",
+				"DIRECT_LAW": "false",
+			},
+			want: &JobSettings{
+				JobType:   models.WorkflowJoiner,
+				DryRun:    false,
+				DirectLaw: false,
+				TaskIndex: 0,
+				TaskCount: 1,
+			},
+		},
+		{
+			name: "invalid DIRECT_LAW value returns ErrConfigInvalid",
+			env: map[string]string{
+				"JOB_TYPE":   "joiner",
+				"DIRECT_LAW": "not-a-bool",
+			},
+			wantErr: models.ErrConfigInvalid,
+		},
+		{
 			name:    "missing JOB_TYPE",
 			env:     map[string]string{},
 			wantErr: models.ErrConfigInvalid,

--- a/search/gemini-enterprise/group-licensing/internal/models/dto/sync.go
+++ b/search/gemini-enterprise/group-licensing/internal/models/dto/sync.go
@@ -21,7 +21,8 @@ package dto
 type SyncAddRequest struct {
 	// DryRun overrides the config-level dry_run setting when present.
 	// A nil pointer means "use the config value".
-	DryRun *bool `json:"dry_run,omitempty"`
+	DryRun    *bool `json:"dry_run,omitempty"`
+	DirectLaw *bool `json:"direct_law,omitempty"`
 }
 
 // Validate checks that SyncAddRequest contains only valid field values.
@@ -37,12 +38,14 @@ type SyncAddResponse struct {
 	LicensesSoftFailed int    `json:"licenses_soft_failed"`
 	GroupsProcessed    int    `json:"groups_processed"`
 	DryRun             bool   `json:"dry_run"`
+	DirectLaw          bool   `json:"direct_law"`
 }
 
 // SyncRemoveRequest is the HTTP request body for POST /sync/remove.
 type SyncRemoveRequest struct {
 	// DryRun overrides the config-level dry_run setting when present.
-	DryRun *bool `json:"dry_run,omitempty"`
+	DryRun    *bool `json:"dry_run,omitempty"`
+	DirectLaw *bool `json:"direct_law,omitempty"`
 }
 
 // Validate checks that SyncRemoveRequest contains only valid field values.
@@ -56,4 +59,5 @@ type SyncRemoveResponse struct {
 	LicensesRevoked int    `json:"licenses_revoked"`
 	UsersEvaluated  int    `json:"users_evaluated"`
 	DryRun          bool   `json:"dry_run"`
+	DirectLaw       bool   `json:"direct_law"`
 }

--- a/search/gemini-enterprise/group-licensing/internal/models/types.go
+++ b/search/gemini-enterprise/group-licensing/internal/models/types.go
@@ -54,7 +54,7 @@ type LicenseUpdate struct {
 	UserEmail         string
 	SKU               SKU
 	Location          Location
-	LicenseConfigPath string // revokes only: resource path from UserLicense
+	LicenseConfigPath string // revokes and direct_law join only: resource path from UserLicense
 	Action            LicenseAction
 }
 
@@ -64,9 +64,10 @@ type LicenseUpdate struct {
 // the human-readable project ID — the Discovery Engine API uses numbers in
 // licenseConfig resource paths.
 type LicenseConfigKey struct {
-	SKU           SKU
-	ProjectNumber string
-	Location      Location
+	SKU            SKU
+	SubscriptionID string // only used in direct_law join mode, admin-specifies the {uuid} in licenseConfigs/{uuid}
+	ProjectNumber  string
+	Location       Location
 }
 
 // LicenseConfigEntry holds the full licenseConfig resource path and the number

--- a/search/gemini-enterprise/group-licensing/internal/ports/gemini.go
+++ b/search/gemini-enterprise/group-licensing/internal/ports/gemini.go
@@ -33,7 +33,7 @@ type GeminiClient interface {
 	// billing account and returns an index mapping (SKU, ProjectID, Location) to
 	// the full licenseConfig resource path. Call this once at startup and pass the
 	// result to SetLicenseConfigIndex before issuing any grant operations.
-	FetchLicenseConfigIndex(ctx context.Context, billingAccountID string) (models.LicenseConfigIndex, error)
+	FetchLicenseConfigIndex(ctx context.Context, billingAccountID string, directLaw bool) (models.LicenseConfigIndex, error)
 
 	// ListUserLicenses returns one page of licensed users for projectID at the
 	// given location. Pass an empty pageToken to start from the beginning. A

--- a/search/gemini-enterprise/group-licensing/internal/services/gc.go
+++ b/search/gemini-enterprise/group-licensing/internal/services/gc.go
@@ -62,12 +62,17 @@ func (s *GCService) Run(ctx context.Context, cfg *config.EntitlementConfig, req 
 	if req.DryRun != nil {
 		dryRun = *req.DryRun
 	}
+	directLaw := false
+	if req.DirectLaw != nil {
+		directLaw = *req.DirectLaw
+	}
 
 	start := time.Now()
 	logger.InfoContext(ctx, "garbage collection workflow starting",
 		slog.Int("project_count", len(cfg.Projects)),
 		slog.Int("staleness_threshold_days", cfg.Settings.StalenessThresholdDays),
 		slog.Bool("dry_run", dryRun),
+		slog.Bool("direct_law_mode", directLaw),
 	)
 
 	var totalRevoked, totalEvaluated int
@@ -93,12 +98,14 @@ func (s *GCService) Run(ctx context.Context, cfg *config.EntitlementConfig, req 
 		slog.Int("licenses_revoked", totalRevoked),
 		slog.Int("users_evaluated", totalEvaluated),
 		slog.Bool("dry_run", dryRun),
+		slog.Bool("direct_law_mode", directLaw),
 	)
 
 	return dto.SyncRemoveResponse{
 		LicensesRevoked: totalRevoked,
 		UsersEvaluated:  totalEvaluated,
 		DryRun:          dryRun,
+		DirectLaw:       directLaw,
 	}, nil
 }
 

--- a/search/gemini-enterprise/group-licensing/internal/services/gc_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/services/gc_test.go
@@ -687,3 +687,51 @@ func TestGCService_processProject_PageLimitReached(t *testing.T) {
 	require.NoError(t, err)
 	gemini.AssertNumberOfCalls(t, "ListUserLicenses", models.MaxPagesPerGroup)
 }
+
+func TestGCService_Run_DirectLaw(t *testing.T) {
+	// Under direct_law mode, the Garbage Collection workflow must run successfully,
+	// verifying entitlements correctly, and propagating the direct_law flag.
+	ctx := context.Background()
+
+	idp := new(MockIdpClient)
+	gemini := new(MockGeminiClient)
+
+	const (
+		projectID = "proj-gc-dl"
+		group     = "grp-dl@example.com"
+		userEmail = "active-dl@example.com"
+	)
+
+	gemini.On("ListUserLicenses", mock.Anything, projectID, models.LocationGlobal, "").
+		Return([]models.UserLicense{
+			{
+				UserEmail:     userEmail,
+				State:         models.LicenseStateAssigned,
+				LastLoginTime: time.Now().AddDate(0, 0, -5),
+			},
+		}, "", nil)
+
+	idp.On("HasMember", mock.Anything, group, userEmail).Return(true, nil)
+
+	cfg := newGCConfig(30, map[string]config.ProjectConfig{
+		projectID: {
+			{
+				SubscriptionTier: models.SKUAgentspaceBusiness,
+				SubscriptionID:   func(s string) *string { return &s }("sub-uuid-abc"),
+				Location:         models.LocationGlobal,
+				Groups:           []string{group},
+			},
+		},
+	})
+
+	svc := NewGCService(idp, gemini)
+	resp, err := svc.Run(ctx, cfg, dto.SyncRemoveRequest{DirectLaw: boolPtr(true)})
+
+	require.NoError(t, err)
+	assert.True(t, resp.DirectLaw)
+	assert.Equal(t, 0, resp.LicensesRevoked)
+	assert.Equal(t, 1, resp.UsersEvaluated)
+
+	idp.AssertExpectations(t)
+	gemini.AssertExpectations(t)
+}

--- a/search/gemini-enterprise/group-licensing/internal/services/joiner.go
+++ b/search/gemini-enterprise/group-licensing/internal/services/joiner.go
@@ -68,8 +68,12 @@ func (s *JoinerService) Run(ctx context.Context, cfg *config.EntitlementConfig, 
 	if req.DryRun != nil {
 		dryRun = *req.DryRun
 	}
+	directLaw := false
+	if req.DirectLaw != nil {
+		directLaw = *req.DirectLaw
+	}
 
-	licenseIndex, err := s.gemini.FetchLicenseConfigIndex(ctx, cfg.BillingAccountID)
+	licenseIndex, err := s.gemini.FetchLicenseConfigIndex(ctx, cfg.BillingAccountID, directLaw)
 	if err != nil {
 		return dto.SyncAddResponse{}, fmt.Errorf("fetching license config index: %w", err)
 	}
@@ -90,12 +94,13 @@ func (s *JoinerService) Run(ctx context.Context, cfg *config.EntitlementConfig, 
 	logger.InfoContext(ctx, "joiner workflow starting",
 		slog.Int("project_count", len(cfg.Projects)),
 		slog.Bool("dry_run", dryRun),
+		slog.Bool("direct_law_mode", directLaw),
 	)
 
 	var totalGranted, totalSoftFailed, totalGroups int
 
 	for projectID, projectCfg := range cfg.Projects {
-		granted, softFailed, groups, err := s.processProject(ctx, projectID, projectNumbers[projectID], projectCfg, licenseIndex, dryRun)
+		granted, softFailed, groups, err := s.processProject(ctx, projectID, projectNumbers[projectID], projectCfg, licenseIndex, dryRun, directLaw)
 		if err != nil {
 			logger.ErrorContext(ctx, "joiner workflow failed",
 				slog.String("project_id", projectID),
@@ -117,6 +122,7 @@ func (s *JoinerService) Run(ctx context.Context, cfg *config.EntitlementConfig, 
 		slog.Int("licenses_soft_failed", totalSoftFailed),
 		slog.Int("groups_processed", totalGroups),
 		slog.Bool("dry_run", dryRun),
+		slog.Bool("direct_law_mode", directLaw),
 	)
 
 	return dto.SyncAddResponse{
@@ -124,14 +130,17 @@ func (s *JoinerService) Run(ctx context.Context, cfg *config.EntitlementConfig, 
 		LicensesSoftFailed: totalSoftFailed,
 		GroupsProcessed:    totalGroups,
 		DryRun:             dryRun,
+		DirectLaw:          directLaw,
 	}, nil
 }
 
 // userEntitlement pairs the highest-precedence SKU a user is entitled to with
-// the location of the group entry that granted it.
+// the location of the group entry that granted it. Alternatively, if admin-specified,
+// it pairs the SubscriptionID a user is entitled to with the location of the group entry.
 type userEntitlement struct {
-	SKU      models.SKU
-	Location models.Location
+	SKU            models.SKU
+	Location       models.Location
+	SubscriptionID string // only used in direct_law join mode, admin-specifies the {uuid} in licenseConfigs/{uuid}
 }
 
 // processProject enumerates all configured groups for a single GCP project,
@@ -142,14 +151,18 @@ type userEntitlement struct {
 // users from an exhausted pool into the next pool's batch.
 // It returns the number of licenses granted, the number of users soft-failed
 // due to license pool exhaustion, and the number of groups processed.
-func (s *JoinerService) processProject(ctx context.Context, projectID, projectNumber string, projectCfg config.ProjectConfig, index models.LicenseConfigIndex, dryRun bool) (licensesGranted, licensesSoftFailed, groupsProcessed int, err error) {
+func (s *JoinerService) processProject(ctx context.Context, projectID, projectNumber string, projectCfg config.ProjectConfig, index models.LicenseConfigIndex, dryRun bool, directLaw bool) (licensesGranted, licensesSoftFailed, groupsProcessed int, err error) {
 	// userBestEntitlement maps each user email to the highest-ranked entitlement
 	// (SKU + location) across all groups in this project.
 	userBestEntitlement := make(map[string]userEntitlement)
 
 	for _, cfgEntry := range projectCfg {
 		for _, groupEmail := range cfgEntry.Groups {
-			if err := s.collectGroupMembers(ctx, groupEmail, cfgEntry.SubscriptionTier, cfgEntry.Location, userBestEntitlement); err != nil {
+			subID := ""
+			if directLaw {
+				subID = *cfgEntry.SubscriptionID
+			}
+			if err := s.collectGroupMembers(ctx, groupEmail, cfgEntry.SubscriptionTier, subID, cfgEntry.Location, userBestEntitlement, directLaw); err != nil {
 				return 0, 0, 0, fmt.Errorf("project %q group %q: %w", projectID, groupEmail, err)
 			}
 			groupsProcessed++
@@ -161,11 +174,42 @@ func (s *JoinerService) processProject(ctx context.Context, projectID, projectNu
 	pendingByKey := make(map[models.LicenseConfigKey][]models.LicenseUpdate)
 
 	for email, ent := range userBestEntitlement {
-		key := models.LicenseConfigKey{SKU: ent.SKU, ProjectNumber: projectNumber, Location: ent.Location}
+		// Default behavior is to index by SKU (automatic mode)
+		key := models.LicenseConfigKey{
+			SKU:           ent.SKU,
+			ProjectNumber: projectNumber,
+			Location:      ent.Location,
+		}
+		// If in direct_law mode, change to index by admin-specified SubscriptionID
+		if directLaw {
+			key = models.LicenseConfigKey{
+				SubscriptionID: ent.SubscriptionID,
+				ProjectNumber:  projectNumber,
+				Location:       ent.Location,
+			}
+		}
 		entries, ok := index[key]
 		if !ok || len(entries) == 0 {
+			if directLaw {
+				return 0, 0, 0, fmt.Errorf("project %q: no licenseConfig found for SKU %q Subscription %q location %q", projectID, ent.SKU, ent.SubscriptionID, ent.Location)
+			}
 			return 0, 0, 0, fmt.Errorf("project %q: no licenseConfig found for SKU %q location %q", projectID, ent.SKU, ent.Location)
 		}
+		// If in direct_law mode, for each user include LicenseConfigPath in the key because {uuid} is unambiguous and should be unique; assume {uuid} unique and defined once in config.json and only create slice of just one LicenseUpdate entry
+		if directLaw {
+			for _, entry := range entries {
+				pendingUpdate := models.LicenseUpdate{
+					UserEmail:         email,
+					SKU:               ent.SKU,
+					Location:          ent.Location,
+					LicenseConfigPath: entry.Path,
+					Action:            models.LicenseActionGrant,
+				}
+				pendingByKey[key] = append(pendingByKey[key], pendingUpdate)
+			}
+
+		} else {
+			// Default behavior for each user is to index by SKU which holds a slice of one or many LicenseUpdates
 		// LicenseConfigPath will be resolved per-entry when building each chunk.
 		pendingByKey[key] = append(pendingByKey[key], models.LicenseUpdate{
 			UserEmail: email,
@@ -173,6 +217,7 @@ func (s *JoinerService) processProject(ctx context.Context, projectID, projectNu
 			Location:  ent.Location,
 			Action:    models.LicenseActionGrant,
 		})
+		}
 	}
 
 	for key, updates := range pendingByKey {
@@ -263,7 +308,7 @@ func (s *JoinerService) grantBatch(ctx context.Context, projectID, projectNumber
 // collectGroupMembers pages through all members of groupEmail and updates
 // userBestEntitlement with the supplied (sku, location) when sku is higher
 // than any previously recorded SKU for that user.
-func (s *JoinerService) collectGroupMembers(ctx context.Context, groupEmail string, sku models.SKU, location models.Location, userBestEntitlement map[string]userEntitlement) error {
+func (s *JoinerService) collectGroupMembers(ctx context.Context, groupEmail string, sku models.SKU, subID string, location models.Location, userBestEntitlement map[string]userEntitlement, directLaw bool) error {
 	var pageToken string
 	var pageCount int
 
@@ -289,7 +334,10 @@ func (s *JoinerService) collectGroupMembers(ctx context.Context, groupEmail stri
 			if m.Type != models.MemberTypeUser {
 				continue
 			}
-
+			if directLaw {
+				userBestEntitlement[m.Email] = userEntitlement{SKU: sku, SubscriptionID: subID, Location: location}
+				continue
+			}
 			existing, seen := userBestEntitlement[m.Email]
 			if !seen || sku.HasHigherPrecedenceThan(existing.SKU) {
 				userBestEntitlement[m.Email] = userEntitlement{SKU: sku, Location: location}

--- a/search/gemini-enterprise/group-licensing/internal/services/joiner_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/services/joiner_test.go
@@ -78,7 +78,7 @@ func TestJoinerService_Run_HappyPath_SKUPrecedence(t *testing.T) {
 		userBoth    = "both@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -145,7 +145,7 @@ func TestJoinerService_Run_DryRun_NoAPIWrite(t *testing.T) {
 		group     = "grp@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -180,7 +180,7 @@ func TestJoinerService_Run_FetchLicenseConfigIndexError_ReturnsError(t *testing.
 	gemini := new(MockGeminiClient)
 	rm := new(MockResourceManagerClient)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(models.LicenseConfigIndex(nil), errors.New("billing api unavailable"))
 
 	cfg := newJoinerConfig(map[string]config.ProjectConfig{
@@ -205,7 +205,7 @@ func TestJoinerService_Run_ResolveProjectNumberError_ReturnsError(t *testing.T) 
 	gemini := new(MockGeminiClient)
 	rm := new(MockResourceManagerClient)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, "proj-x").
 		Return("", errors.New("project not found"))
@@ -236,7 +236,7 @@ func TestJoinerService_Run_ListMembersError_ReturnsWrappedError(t *testing.T) {
 		group     = "grp@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -270,7 +270,7 @@ func TestJoinerService_Run_BatchUpdateError_ReturnsError(t *testing.T) {
 		group     = "grp@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -313,7 +313,7 @@ func TestJoinerService_Run_MultiPagePagination_AllMembersCollected(t *testing.T)
 		tokenP1   = "page-token-1"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -361,7 +361,7 @@ func TestJoinerService_Run_EmptyGroup_NoBatchCall(t *testing.T) {
 		group     = "empty@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(models.LicenseConfigIndex{}, nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -423,7 +423,7 @@ func TestJoinerService_Run_GroupTypeMembersIgnored(t *testing.T) {
 		group     = "parent@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -471,7 +471,7 @@ func TestJoinerService_Run_LicensePoolExhausted_TrimsAndSoftFails(t *testing.T) 
 		allocatedStr = "50"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -533,7 +533,7 @@ func TestJoinerService_Run_LicensePoolFullyExhausted_AllSoftFailed(t *testing.T)
 		configPath = "projects/" + projectNumber + "/locations/global/licenseConfigs/ent-config"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -586,7 +586,7 @@ func TestJoinerService_Run_LicensePoolExhausted_UsageStatsFails_ReturnsError(t *
 		group     = "grp@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -632,7 +632,7 @@ func TestJoinerService_Run_LicensePoolExhausted_DryRun_NoFetchOrRetry(t *testing
 		group     = "grp@example.com"
 	)
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(licenseIndexForProject(projectNumber), nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -687,7 +687,7 @@ func TestJoinerService_Run_TwoPools_FirstExhausted_SpillsToSecond(t *testing.T) 
 		},
 	}
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(twoPoolIndex, nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -759,7 +759,7 @@ func TestJoinerService_Run_TwoPools_BothExhausted_AllSoftFailed(t *testing.T) {
 		},
 	}
 
-	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ").
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", false).
 		Return(twoPoolIndex, nil)
 	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
 
@@ -830,9 +830,113 @@ func TestJoinerService_collectGroupMembers_PageLimitReached(t *testing.T) {
 	svc := NewJoinerService(idp, gemini, new(MockResourceManagerClient))
 	userBestEntitlement := make(map[string]userEntitlement)
 
-	err := svc.collectGroupMembers(ctx, groupEmail, models.SKUAgentspaceBusiness, models.LocationGlobal, userBestEntitlement)
+	err := svc.collectGroupMembers(ctx, groupEmail, models.SKUAgentspaceBusiness, "", models.LocationGlobal, userBestEntitlement, false)
 
 	require.NoError(t, err)
 	idp.AssertNumberOfCalls(t, "ListMembers", models.MaxPagesPerGroup)
 	gemini.AssertNotCalled(t, "BatchUpdateUserLicenses")
+}
+
+func TestJoinerService_Run_DirectLaw_HappyPath(t *testing.T) {
+	// Under direct_law mode, the service must resolve licenses using the
+	// admin-specified SubscriptionID rather than matching by SKU, resolving the
+	// correct path from the index and calling BatchUpdateUserLicenses.
+	ctx := context.Background()
+
+	idp := new(MockIdpClient)
+	gemini := new(MockGeminiClient)
+	rm := new(MockResourceManagerClient)
+
+	const (
+		projectID = "proj-direct-law"
+		group     = "direct-grp@example.com"
+		userEmail = "user-dl@example.com"
+		subID     = "sub-uuid-dl-99"
+	)
+
+	// Mocking index returned from Gemini API
+	index := models.LicenseConfigIndex{
+		{SubscriptionID: subID, ProjectNumber: projectNumber, Location: models.LocationGlobal}: {
+			{Path: "projects/" + projectNumber + "/locations/global/licenseConfigs/" + subID, AllocatedCount: 10},
+		},
+	}
+
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", true).Return(index, nil)
+	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
+
+	idp.On("ListMembers", mock.Anything, group, "").
+		Return([]models.Member{{Email: userEmail, Type: models.MemberTypeUser}}, "", nil)
+
+	// Assert BatchUpdateUserLicenses matches the resolved Subscription ID path
+	gemini.On("BatchUpdateUserLicenses", mock.Anything, projectID, models.LocationGlobal, mock.MatchedBy(func(updates []models.LicenseUpdate) bool {
+		return len(updates) == 1 &&
+			updates[0].UserEmail == userEmail &&
+			updates[0].LicenseConfigPath == "projects/"+projectNumber+"/locations/global/licenseConfigs/"+subID &&
+			updates[0].Action == models.LicenseActionGrant
+	})).Return(nil)
+
+	cfg := newJoinerConfig(map[string]config.ProjectConfig{
+		projectID: {
+			{
+				SubscriptionTier: models.SKUEnterprise, // Not used for lookup under directLaw
+				SubscriptionID:   func(s string) *string { return &s }(subID),
+				Location:         models.LocationGlobal,
+				Groups:           []string{group},
+			},
+		},
+	})
+
+	svc := NewJoinerService(idp, gemini, rm)
+	resp, err := svc.Run(ctx, cfg, dto.SyncAddRequest{DirectLaw: boolPtr(true)})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, resp.LicensesGranted)
+	assert.True(t, resp.DirectLaw)
+
+	idp.AssertExpectations(t)
+	gemini.AssertExpectations(t)
+	rm.AssertExpectations(t)
+}
+
+func TestJoinerService_Run_DirectLaw_MissingSubscriptionInIndex(t *testing.T) {
+	// Under direct_law mode, if the admin-specified SubscriptionID does not
+	// exist in the billing config index returned by the API, the service must
+	// fail and return a descriptive error.
+	ctx := context.Background()
+
+	idp := new(MockIdpClient)
+	gemini := new(MockGeminiClient)
+	rm := new(MockResourceManagerClient)
+
+	const (
+		projectID = "proj-missing-dl"
+		group     = "direct-grp@example.com"
+		userEmail = "user-dl@example.com"
+		subID     = "non-existent-sub-id"
+	)
+
+	// Empty index - no matching subscriptions
+	index := models.LicenseConfigIndex{}
+
+	gemini.On("FetchLicenseConfigIndex", mock.Anything, "ABCDE-12345-FGHIJ", true).Return(index, nil)
+	rm.On("ResolveProjectNumber", mock.Anything, projectID).Return(projectNumber, nil)
+
+	idp.On("ListMembers", mock.Anything, group, "").
+		Return([]models.Member{{Email: userEmail, Type: models.MemberTypeUser}}, "", nil)
+
+	cfg := newJoinerConfig(map[string]config.ProjectConfig{
+		projectID: {
+			{
+				SubscriptionTier: models.SKUEnterprise,
+				SubscriptionID:   func(s string) *string { return &s }(subID),
+				Location:         models.LocationGlobal,
+				Groups:           []string{group},
+			},
+		},
+	})
+
+	svc := NewJoinerService(idp, gemini, rm)
+	_, err := svc.Run(ctx, cfg, dto.SyncAddRequest{DirectLaw: boolPtr(true)})
+
+	require.Error(t, err)
 }

--- a/search/gemini-enterprise/group-licensing/internal/services/mocks_test.go
+++ b/search/gemini-enterprise/group-licensing/internal/services/mocks_test.go
@@ -61,8 +61,8 @@ type MockGeminiClient struct {
 }
 
 // FetchLicenseConfigIndex satisfies ports.GeminiClient.
-func (m *MockGeminiClient) FetchLicenseConfigIndex(ctx context.Context, billingAccountID string) (models.LicenseConfigIndex, error) {
-	args := m.Called(ctx, billingAccountID)
+func (m *MockGeminiClient) FetchLicenseConfigIndex(ctx context.Context, billingAccountID string, directLaw bool) (models.LicenseConfigIndex, error) {
+	args := m.Called(ctx, billingAccountID, directLaw)
 	index, _ := args.Get(0).(models.LicenseConfigIndex)
 	return index, args.Error(1)
 }


### PR DESCRIPTION
# Description

Added new feature to the Gemini Enterprise group-licensing utility which allows the admin to directly specify subscription_id in configuration. This admin-specified subscription_id overrides automation logic that normally aggregates and assigns Gemini Enterprise licenses based on subscription tiers to groups of users.

Tagging peer, @williamsmt for review of code changes.