### PR TITLE
feat: persist Gemini Enterprise Demo Generator surface anchors across a cold start, and cap google-api-core below 2.35.0 (v11.93-public)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1611,6 +1611,7 @@ Reranking
 reranks
 rescope
 Rescope
+rescoped
 rescoper
 resil
 Resona

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1972,6 +1972,7 @@ Tuteja
 tval
 twiml
 typehints
+uab
 ubuntu
 udf
 UDF

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -507,6 +507,8 @@ merge; a stale `TEMPLATE_REPO` keeps every generated script pointed at the fork.
 - `python3 check_deps.py` — dependency cap audit (see section 8).
 - `python3 test_press_retire.py` — the press-retire helper deletes a surface the
   user can see, so its guards are covered off-line (see section 2.6).
+- `python3 test_surface_registry_persist.py` — simulates an instance recycle
+  and checks the surfaceId anchors survive it (see section 10.3).
 - `python3 test_register_fallback.py` — slices the authorization read-back gate
   and `register_ge_agent_with_fallback` out of `app/Code.gs` and runs them under
   `bash -e` against a stubbed `curl` and a stubbed `register_agent.py`. The only
@@ -557,9 +559,25 @@ Two things to know before editing a requirement:
   cap contains `a2a-sdk` without holding ADK back. Only a build that passes
   justifies a bound.
 
-`agent_template/pyproject.toml` repeats four of these requirements verbatim and
+- **A transitive dependency can need a direct entry of its own.**
+  `google-api-core` is pulled in by every Google Cloud client here and nothing
+  declared it, so 2.35.0 (2026-08-24) reached the image unopposed: it added
+  `urllib.parse.quote(val, safe="/")` to
+  `path_template._expand_variable_match`, which percent-encodes the parentheses
+  in Firestore's default database id, and every call in a freshly built demo
+  returned `InvalidArgument: 400 Invalid database id %28default%29` —
+  session persistence, the idempotency claim, task storage and the autonomous
+  worker at once. It is listed in `PINNED_DEPS` purely to hold `<2.35.0`.
+  Bisect before choosing where the cap goes: `google-cloud-firestore` 2.28.1
+  and 2.29.0 both fail on api-core 2.35.0 and both pass on 2.34.0, so capping
+  the Firestore line would have pinned the wrong package and still broken.
+
+`agent_template/pyproject.toml` repeats five of these requirements verbatim and
 is copied into the build context, so it must carry the same caps.
-`check_deps.py` fails if it drifts.
+`check_deps.py` fails if it drifts. The same goes for
+`agent_template/viewer_app/requirements.txt`, which is a static file the script
+copies as-is: the viewer reads the same Firestore collections and needs the
+same cap.
 
 A cap in `requirements.txt` only binds the install *we* issue. When a demo
 imports a custom MCP server, the Dockerfile clones that repo and runs its own
@@ -931,9 +949,10 @@ cannot interleave a half-written history, and it runs even when the turn failed
 
 Deliberate limits, do not "fix" these without thinking:
 
-- **Only the conversation is persisted.** `_session_last_artifact` and
-  `builtins._ws_session_tokens` are process-local by design: the token is
-  re-sent on every request, and losing the regenerate cache costs one replay.
+- **The conversation and the surfaceId anchors are persisted; nothing else
+  is.** `_session_last_artifact` and `builtins._ws_session_tokens` stay
+  process-local by design: the token is re-sent on every request, and losing
+  the regenerate cache costs one replay.
 - **The OAuth token is stripped** from the persisted state
   (`_session_persistable_state` skips the `GEMINI_AUTHORIZATION_ID` key). It is
   short-lived and re-supplied per request; it has no business in Firestore.
@@ -942,6 +961,21 @@ Deliberate limits, do not "fix" these without thinking:
   `Event.model_validate` is not worth the crash.
 - **Firestore caps a document at 1 MiB.** The flush halves the event list until
   the gzipped blob fits under 800 KB, and skips the write if it still does not.
