### PR TITLE
fix: surface Gemini Enterprise Demo Generator deliverable download links without being asked for them (v11.62-public)

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -1000,6 +1000,32 @@ verbatim. `find /.agent/skills -name SKILL.md` fails; `ls .agent/skills` from
 if there are none" hedge. Leave the env spec `target` alone — the platform
 interprets it.
 
+### 11.4 Deliverable links follow `deliver_tid`, not the ticket you asked about (v11.62)
+
+An upload-only follow-up task is delegated with `deliverables_for_task_id` set
+to the ORIGINAL ticket, so its uploads land under `autonomous/<original>/`. The
+follow-up's execution doc records that prefix as `deliver_tid`, but both status
+tools re-collected links under the ticket id they were *called* with — so asking
+about the upload task reported "finished" with no links, and only an explicit
+"…and show me the download link" made the model go hunting for the donor ticket.
+`get_task_status` and `get_autonomous_task_status` now both resolve
+`_d.get("deliver_tid") or task_id`.
+
+Two related gaps closed in the same round:
+
+- `_inject_completed_tasks` truncates `result_summary` to 300 characters, which
+  cut off the link block completion appends to it (and those signatures would be
+  stale by the time the announcement fires anyway). The announcement now
+  re-lists storage through `_ma_collect_deliverables` and appends freshly signed
+  links, so the *first* mention of a finished task already carries them.
+- A task still at `working` can already have uploaded its files — an upload-only
+  follow-up finishes its uploads minutes before its run ends. That branch now
+  returns the links too, with a note that the task is still running.
+
+The general form: **a status tool is the only place the user's question lands,
+so it must answer with everything already true**, not with what was true when
+the record was written.
+
 ---
 
 ## 12. The domain-research 429 is a shared bucket, not a bug (v11.59)

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -1272,10 +1272,28 @@ def _inject_completed_tasks(callback_context):
         for _doc in _docs:
             _d = _doc.to_dict()
             _status_icon = "completed" if _d.get("status") == "completed" else "failed"
-            _summaries.append(
-                "[" + _status_icon.upper() + "] Task '" + _d.get("task_id", "") + "': "
-                + _d.get("result_summary", "")[:300]
-            )
+            _entry = ("[" + _status_icon.upper() + "] Task '" + _d.get("task_id", "") + "': "
+                      + _d.get("result_summary", "")[:300])
+            # The excerpt is truncated at 300 chars, so the link block that
+            # completion appends to result_summary never survives into this
+            # announcement - and those signatures would be stale by now anyway.
+            # Re-list storage and attach fresh links, or the first thing the
+            # user hears about a finished task is that it finished, with no way
+            # to open what it produced (v11.62). deliver_tid, not task_id: an
+            # upload-only follow-up writes into the ORIGINAL ticket's prefix.
+            _collect = getattr(tools, "_ma_collect_deliverables", None)
+            if _collect is not None and _d.get("status") == "completed":
+                try:
+                    _dl_links = _collect(_d.get("deliver_tid") or _d.get("task_id", ""))
+                except Exception:
+                    _dl_links = []
+                if _dl_links:
+                    _entry = (_entry + chr(10)
+                              + "DELIVERABLE DOWNLOADS for this task (freshly signed, valid 7 days). "
+                                "You MUST reproduce EVERY link below verbatim as markdown links "
+                                "whenever you tell the user this task finished - the user cannot see "
+                                "this block:" + chr(10) + chr(10).join(_dl_links))
+            _summaries.append(_entry)
             _doc.reference.update({"reported_to_user": True})
         if _summaries:
             _msg = "--- BACKGROUND TASK RESULTS ---" + chr(10) + chr(10).join(_summaries) + chr(10) + "--- END RESULTS ---"

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -2349,7 +2349,11 @@ def get_task_result(task_id: str, tool_context: ToolContext) -> dict:
             _attach = globals().get("_ma_attach_live_deliverables")
             if _attach is not None:
                 try:
-                    _attach(_res, task_id, "result_summary")
+                    # deliver_tid, not task_id: an upload-only follow-up writes
+                    # into the ORIGINAL ticket's storage prefix, so a status
+                    # check on the follow-up must look there or it reports a
+                    # finished upload with no links (v11.62).
+                    _attach(_res, _d.get("deliver_tid") or task_id, "result_summary")
                 except Exception:
                     pass  # status reporting must never fail on link refresh
         return _res
