### PR TITLE
chore: rename GE Demo Generator to Gemini Enterprise Demo Generator (v11.60-public)

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — AI Agent Development Guide for GE Demo Generator
+# AGENTS.md — AI Agent Development Guide for Gemini Enterprise Demo Generator
 
 > **Purpose**: Project-specific knowledge for AI coding agents (Antigravity, Cursor, Copilot, etc.)
 > and humans working on this sample.
@@ -299,12 +299,12 @@ can delegate long-running autonomous work to over the **Interactions API**
   `create_managed_agent.py start`) → `.env` + Cloud Run env
   (`ENABLE_MANAGED_AGENT`, `MANAGED_AGENT_ID`, `MANAGED_AGENT_SKILLS_SOURCE`)
   → env-gated blocks in `tools.py` / `agent.py` / `fast_api_app.py` → PHASE B
-  (after Cloud Run deploy + GE registration: `create_managed_agent.py wait`
+  (after Cloud Run deploy + Gemini Enterprise registration: `create_managed_agent.py wait`
   polls readiness, `warmup_managed_agent.py` stores the environment id in
   Firestore `<demo>_managed_agent_state/current`). The A/B split hides the
   ~8-10 min agent creation behind the rest of the setup.
-- **`enableWorkspaceAuth` (auth-only mode)**: sets up the GE OAuth
-  authorization WITHOUT the Developer-Preview Workspace MCP servers (no
+- **`enableWorkspaceAuth` (auth-only mode)**: sets up the Gemini
+  Enterprise OAuth authorization WITHOUT the Developer-Preview Workspace MCP servers (no
   allowlist needed). Derived gates: `workspaceAuthEnabled = enableWorkspaceMcp
   || enableWorkspaceAuth` (auth infra) and `driveHandoffEnabled =
   enableManagedAgent && workspaceAuthEnabled` (Drive save tool, gws skills,

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -1,10 +1,10 @@
-# GE Demo Generator
+# Gemini Enterprise Demo Generator
 
 > **Disclaimer:** This is not an officially supported Google product. This open-source solution is intended to enhance the Google customer experience. Support and/or new releases are handled on a best-effort basis.
 
-## What is the GE Demo Generator?
+## What is the Gemini Enterprise Demo Generator?
 
-The **GE Demo Generator** is a low-code web application built on Google Apps Script (GAS) that instantly synthesizes fully functional, domain-specific custom demo environments for **Gemini Enterprise**. By inputting your client's unique business challenges, the tool dynamically provisions datasets, an AI agent with MCP toolsets, and a real-time operations dashboard — all tailored to their business workflow.
+The **Gemini Enterprise Demo Generator** is a low-code web application built on Google Apps Script (GAS) that instantly synthesizes fully functional, domain-specific custom demo environments for **Gemini Enterprise**. By inputting your client's unique business challenges, the tool dynamically provisions datasets, an AI agent with MCP toolsets, and a real-time operations dashboard — all tailored to their business workflow.
 
 ### 💡 Business Value
 - **Hyper-Fast Pre-Sales**: Prepare hyper-personalized demonstrations within minutes instead of weeks.
@@ -35,7 +35,7 @@ The **GE Demo Generator** is a low-code web application built on Google Apps Scr
 
 ## Table of Contents
 
-- [What is the GE Demo Generator?](#what-is-the-ge-demo-generator)
+- [What is the Gemini Enterprise Demo Generator?](#what-is-the-gemini-enterprise-demo-generator)
 - [1. Prerequisites](#1-prerequisites)
 - [2. Repository Setup](#2-repository-setup)
 - [3. Apps Script Project Setup](#3-apps-script-project-setup)
@@ -276,7 +276,7 @@ Even with correct scopes in `appsscript.json`, you **must** manually authorize t
 1. In the Apps Script editor, click **Deploy > New Deployment**.
 2. Click the gear icon next to "Select type" and choose **Web App**.
 3. Configure:
-   - **Description**: e.g., `GE Demo Generator v1`
+   - **Description**: e.g., `Gemini Enterprise Demo Generator v1`
    - **Execute as**: `User accessing the web app`
    - **Who has access**: `Anyone` (or restrict as needed)
 4. Click **Deploy**.
@@ -327,9 +327,10 @@ ge-demo-generator/
 ├── deploy.sh                # Clasp deployment orchestrator script
 ├── validate_examples.py     # Validates agent_template JSON + Python files
 ├── check_deps.py            # Audits the PINNED_DEPS major caps (AGENTS.md 8)
-├── ge-demo-generator-lite/  # (Subproject) GE Demo Generator Lite — Workspace
-│                            #  demo-data generator for Gemini Enterprise
-│                            #  editions without custom-agent support
+├── ge-demo-generator-lite/  # (Subproject) Gemini Enterprise Demo Generator
+│                            #  Lite — Workspace demo-data generator for
+│                            #  Gemini Enterprise editions without
+│                            #  custom-agent support
 │   ├── appsscript.json
 │   ├── Code.gs
 │   ├── index.html
@@ -523,13 +524,13 @@ When you open an issue, please include:
 
 ## 14. System Architecture
 
-This document describes the system architecture of the GE Demo Generator and the synthesized demo environments it produces.
+This document describes the system architecture of the Gemini Enterprise Demo Generator and the synthesized demo environments it produces.
 
 ---
 
 ### 14.1 Overview
 
-The GE Demo Generator is a low-code accelerator built on Google Apps Script that allows Customer Engineers to instantly synthesize fully functional AI agent demo environments for any business domain. It generates domain-specific datasets, an ADK-based agent with MCP toolsets, and a real-time operations dashboard — all provisioned into the user's own Google Cloud project.
+The Gemini Enterprise Demo Generator is a low-code accelerator built on Google Apps Script that allows Customer Engineers to instantly synthesize fully functional AI agent demo environments for any business domain. It generates domain-specific datasets, an ADK-based agent with MCP toolsets, and a real-time operations dashboard — all provisioned into the user's own Google Cloud project.
 
 The system is divided into two main parts: the **Generator Dashboard** (the Apps Script web app) and the **Synthesized Demo Environment** (the Google Cloud resources created by the setup script).
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /**
- * GE Demo Generator — Backend (Code.gs)
+ * Gemini Enterprise Demo Generator — Backend (Code.gs)
  *
  * End-to-end generator for production-ready AI agent demo environments.
  * Given a natural-language business goal, this Google Apps Script file
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.59-public',
+  APP_VERSION: 'v11.60-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -166,7 +166,7 @@ function doGet() {
     const template = HtmlService.createTemplateFromFile('SetupError');
     template.errorMessage = configError;
     return template.evaluate()
-      .setTitle('Setup Required - GE Demo Generator')
+      .setTitle('Setup Required - Gemini Enterprise Demo Generator')
       .addMetaTag('viewport', 'width=device-width, initial-scale=1.0');
   }
 
@@ -179,7 +179,7 @@ function doGet() {
   template.generatorModel = CONFIG.MODEL || 'gemini-3.7-flash';
   
   return template.evaluate()
-    .setTitle('GE Demo Generator')
+    .setTitle('Gemini Enterprise Demo Generator')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1.0')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
@@ -2865,7 +2865,7 @@ if [ "$SKIP_SLACK_OAUTH" = "false" ]; then
   SLACK_REDIRECT_URL="https://localhost"
 
   # ── Step 1: Create Slack App via Manifest URL ──
-  SLACK_MANIFEST='{"display_information":{"name":"${(`GE-${dirName}`).substring(0, 35)}"},"features":{},"oauth_config":{"redirect_urls":["'"$SLACK_REDIRECT_URL"'"],"scopes":{"user":["search:read","channels:read","channels:history","groups:read","groups:history","im:read","im:history","mpim:read","mpim:history","chat:write","reactions:read","users:read","users:read.email","team:read","files:read","canvases:read","canvases:write"]}},"settings":{"org_deploy_enabled":false,"socket_mode_enabled":false,"token_rotation_enabled":false}}'
+  SLACK_MANIFEST='{"display_information":{"name":"${dirName.substring(0, 35)}"},"features":{},"oauth_config":{"redirect_urls":["'"$SLACK_REDIRECT_URL"'"],"scopes":{"user":["search:read","channels:read","channels:history","groups:read","groups:history","im:read","im:history","mpim:read","mpim:history","chat:write","reactions:read","users:read","users:read.email","team:read","files:read","canvases:read","canvases:write"]}},"settings":{"org_deploy_enabled":false,"socket_mode_enabled":false,"token_rotation_enabled":false}}'
   ENCODED_MANIFEST=$(python3 -c "import urllib.parse; print(urllib.parse.quote('''$SLACK_MANIFEST'''))")
   CREATE_URL="https://api.slack.com/apps?new_app=1&manifest_json=$ENCODED_MANIFEST"
 
@@ -2991,7 +2991,7 @@ echo "════════════════════════�
 echo ""
 RMCP_URL="${mcp.endpoint_url}"
 RMCP_SECRET="${rmSecret}"
-RMCP_CLIENT_NAME="GE Demo (${dirName})"
+RMCP_CLIENT_NAME="Gemini Enterprise Demo (${dirName})"
 RMCP_REDIRECT="https://localhost"
 RMCP_CLIENT_ID=""
 RMCP_CLIENT_SECRET=""
@@ -3328,7 +3328,7 @@ echo "The following steps require manual interaction in the Google Cloud Console
   echo ""
   echo "1. Set up the OAuth consent screen (Branding):"
   echo "   URL: https://console.cloud.google.com/auth/branding?project=\$PROJECT_ID"
-  echo "   - App name: 'GE Demo Agent' (any name works - end users see it on the consent screen)"
+  echo "   - App name: 'Gemini Enterprise Demo Agent' (any name works - end users see it on the consent screen)"
   echo "   - Support email: your own email address"
   echo "   - Audience: choose 'Internal' (recommended - only users in your org, no verification needed)."
   echo "     If 'Internal' is not available (no Workspace org), choose 'External' and then add your"
@@ -3362,7 +3362,7 @@ echo "The following steps require manual interaction in the Google Cloud Console
   echo "3. Create an OAuth 2.0 Client ID (Web application):"
   echo "   URL: https://console.cloud.google.com/auth/clients/create?project=\$PROJECT_ID"
   echo "   - Application type: 'Web application'"
-  echo "   - Name: 'GE Demo Generator' (any name works - it is only shown in the console)"
+  echo "   - Name: 'Gemini Enterprise Demo Generator' (any name works - it is only shown in the console)"
   echo "   - Add the following Authorized Redirect URIs:"
   echo "     - https://vertexaisearch.cloud.google.com/oauth-redirect"
   echo "     - https://vertexaisearch.cloud.google.com/static/oauth/oauth.html"
@@ -3383,9 +3383,9 @@ ${ enableWorkspaceMcp ? `  echo "4. Configure the Chat app (required for Chat MC
 ` : `  echo "4. Configure the Google Chat API app (one-time; required for the agent to post to Chat with your authorization):"
   echo "   URL: https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat?project=\$PROJECT_ID"
   echo "   In 'Google Chat API' -> 'Manage' -> 'Configuration', set:"
-  echo "     - App name: 'GE Demo Agent'"
+  echo "     - App name: 'Gemini Enterprise Demo Agent'"
   echo "     - Avatar URL: https://developers.google.com/chat/images/quickstart-app-avatar.png"
-  echo "     - Description: 'GE Demo Agent Workspace actions'"
+  echo "     - Description: 'Gemini Enterprise Demo Agent Workspace actions'"
   echo "     - Disable 'Enable interactive features'."
   echo "     - Under 'Visibility', make the app available to yourself (enter your email or your domain)."
   echo "     - Under 'Logs', select 'Log errors to Logging'."
@@ -3408,7 +3408,7 @@ else
   echo "✅ Stored OAuth credentials found - skipping the console tutorial."
   echo "   Reminder: posting to Google Chat needs a ONE-TIME Google Chat API app configuration:"
   echo "   https://console.cloud.google.com/apis/api/chat.googleapis.com/hangouts-chat?project=\$PROJECT_ID"
-  echo "   If Chat posts fail with a permission/configuration error, open 'Configuration' there and set it up (App name: '${enableWorkspaceMcp ? 'Chat MCP' : 'GE Demo Agent'}')."
+  echo "   If Chat posts fail with a permission/configuration error, open 'Configuration' there and set it up (App name: '${enableWorkspaceMcp ? 'Chat MCP' : 'Gemini Enterprise Demo Agent'}')."
 fi
 
 # ── OAuth credential pre-flight (v11.38) ──────────────────────────────────
@@ -3510,7 +3510,7 @@ rm -f "\$AUTH_RESP"
 
   let fullScript = `#!/bin/bash
 # ===========================================
-# GE Demo Generator - Setup Script (${CONFIG.APP_VERSION})
+# Gemini Enterprise Demo Generator - Setup Script (${CONFIG.APP_VERSION})
 # Generated: ${new Date().toISOString()}
 # Demo: ${dirName}
 # ===========================================
@@ -3697,7 +3697,7 @@ ${ enableManagedAgent ? `    echo "  • Managed Agent (Antigravity): ${managedA
     _HAS_SLACK=\$(gcloud secrets describe "${dirName}-slack-token" --project="\$PROJECT_ID" 2>/dev/null && echo "yes" || echo "no")
     if [ "\$_HAS_SLACK" = "yes" ]; then
       echo "⚠️  Manual cleanup required after deletion:"
-      echo "  • Slack App: GE-${dirName}"
+      echo "  • Slack App: ${dirName}"
       echo "    → Delete manually at https://api.slack.com/apps"
       echo ""
     fi
@@ -3980,12 +3980,12 @@ for coll_name in ['${dirName}_task_definitions', '${dirName}_task_executions', '
       echo ""
       echo "📱 Slack App (manual cleanup required):"
       echo "   ⚠️  Please delete the Slack App manually at: https://api.slack.com/apps"
-      echo "   Look for an app named 'GE-${dirName}' and delete it."
+      echo "   Look for an app named '${dirName}' and delete it."
     fi
 ${ (params.importedMcpList || []).some(m => m.type === 'remote' && m.auth_type === 'oauth2_dcr') ? `
     echo ""
     echo "🔗 Managed remote MCP authorizations (manual cleanup):"
-    echo "   Setup registered an OAuth client named 'GE Demo (${dirName})' with:"
+    echo "   Setup registered an OAuth client named 'Gemini Enterprise Demo (${dirName})' with:"
 ${params.importedMcpList.filter(m => m.type === 'remote' && m.auth_type === 'oauth2_dcr').map(m => `    echo "     • ${m.name || m.endpoint_url}"`).join('\n')}
     echo "   Dynamically registered clients usually cannot be deleted via API."
     echo "   Revoke the demo's access in each provider's connected-apps settings."
@@ -4007,7 +4007,7 @@ AGENT_DISPLAY_NAME='${safeShortName}' # ge:agent-display-name
 # --- 1. Project Detection & Confirmation Loop ---
 while true; do
   echo "========================================================="
-  echo "⚡ GE Demo Generator - Setup Script"
+  echo "⚡ Gemini Enterprise Demo Generator - Setup Script"
   echo "   Version:      ${CONFIG.APP_VERSION}"
   echo "   Generated At: ${new Date().toISOString()}"
   echo "   Options:      --help | --cleanup | --model-analysis-agent | --model-root-agent"
@@ -7484,7 +7484,7 @@ Return ONLY the raw Markdown text in the detected language. Do not include any c
 
 /**
  * Translates Template Hub entries into a target language for display.
- * Ported from GE Demo Generator Lite: the frontend ships English-only data
+ * Ported from Gemini Enterprise Demo Generator Lite: the frontend ships English-only data
  * and asks the backend for translations on demand, so non-ASCII translations
  * never live in the inline frontend JS (which would break the GAS minifier).
  * Entries with an empty "text" are category labels (industries/job functions).

--- a/search/gemini-enterprise/ge-demo-generator/app/index.html
+++ b/search/gemini-enterprise/ge-demo-generator/app/index.html
@@ -1471,7 +1471,7 @@ limitations under the License.
         <header class="mb-6 text-center lg:text-left relative">
 
           <h1 class="text-3xl lg:text-4xl font-bold tracking-tight py-2 bg-clip-text text-transparent bg-gradient-to-r from-white to-gray-400 text-center lg:text-left mb-3">
-              GE Demo Generator
+              Gemini Enterprise Demo Generator
           </h1>
 
           <p
@@ -1531,7 +1531,7 @@ limitations under the License.
                         d="M13 10V3L4 14h7v7l9-11h-7z">
                       </path>
                     </svg>
-                    How GE Demo Generator Works
+                    How Gemini Enterprise Demo Generator Works
                   </h3>
                   <p class="text-[13px] text-gray-300 leading-relaxed mb-4">
                     This web application does not deploy resources directly into your project. Instead, it dynamically synthesizes a personalized <b>Setup Shell Script</b> based on your custom inputs. Once you execute this script in your Google Cloud Shell, it automatically provisions all necessary resources (BigQuery, Firestore, Cloud Run) securely within your own Google Cloud environment, allowing you to instantly start demonstrations.
@@ -4268,7 +4268,7 @@ limitations under the License.
       return preset ? { id: preset.id, label: preset.label, description: preset.description } : null;
     }
 
-    // ---- Template Hub dynamic translation (ported from GE Demo Generator Lite) ----
+    // ---- Template Hub dynamic translation (ported from Gemini Enterprise Demo Generator Lite) ----
     // English is the only authored dataset. Other languages are translated on
     // demand by the backend (translateTemplates) and cached per session, so
     // non-ASCII translations never live in this inline JS (GAS minifier).

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 /**
- * GE Demo Generator Lite - Backend (Code.gs)
+ * Gemini Enterprise Demo Generator Lite - Backend (Code.gs)
  *
  * Gemini Enterprise Business Edition (GEBE) does not support custom ADK agents.
  * Instead of generating a Cloud setup script, this app synthesizes demo content
@@ -23,7 +23,7 @@
  * Execution identity: the web app runs as USER_ACCESSING, so all files are created
  * in the accessing user's own Drive with their own authorization.
  *
- * Many helpers here are reused verbatim from the GE Demo Generator (Code.gs):
+ * Many helpers here are reused verbatim from the Gemini Enterprise Demo Generator (Code.gs):
  * Vertex AI Agent Platform calls, image generation, JSON repair, and retry.
  */
 
@@ -38,7 +38,7 @@ const CONFIG = {
   MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.7-flash',
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v1.8-public',
+  APP_VERSION: 'v1.9-public',
   MY_DEMOS_FOLDER: 'My Demos'
 };
 
@@ -60,7 +60,7 @@ function doGet(e) {
     const template = HtmlService.createTemplateFromFile('SetupError');
     template.errorMessage = configError;
     return template.evaluate()
-      .setTitle('Setup Required - GE Demo Generator Lite')
+      .setTitle('Setup Required - Gemini Enterprise Demo Generator Lite')
       .addMetaTag('viewport', 'width=device-width, initial-scale=1.0');
   }
 
@@ -79,7 +79,7 @@ function doGet(e) {
   template.webAppUrl = webAppUrl;
 
   return template.evaluate()
-    .setTitle('GE Demo Generator Lite')
+    .setTitle('Gemini Enterprise Demo Generator Lite')
     .addMetaTag('viewport', 'width=device-width, initial-scale=1.0')
     .setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
 }
@@ -123,7 +123,7 @@ function initializeProject(projectId) {
 }
 
 // ===========================================
-// Vertex AI Agent Platform utilities (reused from GE Demo Generator)
+// Vertex AI Agent Platform utilities (reused from Gemini Enterprise Demo Generator)
 // ===========================================
 
 function callVertexAIWithRetry(prompt) { return executeWithRetry(function () { return callVertexAI(prompt); }); }
@@ -498,7 +498,7 @@ function planDemo(userGoal, options) {
   // Normalize / clamp.
   plan.referenceDate = plan.referenceDate || todayStr;
   plan.customerName = plan.customerName ? String(plan.customerName) : '';
-  plan.folderName = sanitizeFolderName_(plan.folderName || ('Demo - ' + (plan.customerName || plan.domainName || 'GE Demo')));
+  plan.folderName = sanitizeFolderName_(plan.folderName || ('Demo - ' + (plan.customerName || plan.domainName || 'Gemini Enterprise Demo')));
   plan.agentDesignerPrompt = plan.agentDesignerPrompt ? String(plan.agentDesignerPrompt) : '';
   plan.demoGuide = Array.isArray(plan.demoGuide) ? plan.demoGuide.slice(0, 5) : [];
   plan.files = plan.files.slice(0, 6).filter(function (f) { return wanted.indexOf(f.type) !== -1; });
@@ -527,7 +527,7 @@ function sanitizePersonaText_(persona) {
 /**
  * Magic-wand goal optimizer. Expands a raw/loose business scenario (optionally
  * carrying selected research workflows) into a structured Markdown business
- * scenario in the SAME language. Reused from the GE Demo Generator, retargeted
+ * scenario in the SAME language. Reused from the Gemini Enterprise Demo Generator, retargeted
  * for Workspace-file demos. Returns { success, optimizedGoal } or { success:false, error }.
  */
 function optimizeGoalWithMagicWand(rawGoal, persona) {
@@ -638,7 +638,7 @@ function translateTemplates(lang, items) {
 
 /**
  * Researches the company behind a domain via Google Search grounding and proposes
- * a demo goal. Reused from the GE Demo Generator. Returns a structured object the
+ * a demo goal. Reused from the Gemini Enterprise Demo Generator. Returns a structured object the
  * frontend uses to pre-fill the goal + show challenges and automatable workflows.
  * Optional persona ({ id, label, description }) frames the suggested goal around
  * that target user's business process.
@@ -1138,7 +1138,7 @@ function createDemoGuideDoc(folderId, plan, fileResults) {
   }
 
   body.appendParagraph('How to delete this demo').setHeading(DocumentApp.ParagraphHeading.HEADING1);
-  body.appendListItem('Open GE Demo Generator Lite and click the trash icon on this demo in My Demos. This removes it from your history AND moves this entire demo folder (with all generated files) to your Google Drive Trash.');
+  body.appendListItem('Open Gemini Enterprise Demo Generator Lite and click the trash icon on this demo in My Demos. This removes it from your history AND moves this entire demo folder (with all generated files) to your Google Drive Trash.');
   body.appendListItem('Trashed items are recoverable from Google Drive Trash for about 30 days, or empty the Trash to delete them permanently.');
   body.appendListItem('You can also delete it manually: move this folder to the Trash in Google Drive.');
 

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
@@ -1,4 +1,4 @@
-# GE Demo Generator Lite
+# Gemini Enterprise Demo Generator Lite
 
 A standalone Google Apps Script web app that generates Google Workspace demo data
 (Docs, Sheets, Slides, optional Office/PDF exports, and AI-generated images) directly
@@ -7,7 +7,7 @@ with a per-demo Guide Doc. Built for Gemini Enterprise Business Edition (GEBE), 
 does not support custom ADK agents — and works seamlessly with Gemini Enterprise
 Standard and Plus editions as well.
 
-This is a **separate GAS project** that lives as a subdirectory of the GE Demo Generator
+This is a **separate GAS project** that lives as a subdirectory of the Gemini Enterprise Demo Generator
 repo (same pattern as `experimental/mcp-importer/`). It has its own `scriptId` and
 deployment; the root project's `clasp push` does not include it.
 

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/SetupError.html
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/SetupError.html
@@ -33,7 +33,7 @@ limitations under the License.
 
     <h1 class="text-3xl font-bold mb-4 tracking-tight">Configuration Required</h1>
     <p class="text-slate-400 mb-8 leading-relaxed">
-      GE Demo Generator Lite is not yet configured. To protect your security, sensitive project properties must be set manually in your Google Apps Script project settings.
+      Gemini Enterprise Demo Generator Lite is not yet configured. To protect your security, sensitive project properties must be set manually in your Google Apps Script project settings.
     </p>
 
     <div class="bg-red-500/10 border border-red-500/20 rounded-2xl p-6 mb-8 text-left">

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/index.html
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/index.html
@@ -98,7 +98,7 @@ limitations under the License.
         <!-- Header -->
         <header class="mb-6">
           <h1 class="text-3xl lg:text-4xl font-bold tracking-tight">
-            <span class="bg-clip-text text-transparent bg-gradient-to-r from-white to-slate-400">GE Demo Generator</span> <span class="bg-clip-text text-transparent bg-gradient-to-r from-sky-400 to-emerald-300" title="Works with Gemini Enterprise Business, Standard and Plus editions">Lite</span>
+            <span class="bg-clip-text text-transparent bg-gradient-to-r from-white to-slate-400">Gemini Enterprise Demo Generator</span> <span class="bg-clip-text text-transparent bg-gradient-to-r from-sky-400 to-emerald-300" title="Works with Gemini Enterprise Business, Standard and Plus editions">Lite</span>
             <a href="https://goo.gle/ge-demo-gen-lite" target="_blank" class="align-middle ml-2 text-sm font-mono font-normal text-sky-400 hover:text-sky-300 no-underline">goo.gle/ge-demo-gen-lite &#8599;</a>
           </h1>
           <p class="text-slate-400 mt-2">Instantly generate <b class="text-slate-200">Google Workspace demo data</b> &mdash; Docs, Sheets, Slides &amp; more &mdash; straight into your Drive, with an Agent Designer prompt to match. Built to run demos on <b class="text-slate-200">Gemini Enterprise Business Edition (GEBE)</b> &mdash; and works seamlessly with Gemini Enterprise <b class="text-slate-200">Standard</b> and <b class="text-slate-200">Plus</b> editions too.</p>
@@ -329,7 +329,7 @@ limitations under the License.
   <!-- ONBOARDING MODAL -->
   <div id="onboardingModal" class="fixed inset-0 modal-bg hidden items-center justify-center p-6 z-[60]">
     <div class="glass rounded-3xl w-full max-w-lg p-8">
-      <h2 class="text-2xl font-bold text-white mb-1">Welcome to GE Demo Generator Lite</h2>
+      <h2 class="text-2xl font-bold text-white mb-1">Welcome to Gemini Enterprise Demo Generator Lite</h2>
       <p class="text-slate-400 text-sm mb-6">Generate demo content for Gemini Enterprise in seconds.</p>
       <div class="space-y-4 mb-8">
         <div class="flex items-start gap-3"><div class="w-9 h-9 rounded-xl bg-sky-500/20 flex items-center justify-center text-sky-300">1</div><div><p class="text-slate-200 font-semibold text-sm">Describe a business goal</p><p class="text-slate-500 text-xs">Any industry, any language. Optionally research a customer domain.</p></div></div>

--- a/search/gemini-enterprise/ge-demo-generator/tutorial.md
+++ b/search/gemini-enterprise/ge-demo-generator/tutorial.md
@@ -24,7 +24,7 @@ gcloud config set project {{project-id}}
 
 The Demo Generator has synthesized a custom setup script for you. This script is responsible for provisioning the BigQuery dataset and setting up the agent code within YOUR Google Cloud environment.
 
-1. Go back to the **GE Demo Generator** Web UI.
+1. Go back to the **Gemini Enterprise Demo Generator** Web UI.
 2. Under **Step 3: Deploy**, click the **Copy** button next to the **Setup Script**.
 3. **Paste the command** into the Cloud Shell terminal window (at the bottom of your screen) and press **Enter**.
 
@@ -136,4 +136,4 @@ This will remove:
 ---
 
 ### Need Help?
-See the [GE Demo Generator README](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator) or open an issue on the [GoogleCloudPlatform/generative-ai](https://github.com/GoogleCloudPlatform/generative-ai/issues) repository. Support is handled on a best-effort basis.
+See the [Gemini Enterprise Demo Generator README](https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator) or open an issue on the [GoogleCloudPlatform/generative-ai](https://github.com/GoogleCloudPlatform/generative-ai/issues) repository. Support is handled on a best-effort basis.

--- a/search/gemini-enterprise/ge-demo-generator/validate_examples.py
+++ b/search/gemini-enterprise/ge-demo-generator/validate_examples.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Agent-template validator for the GE Demo Generator.
+"""Agent-template validator for the Gemini Enterprise Demo Generator.
 
 The A2UI example JSONs and the agent runtime Python live as real files under
 agent_template/ (the generated setup script fetches them at run time), so


### PR DESCRIPTION
## Summary

Renames the sample's product name from **GE Demo Generator** to **Gemini Enterprise Demo Generator**. `GE` is a registered trademark of General Electric, so the abbreviation should not be used externally as a product name.

Scope: the product name and every user-facing string that carried it. Code comments where `GE` abbreviates the Gemini Enterprise *client* (e.g. "GE stops rendering the streamed turn at ~120s") are unchanged — they are internal notes about the product, not the tool's name.

## What changed

- **`README.md`** — title, `What is the ...?` heading and its table-of-contents anchor, intro paragraph, architecture sections, the deployment-description example, and the repository-tree comment.
- **`AGENTS.md`**, **`tutorial.md`**, **`validate_examples.py`** — headings and prose.
- **`app/index.html`** — the web app `<h1>` and the "How ... Works" architecture panel heading.
- **`app/Code.gs`** — web app page titles (`setTitle`), the setup-script banner and header comment, and the generated display names:
  - OAuth consent app name `GE Demo Agent` → `Gemini Enterprise Demo Agent`
  - Dynamically registered remote-MCP client `GE Demo (<dir>)` → `Gemini Enterprise Demo (<dir>)`
  - Slack app manifest name `GE-<dir>` → `<dir>`. Slack caps display names at 35 characters and `<dir>` alone already reaches 29, so a `Gemini Enterprise` prefix would truncate away the unique suffix. The demo directory name is unique on its own and already labels the demo's secrets and local directory. The two cleanup messages that tell the user which app to delete were updated to match.
- **`ge-demo-generator-lite/`** — the same rename for the Lite subproject, plus its default Drive folder fallback name.
- Versions bumped to `v11.60-public` / Lite `v1.9-public`.

The directory name `ge-demo-generator/` is deliberately unchanged so existing links, pinned `TEMPLATE_REF` checkouts, and previously generated setup scripts keep working.

## Verification

- `node --check` on both `Code.gs` files; `python3 validate_examples.py` → 33 template files pass.
- Generated the 9-flag setup-script matrix from `main`'s `Code.gs` and from this branch and diffed set by set: every difference is a renamed string, the version line, or the generation timestamp. All 10 scripts (including an added Slack + remote-MCP OAuth fixture with a maximum-length directory name) pass `bash -n`.
- Confirmed the Slack manifest `display_information.name` and both cleanup messages emit the identical string.