### PR TITLE
fix: stop the registration test's stub project id tripping secret scanning

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/test_register_fallback.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_register_fallback.py
@@ -98,7 +98,7 @@ def run_bash(script: str) -> subprocess.CompletedProcess:
 # --- 1. the authorization read-back gate -------------------------------------
 GATE_PRELUDE = """
 TOKEN=stub-token
-# Shouty on purpose: curl is stubbed, so the value is never used, and a
+# Upper case on purpose: curl is stubbed, so the value is never used, and a
 # lowercase project-id-shaped literal reads as a real project to a secret
 # scanner.
 PROJECT_ID=STUB_PROJECT_ID

--- a/search/gemini-enterprise/ge-demo-generator/test_register_fallback.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_register_fallback.py
@@ -98,7 +98,10 @@ def run_bash(script: str) -> subprocess.CompletedProcess:
 # --- 1. the authorization read-back gate -------------------------------------
 GATE_PRELUDE = """
 TOKEN=stub-token
-PROJECT_ID=stub-project
+# Shouty on purpose: curl is stubbed, so the value is never used, and a
+# lowercase project-id-shaped literal reads as a real project to a secret
+# scanner.
+PROJECT_ID=STUB_PROJECT_ID
 AUTH_ID=demo-acme-x7k2-auth
 curl() { echo "$FAKE_HTTP"; }
 """


### PR DESCRIPTION
# Description

Secret scanning flagged `PROJECT_ID=stub-project` in
`search/gemini-enterprise/ge-demo-generator/test_register_fallback.py`
(added in #3056) against the repository's *Google Cloud Project ID* custom
pattern.

It is a false positive: the line is a literal placeholder inside the bash
prelude the test feeds to `bash -e`, and that same prelude stubs `curl`, so
the value is never interpolated into a request and never leaves the process.
No credential is involved and there is nothing to rotate.

The alert is still worth closing rather than dismissing, so this renames the
placeholder to `STUB_PROJECT_ID` — a shape no project id can have, since
project ids are lowercase — and leaves a comment saying why, so it does not
get tidied back into something scanner-shaped. The nine cases still pass.

# Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] Ensure the tests and linter pass.
- [x] Appropriate docs were updated (no doc change needed).
- [x] The author is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for these files.