+- **The surfaceId anchors ride in the same document** (v11.92, field
+  `surface_registry`). The cross-turn rescope guard in section 2.5 lived in
+  process memory while the cards it tracks live in the Gemini Enterprise
+  client, which outlives the instance: after a scale-to-zero the next turn
+  re-emitted a `surfaceId` the client had already bound to an older message,
+  that older card was patched instead, and the new turn rendered text only.
+  Three details are load-bearing. The anchors are stored as JSON **text**, not
+  a map — a `surfaceId` is model-authored and Firestore rejects a field name
+  matching `__.*__`, and that 400 would fail the whole flush and take the event
+  history with it. The restore runs **before** the ADK-version gate, because
+  the cards on screen do not care which ADK wrote the blob. And it **mutates**
+  the registry dict rather than rebinding it, because `_process_request` armed
+  the guard with that object before the restore ran. The oversized-blob skip
+  path still writes the anchors with `merge=True`; they are a few hundred bytes
+  and have nothing to do with why the history did not fit.
 
 ### 10.4 Why `--max-instances 1`
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
@@ -525,6 +525,64 @@ def _get_surface_registry(_sid):
                 _session_surface_registry.pop(_old, None)
     return _reg
 
+# v11.92: the registry above is process memory, but the anchors it tracks live
+# in the GE client, which outlives the process. A scale-to-zero (or a deploy, or
+# an instance recycle) therefore used to reset it while the conversation kept
+# every card on screen: the next turn re-emitted a surfaceId GE had already
+# anchored to an OLD message, GE patched that card instead of rendering a new
+# one, and the turn showed text only - the #14/#15 failure, reintroduced by
+# amnesia. Confirmed 2026-08-25 on a live demo: two analysis-plan cards were
+# rescoped correctly, the instance shut down idle at 04:57, and the third one
+# (05:29) emitted the bare ids again with no [surface_rescope] line and never
+# rendered - the user saw the lead-in text and a turn that appeared to stop.
+# Session events are already mirrored to Firestore for exactly this reason, so
+# the anchors ride along in the same document.
+
+def _snapshot_surface_registry(_sid):
+    """The session's surfaceId anchors as JSON TEXT (newest 50).
+
+    Text rather than a Firestore map because the keys are model-authored
+    surfaceIds: Firestore rejects a field name matching __.*__ ("field name is
+    reserved", probed live 2026-08-25 - 'a.b' and 'has/slash' are accepted,
+    '__evil__' is a 400), and that 400 would fail the WHOLE session flush and
+    take the event history down with it, which is the cold-start amnesia this
+    is here to prevent. A string also keeps unbounded invented keys out of the
+    index.
+    """
+    _out = {}
+    for _k, _v in list((_session_surface_registry.get(_sid) or {}).items())[-50:]:
+        if isinstance(_v, dict) and _v.get('current'):
+            _out[str(_k)] = {'current': str(_v.get('current')),
+                             'owner': str(_v.get('owner') or '')}
+    try:
+        return json.dumps(_out, ensure_ascii=False)
+    except Exception:
+        return ''
+
+def _load_surface_registry(_sid, _stored):
+    """Re-seed the in-memory registry from a persisted snapshot."""
+    if isinstance(_stored, str):
+        try:
+            _stored = json.loads(_stored or '{}')
+        except Exception:
+            return
+    if not isinstance(_stored, dict) or not _stored:
+        return
+    # Mutated in place: _process_request armed the guard with THIS dict object
+    # before the restore runs, so rebinding it here would be invisible.
+    _reg = _get_surface_registry(_sid)
+    _n = 0
+    for _k, _v in _stored.items():
+        # Anything this process already owns is newer than the blob.
+        if _k in _reg or not isinstance(_v, dict) or not _v.get('current'):
+            continue
+        _reg[str(_k)] = {'current': str(_v.get('current')),
+                         'owner': str(_v.get('owner') or '')}
+        _n += 1
+    if _n:
+        logger.log_text('[surface_rescope] restored ' + str(_n)
+                        + ' surface id(s) after a cold start')
+
 def _a2ui_components(_v):
     _c = _v.get('components')
     return _c if isinstance(_c, list) else []
@@ -2297,6 +2355,10 @@ async def _persist_session(_session, _session_id, _user_id):
         if len(_blob) > _SESSION_BLOB_MAX_BYTES:
             logger.log_text("[session_persist] " + str(_session_id) + ": blob still "
                             + str(len(_blob)) + " bytes after trimming - skipping flush")