@@ -4058,13 +4062,33 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
                     "When telling the user about progress, lead with elapsed_minutes and the latest "
                     "concrete activity from recent_activity; never phrase the percentage as "
                     "'almost done'.")
+                # Files can reach storage well before the run ends - an upload-only
+                # follow-up in particular finishes its uploads and then spends
+                # minutes tidying up. Surfacing them mid-run is what the user asked
+                # for when they asked about the task at all (v11.62).
+                try:
+                    _wip_links = _ma_collect_deliverables(_d.get("deliver_tid") or task_id)
+                except Exception:
+                    _wip_links = []
+                if _wip_links:
+                    _out["deliverable_downloads"] = _wip_links
+                    _out["_MANDATORY_ACTION"] = (
+                        "The task is STILL RUNNING - say so - but files it produced are ALREADY in "
+                        "storage. Your response MUST list EVERY link in deliverable_downloads, verbatim, "
+                        "as markdown links under a short heading meaning 'Deliverables' in the "
+                        "conversation language. The user cannot see this tool result; a link you do not "
+                        "copy does not exist for them. More files may follow when the task completes.")
             if _d.get("status") in ("completed", "failed"):
                 _out["report"] = _d.get("result_summary", "")
                 _out["_MANDATORY_ACTION"] = ("Present the report as formatted markdown text, verbatim, "
                                              "including any deliverable download links.")
                 if _d.get("status") == "completed":
                     try:
-                        _ma_attach_live_deliverables(_out, task_id, "report")
+                        # deliver_tid, not task_id (v11.62): see the same call in
+                        # get_task_status. An upload-only follow-up delegated with
+                        # deliverables_for_task_id uploads into the ORIGINAL
+                        # ticket's prefix, and the user asks about the FOLLOW-UP.
+                        _ma_attach_live_deliverables(_out, _d.get("deliver_tid") or task_id, "report")
                     except Exception:
                         pass  # status reporting must never fail on link refresh
             return _out

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.61-public',
+  APP_VERSION: 'v11.62-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a


### PR DESCRIPTION
## Description

An autonomous task that finishes its report leaves the user without a way to open what it produced: the status check reports the task completed, and the download links only appear if the user explicitly asks for them a second time (`"…and show me the download link"`).

Three causes, all fixed here, all in `search/gemini-enterprise/ge-demo-generator/`:

1. **Links followed the wrong ticket.** An upload-only follow-up task is delegated with `deliverables_for_task_id` set to the ORIGINAL ticket, so its uploads land under `autonomous/<original>/`. The follow-up's execution doc records that prefix as `deliver_tid`, but `get_task_status` and `get_autonomous_task_status` re-collected links under the ticket id they were *called* with — the follow-up. Both now resolve `deliver_tid or task_id`.

2. **The completion announcement dropped them.** `_inject_completed_tasks` announces a completed task with the first 300 characters of `result_summary`, which cuts off the link block completion appends to it — and those signatures would be stale by then anyway. The announcement now re-lists storage and appends freshly signed links, so the first mention of a finished task already carries them.

3. **A still-running task can already have files.** An upload-only follow-up finishes its uploads minutes before its run ends. The `working` branch of `get_autonomous_task_status` now returns those links too, with a note that the task is still running.

Documented as AGENTS.md section 11.4. `APP_VERSION` bumped to `v11.62-public`.

## Checklist

- [x] Followed the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
- [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Made an entry in the appropriate [`README.md`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/README.md).

## Verification

- Every one of the 48 added Python lines is byte-identical to the internal source (modulo the `+4` `ENABLE_MANAGED_AGENT` guard indent) — checked programmatically, 0 misses.
- `py_compile` clean on all five `agent_template/adk_agent/app/*.py`; `Code.gs` parses under Node.
- Forbidden-pattern sweep over the added lines: 0 hits.
- Spelling pre-checked against the repo's own baseline vocabulary: 5 new tokens (`excerpt`, `hears`, `spends`, `tidying`, `truncates`), all ordinary English — no `allow.txt` change.
- markdownlint on `AGENTS.md`: no new findings vs. the base revision.