+            # The surfaceId anchors are a few hundred bytes and have nothing to
+            # do with why the history did not fit; dropping them too would cost
+            # an unrendered card on the next cold start (v11.92).
+            _ref.set({"surface_registry": _snapshot_surface_registry(_session_id)}, merge=True)
             return
         _ref.set({
             "session_id": str(_session_id),
@@ -2305,6 +2367,7 @@ async def _persist_session(_session, _session_id, _user_id):
             "adk_version": _ADK_VERSION,
             "event_count": len(_payload["events"]),
             "updated_at": datetime.now(timezone.utc).isoformat(),
+            "surface_registry": _snapshot_surface_registry(_session_id),
             "blob": _blob,
         })
     except Exception as _pe:
@@ -2322,6 +2385,15 @@ async def _restore_session(_session_id, _user_id, _initial_state):
         if not _snap.exists:
             return None
         _doc = _snap.to_dict() or {}
+        # Ahead of the version gate on purpose (v11.92): the cards GE has on
+        # screen are unaffected by which ADK wrote the blob, so their surfaceId
+        # anchors stay valid even on the paths that discard the event history.
+        # Own try: a card that renders in the wrong place is a far smaller loss
+        # than the event history this function exists to bring back.
+        try:
+            _load_surface_registry(_session_id, _doc.get("surface_registry"))
+        except Exception as _sre:
+            logger.log_text("[surface_rescope] anchor restore skipped: " + str(_sre)[:200])
         _stored_version = _doc.get("adk_version", "")
         if _stored_version != _ADK_VERSION:
             logger.log_text("[session_persist] " + str(_session_id) + ": discarding blob written by adk "

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/pyproject.toml
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/pyproject.toml
@@ -2,10 +2,10 @@
 name = "mcp-agent"
 version = "0.1.0"
 # Keep these in sync with PINNED_DEPS in app/Code.gs (adk / mcp / genai /
-# storage). `python3 check_deps.py` fails when they drift apart: a cap only
-# protects the build if BOTH the generated requirements.txt and this file carry
-# it. See AGENTS.md section 8.
-dependencies = ["google-adk[a2a]>=1.31.1,<3.0.0", "mcp>=1.24.0,<2.0.0", "google-genai>=1.27.0,<3.0.0", "google-cloud-storage>=2.14.0,<4.0.0"]
+# storage / api-core). `python3 check_deps.py` fails when they drift apart: a
+# cap only protects the build if BOTH the generated requirements.txt and this
+# file carry it. See AGENTS.md section 8.
+dependencies = ["google-adk[a2a]>=1.31.1,<3.0.0", "mcp>=1.24.0,<2.0.0", "google-genai>=1.27.0,<3.0.0", "google-cloud-storage>=2.14.0,<4.0.0", "google-api-core>=2.20.0,<2.35.0"]
 requires-python = ">=3.10,<3.13"
 [tool.adk]
 project_type = "agent"

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/viewer_app/requirements.txt
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/viewer_app/requirements.txt
@@ -1,3 +1,4 @@
 functions-framework>=3.5.0
 flask>=3.0.3
 google-cloud-firestore>=2.16.0
+google-api-core>=2.20.0,<2.35.0

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.91-public',
+  APP_VERSION: 'v11.93-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2605,6 +2605,21 @@ function generateSetupScript(params) {
     firestore: 'google-cloud-firestore>=2.16.0,<3.0.0',
     logging: 'google-cloud-logging>=3.0.0,<4.0.0',
 
+    // (v11.93) google-api-core is a TRANSITIVE dependency of every Google Cloud
+    // client here, declared directly only to hold this cap. 2.35.0 (2026-08-24)
+    // added urllib.parse.quote(val, safe="/") to
+    // path_template._expand_variable_match as path-traversal hardening, and that
+    // encodes the parentheses in Firestore's default database id: every call
+    // becomes
+    //   InvalidArgument: 400 Invalid database id %28default%29
+    // which takes down session persistence, the idempotency claim, task storage
+    // and the autonomous worker in one go. Bisected 2026-08-25 against a live
+    // project - firestore 2.28.1 and 2.29.0 both fail on api-core 2.35.0 and
+    // both pass on 2.34.0, so the cap belongs here and NOT on the firestore
+    // line. Independently hit by a demo author the same day. Lift the cap once
+    // a release above 2.35.0 restores the unencoded id.
+    apiCore: 'google-api-core>=2.20.0,<2.35.0',
+
     // Utilities
     dotenv: 'python-dotenv>=1.0.0,<2.0.0',
     dbDtypes: 'db-dtypes>=1.0.0,<2.0.0',
@@ -2620,6 +2635,8 @@ function generateSetupScript(params) {
     viewerFunctionsFramework: 'functions-framework>=3.5.0,<4.0.0',
     viewerFlask: 'flask>=3.0.3,<4.0.0',
     viewerFirestore: 'google-cloud-firestore>=2.16.0,<3.0.0',
+    // The viewer reads the same Firestore collections, so it needs the same cap.
+    viewerApiCore: 'google-api-core>=2.20.0,<2.35.0',
 
     // Computer Use (browser agent) -- only added when enableComputerUse is set.
     // playwright pin matches the official reference impl
@@ -2667,6 +2684,7 @@ function generateSetupScript(params) {
   const CONSTRAINT_KEYS = [
     'adk', 'mcp', 'genai', 'a2a', 'aiplatform', 'storage', 'scheduler',
     'tasks', 'pubsub', 'firestore', 'logging', 'dotenv', 'dbDtypes', 'otel',
+    'apiCore',
     'playwright', 'genaiComputerUse', 'cuOtelGcpLogging', 'cuOtelGcpResourceDetector',
   ];
   const constraintLines = [];
@@ -2826,7 +2844,7 @@ if __name__ == '__main__':
     init_data()
 __PY_EOF__\n`;
 
-    firestoreCommands += `uv run --no-project --with "${PINNED_DEPS.firestore}" python setup_fs.py\n`;
+    firestoreCommands += `uv run --no-project --with "${PINNED_DEPS.firestore}" --with "${PINNED_DEPS.apiCore}" python setup_fs.py\n`;
     firestoreCommands += `rm setup_fs.py\n\n`;
 
     firestoreCommands += `echo "🌐 Deploying Real-time Data Viewer Web App (Cloud Run Functions)..."\n`;
@@ -4009,7 +4027,7 @@ ${ enableManagedAgent ? `
     echo ""
     echo "🔥 Deleting Firestore Collection: ${fsCollection}..."
     if command -v uv >/dev/null 2>&1; then
-      GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" python3 -c "from google.cloud import firestore; db=firestore.Client(); [d.reference.delete() for d in db.collection('${fsCollection}').stream()]" 2>/dev/null && echo "   ✅ Firestore documents in collection deleted." || echo "   ⚠️  Could not clear Firestore collection automatically."
+      GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" --with "${PINNED_DEPS.apiCore}" python3 -c "from google.cloud import firestore; db=firestore.Client(); [d.reference.delete() for d in db.collection('${fsCollection}').stream()]" 2>/dev/null && echo "   ✅ Firestore documents in collection deleted." || echo "   ⚠️  Could not clear Firestore collection automatically."
     fi
 
     echo ""
@@ -4177,7 +4195,7 @@ ${ enableManagedAgent ? `
 
     echo ""
     echo "📁 Deleting Firestore task collections..."
-    GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" python3 -c "
+    GOOGLE_API_USE_CLIENT_CERTIFICATE=false uv run --no-project --with "${PINNED_DEPS.firestore}" --with "${PINNED_DEPS.apiCore}" python3 -c "
 from google.cloud import firestore
 db = firestore.Client()
 for coll_name in ['${dirName}_task_definitions', '${dirName}_task_executions', '${dirName}_task_push_configs', '${dirName}_adk_sessions']:
@@ -4957,6 +4975,7 @@ ${PINNED_DEPS.pubsub}
 ${PINNED_DEPS.firestore}
 ${PINNED_DEPS.logging}
 ${PINNED_DEPS.otel}
+${PINNED_DEPS.apiCore}
 ${ enableComputerUse ? `${PINNED_DEPS.playwright}\n${PINNED_DEPS.genaiComputerUse}\n${PINNED_DEPS.cuOtelGcpLogging}\n${PINNED_DEPS.cuOtelGcpResourceDetector}` : '' }
 __REQ_EOF__
 

--- a/search/gemini-enterprise/ge-demo-generator/check_deps.py
+++ b/search/gemini-enterprise/ge-demo-generator/check_deps.py
@@ -45,11 +45,11 @@ from pathlib import Path
 
 HERE = Path(__file__).parent
 CODE_GS = HERE / "app" / "Code.gs"
-# The agent template ships a static pyproject.toml that repeats four of the
+# The agent template ships a static pyproject.toml that repeats five of the
 # PINNED_DEPS requirements; a cap only protects the build if both carry it.
 PYPROJECT = HERE / "agent_template" / "pyproject.toml"
 # PINNED_DEPS key -> the requirement pyproject.toml must repeat verbatim.
-PYPROJECT_KEYS = ("adk", "mcp", "genai", "storage")
+PYPROJECT_KEYS = ("adk", "mcp", "genai", "storage", "apiCore")
 
 # PINNED_DEPS keys that are not pip requirements.
 NON_PIP_KEYS = {"pythonImage", "uvImage", "uvVersion", "supergateway"}
@@ -61,7 +61,8 @@ COMPUTER_USE_KEYS = {
     "cuOtelGcpResourceDetector",
 }
 # Keys that go into the separate viewer_app/requirements.txt, not the agent's.
-VIEWER_KEYS = {"viewerFunctionsFramework", "viewerFlask", "viewerFirestore"}
+VIEWER_KEYS = {"viewerFunctionsFramework", "viewerFlask", "viewerFirestore",
+               "viewerApiCore"}
 
 REQ_SPEC = re.compile(
     r"^(?P<name>[A-Za-z0-9._-]+)"

--- a/search/gemini-enterprise/ge-demo-generator/test_surface_registry_persist.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_surface_registry_persist.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exercises the v11.92 surfaceId-anchor persistence off-line.
+
+The cross-turn rescope guard is the only thing standing between a second card of
+the same type and GE patching the FIRST one in place, and it decides from a dict
+that used to live in process memory alone. That made it wrong exactly where it
+could not be noticed: a scale-to-zero wiped the anchors while the GE client kept
+every card on screen, so the next turn re-used an id GE had already bound to an
+older message and the card silently never rendered (confirmed 2026-08-25 on a
+live demo - the third analysis-plan card of a session, first request after an
+idle shutdown, no [surface_rescope] line, text-only turn).
+
+Reproducing that in front of an audience costs an instance recycle mid-demo, so
+the recycle is simulated here instead: the registry is cleared between turns and
+the snapshot has to carry the anchors across. Read from the same agent_template/
+file the running demo is built from, the way test_press_retire.py is.
+
+    python3 test_surface_registry_persist.py
+"""
+import ast
+import contextvars
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATE = os.path.join(HERE, "agent_template", "adk_agent", "app",
+                        "fast_api_app.py")
+
+# Everything the guard touches, pulled by name so edits elsewhere in the file
+# cannot change what is under test.
+UNDER_TEST = (
+    "_get_surface_registry", "_snapshot_surface_registry", "_load_surface_registry",
+    "_rescope_one", "_rescope_reused_surfaces", "_a2ui_body", "_a2ui_kind",
+    "_mk_msg", "_a2ui_components", "_a2ui_is_full_card_tree", "_a2ui_catalog_id",
+)
+
+
+class _Logger:
+    def __init__(self):
+        self.lines = []
+
+    def log_text(self, line):
+        self.lines.append(line)
+
+
+def load_helpers(logger):
+    src = open(TEMPLATE, encoding="utf-8").read()
+    wanted = set(UNDER_TEST)
+    bodies = []
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in wanted:
+            bodies.append(ast.unparse(node))
+            wanted.discard(node.name)
+    if wanted:
+        raise SystemExit("not in the template any more: %s" % ", ".join(sorted(wanted)))
+    ns = {
+        "re": re, "json": json, "contextvars": contextvars, "logger": logger,
+        "_session_surface_registry": {},
+        "_current_surface_guard": contextvars.ContextVar("surface_guard", default=None),
+        "_A2UI_MSG_KEYS": ("createSurface", "updateComponents",
+                           "updateDataModel", "deleteSurface"),
+    }
+    exec(compile("\n\n".join(bodies), TEMPLATE, "exec"), ns)  # noqa: S102
+    return ns
+
+
+def main():
+    logger = _Logger()
+    ns = load_helpers(logger)
+    registry = ns["_session_surface_registry"]
+    failures = 0
+
+    def check(name, ok, got):
+        nonlocal failures
+        failures += 0 if ok else 1
+        print("  %-4s %-56s got=%s" % ("ok" if ok else "FAIL", name, got))
+
+    def arm(sid, task):
+        # Mirrors _process_request: the guard is armed BEFORE the session (and
+        # therefore the registry) is restored, so it holds the dict object.
+        ns["_current_surface_guard"].set({
+            "registry": ns["_get_surface_registry"](sid), "task": task,
+            "suffix": task[:12],
+        })
+
+    def emit(kind, sid):
+        body = {"surfaceId": sid}
+        if kind == "createSurface":
+            body["catalogId"] = "c"
+        msg = ns["_rescope_reused_surfaces"]({"version": "v0.9", kind: body})
+        return msg[kind]["surfaceId"]
+
+    sid = "sess-1"
+    print("surface-registry persistence (v11.92)")
+
+    arm(sid, "a" * 12)
+    got = emit("createSurface", "analysis-plan")
+    check("first render keeps its id", got == "analysis-plan", got)
+
+    arm(sid, "b" * 12)
+    got = emit("createSurface", "analysis-plan")
+    check("same-process reuse is renamed", got == "analysis-plan-ubbbbbbbbbbbb", got)
+
+    blob = ns["_snapshot_surface_registry"](sid)
+    check("snapshot is JSON text, not a Firestore map", isinstance(blob, str),
+          type(blob).__name__)
+    check("snapshot carries the latest incarnation",
+          json.loads(blob).get("analysis-plan", {}).get("current")
+          == "analysis-plan-ubbbbbbbbbbbb", blob)
+
+    registry.clear()  # scale-to-zero: the process that held the anchors is gone
+    arm(sid, "c" * 12)
+    ns["_load_surface_registry"](sid, blob)
+    got = emit("createSurface", "analysis-plan")
+    check("reuse across a cold start is renamed", got == "analysis-plan-ucccccccccccc", got)
+    check("restore is logged",
+          any("restored 1 surface id" in line for line in logger.lines),
+          [l for l in logger.lines if "restored" in l])
+    check("restore mutates the armed dict rather than rebinding it",
+          ns["_current_surface_guard"].get()["registry"] is registry[sid], "same object")
+
+    got = emit("deleteSurface", "analysis-plan")
+    check("teardown follows the latest incarnation",
+          got == "analysis-plan-ucccccccccccc", got)
+
+    # A restored blob is history; whatever this process already rendered is newer.
+    registry.clear()
+    arm(sid, "d" * 12)
+    emit("createSurface", "welcome-card")
+    ns["_load_surface_registry"](sid, {"welcome-card": {"current": "welcome-card-uSTALE",
+                                                        "owner": "old"}})
+    got = registry[sid]["welcome-card"]["current"]
+    check("a stale blob never clobbers a live anchor", got == "welcome-card", got)
+
+    registry["big"] = {("k%03d" % i): {"current": "c%d" % i, "owner": "o"}
+                       for i in range(120)}
+    snap = json.loads(ns["_snapshot_surface_registry"]("big"))
+    check("snapshot keeps the newest 50 anchors",
+          len(snap) == 50 and "k119" in snap and "k070" in snap and "k069" not in snap,
+          len(snap))
+
+    # A surfaceId is model-authored, and Firestore rejects a FIELD name matching
+    # __.*__ - as a map that 400 would fail the whole flush, history included.
+    registry["odd"] = {"__evil__": {"current": "__evil__-uab", "owner": "t"},
+                       "a.b/c": {"current": "a.b/c", "owner": "t"}}
+    odd = ns["_snapshot_surface_registry"]("odd")
+    check("reserved-looking ids survive as JSON text",
+          json.loads(odd).get("__evil__", {}).get("current") == "__evil__-uab", odd[:48])
+
+    ns["_load_surface_registry"]("junk", {"a": None, "b": {"owner": "x"}, "c": "nope"})
+    check("malformed stored entries are ignored", not registry.get("junk"),
+          registry.get("junk"))
+    for bad in (None, "", "not json{", "[]", 7):
+        ns["_load_surface_registry"]("junk2", bad)
+    check("a missing or corrupt snapshot is survived", "junk2" not in registry, "no-op")
+    check("an unseen session snapshots empty",
+          ns["_snapshot_surface_registry"]("never-seen") == "{}", "{}")
+
+    if failures:
+        print("\n%d case(s) FAILED" % failures)
+        return 1
+    print("\nAll case(s) passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Two unrelated production failures, both first seen on a live demo generated by this sample.

### 1. A card that never rendered after a scale-to-zero (v11.92)

A heavy request rendered only its two-line intro and stopped. The preflight gate had short-circuited normally, but its `analysis-plan` card was invisible.

`_session_surface_registry` — the cross-turn rescope guard documented in `AGENTS.md` §2.5 — lives in process memory, while the cards it tracks live in the Gemini Enterprise client, which outlives the instance. An idle scale-to-zero wiped the guard while the client kept every card on screen, so the next turn re-emitted a bare `surfaceId` the client had already anchored to an older message: that older card was patched instead, and the new turn rendered text only. The logs show the sequence exactly — a `[surface_rescope]` rename before the shutdown, none after it.

The session events were already mirrored to Firestore for exactly this class of problem, so the anchors now ride along in the same document:

- `_snapshot_surface_registry` / `_load_surface_registry` carry the newest 50 anchors in `<demo>_adk_sessions`.
- Stored as **JSON text, not a Firestore map** — a `surfaceId` is model-authored and Firestore rejects a field name matching `__.*__` with a 400, which would fail the whole flush and take the event history down with it.
- The restore runs **before** the `adk_version` gate: the cards on screen do not care which ADK wrote the blob.
- It **mutates** the registry dict rather than rebinding it, because `_process_request` arms the guard with that object before the restore runs.
- The oversized-blob skip path still writes the anchors with `merge=True`.

`test_surface_registry_persist.py` (new, 14 cases) covers this off-line by clearing the registry between turns to stand in for the instance recycle.

### 2. `400 Invalid database id %28default%29` in every freshly built image (v11.93)

Every Firestore call in a newly built demo started failing with `InvalidArgument: 400 Invalid database id %28default%29`, taking out session persistence, the idempotency claim, task storage and the autonomous worker at once.

`google-api-core` 2.35.0 (2026-08-24) added `urllib.parse.quote(val, safe="/")` to `path_template._expand_variable_match` as path-traversal hardening, and that percent-encodes the parentheses in Firestore's default database id. Nothing declared `google-api-core` directly, so the new release reached the image unopposed.

Bisected in a clean venv: `google-cloud-firestore` 2.28.1 **and** 2.29.0 both fail on api-core 2.35.0 and both pass on 2.34.0 — so the cap belongs on api-core, not on the Firestore line.

- `PINNED_DEPS.apiCore` / `viewerApiCore` cap it below 2.35.0, and `CONSTRAINT_KEYS` puts the upper bound in the image-wide `constraints.txt`.
- The two static template files the setup script copies verbatim — `agent_template/pyproject.toml` and `agent_template/viewer_app/requirements.txt` — carry the same cap, and `check_deps.py` now enforces the pyproject one.
- Already-deployed demos are unaffected until they are rebuilt. Lift the cap once a release above 2.35.0 restores the unencoded id.

## Verification

- `python3 test_surface_registry_persist.py` — 14/14 against `agent_template/`.
- `python3 test_press_retire.py` — 9/9; `python3 validate_examples.py` — 35 files.
- `python3 check_deps.py` — exit 0; agent resolves `google-api-core` 2.34.0, viewer variant resolves separately, pyproject drift check passes.
- 10-variant setup-script matrix generated before and after: every script `bash -n` clean, and the diff is **exactly 16 lines in every variant** — the three `uv run --with` sites, the two new requirement lines (`requirements.txt`, `constraints.txt`), the version string and the generation timestamp.
- `node --check` on `app/Code.gs`; `py_compile` on every template module.
