### PR TITLE
feat(ge-demo-generator): upload the external documents to the deploy account's Drive (skill v2.13.0)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -794,6 +794,7 @@ GSM
 gsod
 gspread
 gstatic
+GSUITE
 gsutil
 gtk
 guanciale
@@ -1644,6 +1645,7 @@ rbm
 rdoc
 RDONLY
 reallocations
+REAUTH
 recontext
 Recontext
 recrawl

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -514,6 +514,10 @@ merge; a stale `TEMPLATE_REPO` keeps every generated script pointed at the fork.
   `bash -e` against a stubbed `curl` and a stubbed `register_agent.py`. The only
   way to exercise a path whose real trigger is a broken Discovery Engine
   authorization (see section 6).
+- `python3 test_external_files_wiring.py` — the skill's sample documents have
+  exactly one route into a Drive and one banner that reports it; the gate slices
+  the upload job out of `skills/…/setup_and_deploy.sh` and runs it under a
+  stubbed `gcloud` in both data-exploration modes (see section 14.4).
 - `python3 canary.py --out /tmp/canary --run-venv` — resolve today's
   requirements and actually run the imports (see section 8.4);
   `docker build /tmp/canary` for the full image.
@@ -1475,3 +1479,48 @@ checked against each other by eye and drift easily: the `version:` field in
 `SKILL.md`'s front matter, the version in `SKILL.md`'s title line, and the
 banner string in `templates/scripts/verify_and_heal.py`. The skill's version is
 independent of `APP_VERSION` in `app/Code.gs`.
+
+### 14.4 The Drive copy belongs to the account running the deploy (v2.13.0)
+
+The skill generates four documents the web app does not — a PDF audit report, an
+Excel ledger and two simulated scans — and puts them somewhere a demo can open
+them. They always go to `gs://$GCS_BUCKET_NAME/`, in every data-exploration mode.
+The Drive copy is the part with a history worth knowing.
+
+Until v2.11.x the upload ran through a CLI authenticated as whoever was operating
+the tool, so the folder belonged to that operator and the deploy target reached it
+through a share. Sharing across an organization boundary is frequently refused by
+policy, which handed the demo a link that 404s. Since v2.13.0
+`templates/scripts/generate_and_upload_external_files.py` calls the Drive v3 REST
+API directly with the access token `gcloud` already holds: `about.get` to identify
+the Drive and prove the scope, `files.list` + `files.create` for the folder, one
+`multipart/related` upload per document, `permissions.create` for link sharing.
+There is no CLI to install and no second identity — the folder is owned by the
+same account that owns the demo.
+
+Four properties are worth preserving if you touch this file:
+
+- **The Drive scope is the one real prerequisite.** A plain `gcloud auth login`
+  grants `cloud-platform` and nothing else, so Drive answers 403
+  `ACCESS_TOKEN_SCOPE_INSUFFICIENT`. The script does not treat that as a broken
+  feature: it skips the upload and names the fix, `gcloud auth login
+  --enable-gdrive-access`, in the summary and in the completion banner.
+- **A folder with nothing in it is not a Drive copy.** Creating a folder and
+  writing into it are separate permissions, so every upload can fail under a
+  folder that was created fine. Reporting the folder URL then hands the demo a
+  link to nothing, so a zero-upload guard reports no Drive copy instead, with the
+  upload's own error, while keeping `folder_id` so cleanup still tears the empty
+  folder down.
+- **Re-running the deploy must not duplicate anything.** The folder is looked up
+  by name (with `'me' in owners`, or a same-named folder somebody shared with you
+  wins and the documents land in a stranger's Drive), and each document is looked
+  up inside it and replaced with `PATCH upload/drive/v3/files/<id>` when it is
+  already there. Two consecutive runs leave four files with the same ids, so a
+  link already pasted into a demo script survives the re-deploy.
+- **Cleanup trashes, it does not delete.** `templates/scripts/cleanup.sh` sends
+  `PATCH {"trashed": true}`, because this is a folder in a person's own Drive and
+  the reversible operation is the correct one there.
+
+Link sharing (`anyone`, `reader`) is best-effort: plenty of organizations forbid
+it, so the refusal is recorded as `share_error` and the banner notes it rather
+than failing the deploy. The owner can always open the folder.

--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -1504,7 +1504,11 @@ Four properties are worth preserving if you touch this file:
   grants `cloud-platform` and nothing else, so Drive answers 403
   `ACCESS_TOKEN_SCOPE_INSUFFICIENT`. The script does not treat that as a broken
   feature: it skips the upload and names the fix, `gcloud auth login
-  --enable-gdrive-access`, in the summary and in the completion banner.
+  --enable-gdrive-access --no-launch-browser`, in the summary and in the
+  completion banner. The `--no-launch-browser` half is not decoration: this
+  script runs from an agentic IDE terminal or a remote development machine,
+  neither of which has a local browser for gcloud to hand the consent flow to,
+  so without it the re-login stalls where nobody can see it.
 - **A folder with nothing in it is not a Drive copy.** Creating a folder and
   writing into it are separate permissions, so every upload can fail under a
   folder that was created fine. Reporting the folder URL then hands the demo a

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -1024,7 +1024,10 @@ Then ask for a demo in your own words — "build me a Gemini Enterprise demo for
    ER diagram, the Drive file lineage, the target project — and waits for your approval.
    Nothing is created before that gate.
 3. **Generates the sample data and the external documents** (PDF, Excel, scanned images) and
-   uploads them to Google Drive.
+   uploads them to the Google Drive of the account running the deploy, over the Drive v3 REST
+   API with the token `gcloud` already holds. Sign in with `gcloud auth login
+   --enable-gdrive-access` first — a plain login carries no Drive scope, and without it the
+   documents still reach Cloud Storage but there is no Drive copy.
 4. **Scaffolds the ADK multi-agent project** from `templates/`, filling in only the
    business-context placeholders.
 5. **Provisions in dependency order** — BigQuery and Firestore, the Agent Engine Sandbox, the

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: ge-demo-generator
-description: Synthesizes and deploys complete, domain-specific Gemini Enterprise demo environments directly to Google Cloud. Use when the user asks to create an AI agent demo for any customer domain (e.g. 'example.com', 'example.co.jp', 'example.de', 'example.fr' - any company, any industry, any region) or business goal, generate realistic BigQuery/Firestore sample datasets, create external demo files (PDF, Excel, scanned images) and upload them to Google Drive, scaffold ADK multi-agent architectures with MCP tools and A2UI cards, deploy to Cloud Run, publish to Gemini Enterprise, and generate 7 structured demo prompts in any language. Confirms the requirements interactively and presents a demo architecture & data model plan (Mermaid ER diagram, Google Drive file lineage, target project) for approval before anything is deployed. Also triggered by /ge-demo-generator.
+description: Synthesizes and deploys complete, domain-specific Gemini Enterprise demo environments directly to Google Cloud. Use when the user asks to create an AI agent demo for any customer domain (e.g. 'example.com', 'example.co.jp', 'example.de', 'example.fr' - any company, any industry, any region) or business goal, generate realistic BigQuery/Firestore sample datasets, create external demo files (PDF, Excel, scanned images), stage them in Cloud Storage and upload them to the deploying account's Google Drive, scaffold ADK multi-agent architectures with MCP tools and A2UI cards, deploy to Cloud Run, publish to Gemini Enterprise, and generate 7 structured demo prompts in any language. Confirms the requirements interactively and presents a demo architecture & data model plan (Mermaid ER diagram, external file lineage, target project) for approval before anything is deployed. Also triggered by /ge-demo-generator.
 metadata:
   author: Google Cloud Customer Engineering
-  version: 2.11.2
+  version: 2.13.0
 ---
 
-# GE Demo Generator Skill (v2.11.2)
+# GE Demo Generator Skill (v2.13.0)
 
-Synthesizes production-grade, domain-tailored AI agent demo environments using **Gemini 3.7 Flash** for reasoning and **Gemini 3.1 Flash Image** for visual generation, adhering to a strict **6-step infrastructure dependency graph**, rich **A2UI interactive component streaming**, **Google Workspace OAuth authorization**, direct **Google Drive external sample files storage**, **7 structured demo prompts**, and **global multilingual localization (i18n/l10n)**.
+Synthesizes production-grade, domain-tailored AI agent demo environments using **Gemini 3.7 Flash** for reasoning and **Gemini 3.1 Flash Image** for visual generation, adhering to a strict **6-step infrastructure dependency graph**, rich **A2UI interactive component streaming**, **Google Workspace OAuth authorization**, **external sample files staged in Cloud Storage and, when the credentials carry the Drive scope, in the deploying account's Google Drive**, **7 structured demo prompts**, and **global multilingual localization (i18n/l10n)**.
 
 ---
 
@@ -65,7 +65,7 @@ Phase 6: Gemini Enterprise App Discovery, Workspace Authorization & Registration
    ↓
 Phase 7: Comprehensive Results Output:
    ├── 💬 Direct Gemini Enterprise Console Chat Link
-   ├── 📁 Google Drive External Sample Files & Folder Links
+   ├── 📁 External Sample Files: Cloud Storage links, plus Drive links when the upload ran
    ├── 📊 Firestore Data Viewer Dashboard Link
    ├── 🔎 BigQuery Console Link
    └── 🎯 7 Structured Demo Prompts Playbook (Localized to Target Language)
@@ -126,11 +126,11 @@ with a stated default so the user can answer "all defaults" in three words:
    counterpart. If the user declines, rotate personas freely instead.
 2. **Scope of the narrative** — which single process instance the demo follows, if Phase 1
    left more than one plausible reading of the chosen scenario.
-3. **Advanced settings** — the options from the table in brief section 6 that this demo is a
-   plausible candidate for, with their defaults. Do not read out all eight; name the two or
-   three that matter here (Workspace OAuth when the scenario touches Gmail/Drive/Calendar,
-   `rag` when it turns on documents rather than numbers, `dataScale` when the narrative claims
-   enterprise volume) and say the rest keep their defaults.
+3. **Advanced settings** — ask about the two or three the demo is a plausible candidate for
+   (Workspace OAuth when the scenario touches Gmail/Drive/Calendar, `rag` when it turns on
+   documents rather than numbers, `dataScale` when the narrative claims enterprise volume),
+   and say the rest keep their defaults. Keep the *question* short — brief section 6 lists
+   every option with its resolved value, so nothing is hidden by asking about a few.
 4. **Target environment** — only if what `gcloud` reports (read it now, see below) is not
    obviously the project the user means.
 
@@ -145,7 +145,20 @@ GCP_ACCOUNT=$(gcloud config get-value account 2>/dev/null || echo "Unknown")
 PROJECT_ID=$(gcloud config get-value project)
 PROJECT_NUMBER=$(gcloud projects describe "$PROJECT_ID" --format="value(projectNumber)")
 REGION=${CLOUD_RUN_REGION:-"asia-northeast1"}
+# Whether the sample documents can reach a Google Drive at all - sections 3 and 5
+# depend on it. The deploy uploads them with this same token, so this one call
+# answers the question exactly as the deploy will.
+DRIVE_OK=$(curl -s -o /dev/null -w '%{http_code}' \
+  -H "Authorization: Bearer $(gcloud auth print-access-token 2>/dev/null)" \
+  'https://www.googleapis.com/drive/v3/about?fields=user')
 ```
+
+`DRIVE_OK` is `200` when the Drive copy will happen, and the owner is `${GCP_ACCOUNT}` — the
+same account, because the upload uses this token. Anything else (usually `403`, a token
+carrying no Drive scope, which is what a plain `gcloud auth login` gives you) means **this
+demo will have no Google Drive copy of the sample documents at all**. That is a fact the
+brief has to state, not discover at deploy time — see brief sections 3 and 5. It is also one
+command to fix, so say it now: `gcloud auth login --enable-gdrive-access`, then re-read.
 
 ### Step 2.2 — Present the Demo Architecture & Data Model Plan
 
@@ -191,7 +204,11 @@ self-contained when it is pasted into a chat with a colleague:
   an audit seed visible only when the departments' views are joined. Details and the
   single-department escape hatch: `references/data_generation.md` §1.3.
 
-### § Brief section 3 — 📁 Google Drive External Files & Cross-Source Lineage
+### § Brief section 3 — 📁 External Sample Files & Cross-Source Lineage
+
+Title this section after where the files will actually be, not after where people assume they
+go. Cloud Storage is the only guaranteed destination (below), so a heading that says "Google
+Drive" is wrong in every run whose token lacks the Drive scope — and it was, in most of them.
 
 A table with one row per external file — type, filename, and what binds it to BigQuery:
 
@@ -208,13 +225,19 @@ document *and* querying a table, and that only works if the keys line up (70%+ F
 5-15% audit variance). See `references/external_files_and_drive.md`.
 
 Close the section with where the files will actually live, in one line, because it is the
-part users assume wrongly: they are staged to `gs://<project>-<domain>-<suffix>-docs/` in
-every mode; at deploy time the `gdrive` CLI uploads them into the Drive of whoever is
-running this skill and shares that folder with `${GCP_ACCOUNT}` as Writer; and when the
-CLI is not available or not signed in, there is no Drive copy at all — the deploy banner
-says so, and the documents are reachable only from Cloud Storage and `./external_files/`.
-The deployed agent has no way to put them in anyone's Drive. If the user wants them in
-Drive and has no working `gdrive` CLI, say so here, while it can still be sorted out.
+part users assume wrongly. Write the line that matches the `DRIVE_OK` read above:
+
+| `DRIVE_OK` | The line to write |
+| --- | --- |
+| `200` | Staged to `gs://<project>-<domain>-<suffix>-docs/` **and** uploaded at deploy time to the Google Drive of `${GCP_ACCOUNT}`, which owns the folder. |
+| anything else | Staged to `gs://<project>-<domain>-<suffix>-docs/`. **No Google Drive copy** — this machine's `gcloud` credentials carry no Drive scope, so a Drive or Sheets step in the demo script would find nothing. |
+
+The Cloud Storage staging happens in **both** `mcp` and `rag` mode; the deploy-time upload is
+the *only* path into any Drive. The deployed agent has no way to put them in anyone's Drive —
+v2.11.0 removed the in-conversation import, deliberately. If the user wants them in Drive and
+`DRIVE_OK` is not `200`, say so here, while it can still be sorted out
+(`gcloud auth login --enable-gdrive-access` and re-run, or upload `./external_files/` by hand
+afterwards).
 
 ### § Brief section 4 — 🤖 Agent Models & Runtime
 
@@ -234,19 +257,26 @@ Show what the commands above returned, verbatim, in a fenced block:
 👤 Active User Account : ${GCP_ACCOUNT}
 🏢 Target Project      : ${PROJECT_ID} (${PROJECT_NUMBER})
 🌐 Target Region       : ${REGION}
-📁 Google Drive Storage: Google Drive of ${GCP_ACCOUNT}
+🗂️ Sample File Storage : gs://${PROJECT_ID}-<domain>-<suffix>-docs/
+📁 Google Drive Copy   : <the DRIVE_OK line, below>
 ```
 
 This is the section users most often stop on, because the answer is frequently "wrong
 project". Do not paraphrase the values and do not print a project the user named unless
-`gcloud` agrees — the deploy will use what `gcloud` says, not what the brief claims. The Drive
-line is only true when the `gdrive` CLI is authenticated as the same account. When the CLI is
-signed in as someone else, that account owns the folder and `${GCP_ACCOUNT}` gets it as a
-share, so write `📁 Google Drive Storage: Google Drive of <gdrive account>, shared with
-${GCP_ACCOUNT}`; when there is no CLI at all, write `📁 Google Drive Storage: staged in GCS;
-imported into the Drive of ${GCP_ACCOUNT} on the first message to the agent`. See
-`references/external_files_and_drive.md` §5. Never print a Drive destination the deploy
-cannot reach.
+`gcloud` agrees — the deploy will use what `gcloud` says, not what the brief claims.
+
+Both storage lines are mandatory, and neither is optional wording: the Cloud Storage bucket is
+created in every mode, and the Drive line is the one users read as a promise. Write it from
+`DRIVE_OK`, never from intent:
+
+| `DRIVE_OK` | `📁 Google Drive Copy` |
+| --- | --- |
+| `200` | `Google Drive of ${GCP_ACCOUNT}` |
+| anything else | `none - these credentials have no Drive scope (fix: gcloud auth login --enable-gdrive-access)` |
+
+Never print a Drive destination the deploy cannot reach, and never describe the copy as
+something the agent will do later — nothing after the deploy writes to a Drive. See
+`references/external_files_and_drive.md` §5.
 
 ### § Brief section 6 — 🎛️ Advanced Settings & Integrations
 
@@ -256,16 +286,24 @@ cannot reach.
    real switch in the deployed container, so an option discussed here but not written to
    `.env` is a feature the demo will not have.
 
-   | Option | Default | What it buys, and what it costs |
-   |---|---|---|
-   | 🤖 `enableManagedAgent` | **`true`** | Agent Engine Sandbox code execution, asynchronous background delegation (`delegate_autonomous_task`), scheduled tasks and Drive deliverable exports. The delegation prompts in the demo playbook exercise this, which is why it is the one default-on capability. Adds ~8-10 min of provisioning, overlapped with the rest of the deploy. |
-   | 🔎 `dataExplorationMode` | **`mcp`** | How the agent reads the demo's data. **`mcp`** (default) provisions no search index: the data-asset catalog is already in the agent's system instruction, so a figure question is *one* `execute_sql` call — the four-to-five round trips people blame on "no index" came from the metadata expedition in front of the query, and the mcp routing block overrides exactly that. **`rag`** additionally builds a Discovery Engine index over the BigQuery dataset and the staged files and makes it the read path: lookups and document questions return in one sub-second `search_datastore` call, while computed figures, joins and every write stay on MCP because the index lags the tables. Pick `rag` when the demo turns on documents rather than on numbers, and note it also attaches data stores to the (often shared) Gemini Enterprise app — see `references/datastore_connectors.md`. |
-   | 🔑 `enableWorkspaceAuth` | `false` | User-OAuth passthrough — the agent acts as the signed-in user for the Drive handoff and Workspace token plumbing. Commonly wanted, since Workspace is usually available in the target environment, but **not** default-on: some organizations refuse to authorize an OAuth client they have not vetted, and there sign-in fails for every demo user. Confirm the target org permits it before enabling. |
-   | 🔑 `enableWorkspaceMcp` | `false` | **Advanced, rarely used.** Adds the Gmail / Drive / Calendar / Docs / Chat MCP toolsets on top of the auth passthrough. The Workspace MCP servers are Developer Preview and the project must be allowlisted first — enable it without that and every Workspace call 403s. Kept separate from `enableWorkspaceAuth` for exactly this reason. |
-   | 🖥️ `enableComputerUse` | `false` | Headless browser automation (Playwright). Also requires uncommenting the Playwright block in **both** `requirements.txt` and the `Dockerfile`; the deploy pre-flights this and refuses a half-configured build. |
-   | 📦 `customMcpRepos` | empty | Third-party MCP servers. Both GitHub sidecars and remote managed servers (Slack included — it is one entry in this list, not a flag of its own) go here. |
-   | 🌐 `publicDatasetId` | unset | Ground the demo in a real BigQuery public dataset (e.g. NOAA Weather, Google Trends) alongside the synthetic data. |
-   | 📈 `dataScale` | unset (hero rows only) | Row count to grow the fact tables to before loading — thousands to tens of thousands. You still write only the 50-200 hero rows the demo script names; `scripts/amplify_data.py` expands the tables around them deterministically, keeping the hero rows verbatim and foreign keys intact. Ask for it when the narrative claims enterprise volume or the demo opens with an aggregate — a `COUNT(*)` of 63 undercuts both. Costs ~10-30s of setup and a longer Discovery Engine ingest. |
+   **List all eight, every time**, in this order, with the value this deploy will use in the
+   second column — `✅ true` / `❌ false` / the literal value / `— (unset)`. An option the
+   brief leaves out is an option the user cannot ask for: they do not know it exists, and by
+   the time the deploy banner mentions it the 15-30 minutes are already spent. The gate is the
+   last cheap moment to turn one on, so the gate has to show the whole board. Keep the third
+   column as written here — it is what makes a `false` decidable rather than merely visible —
+   and reword only where this demo's scenario changes what an option would buy.
+
+   | Option | This demo | Default | What it buys, and what it costs |
+   |---|---|---|---|
+   | 🤖 `enableManagedAgent` | `<value>` | **`true`** | Agent Engine Sandbox code execution, asynchronous background delegation (`delegate_autonomous_task`), scheduled tasks and Drive deliverable exports. The delegation prompts in the demo playbook exercise this, which is why it is the one default-on capability. Adds ~8-10 min of provisioning, overlapped with the rest of the deploy. |
+   | 🔎 `dataExplorationMode` | `<value>` | **`mcp`** | How the agent reads the demo's data. **`mcp`** (default) provisions no search index: the data-asset catalog is already in the agent's system instruction, so a figure question is *one* `execute_sql` call — the four-to-five round trips people blame on "no index" came from the metadata expedition in front of the query, and the mcp routing block overrides exactly that. **`rag`** additionally builds a Discovery Engine index over the BigQuery dataset and the staged files and makes it the read path: lookups and document questions return in one sub-second `search_datastore` call, while computed figures, joins and every write stay on MCP because the index lags the tables. Pick `rag` when the demo turns on documents rather than on numbers, and note it also attaches data stores to the (often shared) Gemini Enterprise app — see `references/datastore_connectors.md`. |
+   | 🔑 `enableWorkspaceAuth` | `<value>` | `false` | User-OAuth passthrough — the agent acts as the signed-in user for the Drive handoff and Workspace token plumbing. Commonly wanted, since Workspace is usually available in the target environment, but **not** default-on: some organizations refuse to authorize an OAuth client they have not vetted, and there sign-in fails for every demo user. Confirm the target org permits it before enabling. |
+   | 🔑 `enableWorkspaceMcp` | `<value>` | `false` | **Advanced, rarely used.** Adds the Gmail / Drive / Calendar / Docs / Chat MCP toolsets on top of the auth passthrough. The Workspace MCP servers are Developer Preview and the project must be allowlisted first — enable it without that and every Workspace call 403s. Kept separate from `enableWorkspaceAuth` for exactly this reason. |
+   | 🖥️ `enableComputerUse` | `<value>` | `false` | Headless browser automation (Playwright). Also requires uncommenting the Playwright block in **both** `requirements.txt` and the `Dockerfile`; the deploy pre-flights this and refuses a half-configured build. |
+   | 📦 `customMcpRepos` | `<value>` | empty | Third-party MCP servers. Both GitHub sidecars and remote managed servers (Slack included — it is one entry in this list, not a flag of its own) go here. |
+   | 🌐 `publicDatasetId` | `<value>` | unset | Ground the demo in a real BigQuery public dataset (e.g. NOAA Weather, Google Trends) alongside the synthetic data. |
+   | 📈 `dataScale` | `<value>` | unset (hero rows only) | Row count to grow the fact tables to before loading — thousands to tens of thousands. You still write only the 50-200 hero rows the demo script names; `scripts/amplify_data.py` expands the tables around them deterministically, keeping the hero rows verbatim and foreign keys intact. Ask for it when the narrative claims enterprise volume or the demo opens with an aggregate — a `COUNT(*)` of 63 undercuts both. Costs ~10-30s of setup and a longer Discovery Engine ingest. |
 
 Only list the options that are on, plus the two or three the demo is a plausible candidate
 for. A user reading eight defaults they did not ask about is a user who skims the whole brief.
@@ -358,24 +396,25 @@ arrive here without that, go back and present it.
        `style` wording for the scanned forms), written in the demo's own language and
        domain. Without it the script emits generic placeholder documents - it holds no
        built-in industry content by design.
-     - Creates dedicated Drive folder: `GE Demo - <Company Name> (<Suffix>)`.
+     - Creates dedicated Drive folder: `GE Demo - <Company Name> (<Suffix>)`, reusing one
+       of that name if a previous run already made it.
      - Uploads `.pdf`, `.xlsx`, and `.jpg` files.
      - Saves links to `external_files/drive_upload_summary.json` and creates `.url.json` artifacts.
-     - **The folder lands in the Drive of whoever the `gdrive` CLI is signed in as** — a
-       CLI owns what it creates — **and the deploy target is added as Writer** with
-       `mutate share --email <target> --role writer --notify=false`, so it shows up under
-       that account's "Shared with me". Report the owner, the share recipient, and the
-       folder URL; when the share itself failed (cross-domain sharing is often blocked by
-       policy), the summary carries `share_error` and the banner says `❗ SHARING FAILED`
-       — pass that on with the manual share command rather than handing over a link the
-       target cannot open.
-     - When there is no authenticated `gdrive` CLI the upload is skipped and the summary
-       carries `skip_reason`. The documents are not lost — `setup_and_deploy.sh` stages
+     - **The folder is owned by `${GCP_ACCOUNT}`** — the upload is a Drive v3 REST call
+       carrying this machine's own `gcloud` access token, so the account deploying the
+       demo owns what it creates and nothing has to be shared with it. Report that owner
+       and the folder URL. The script also asks for "anyone with the link (Reader)" as a
+       convenience; plenty of organizations refuse it, in which case the summary carries
+       `share_error` and the banner notes `ℹ️ LINK SHARING OFF` — the owner can still open
+       everything, so this is a footnote, not a failure.
+     - When the token has no Drive scope the upload is skipped and the summary carries
+       `upload_skipped_reason`. The documents are not lost — `setup_and_deploy.sh` stages
        every file to `gs://$GCS_BUCKET_NAME/` in **both** data-exploration modes — but
        there will be no Drive folder, and nothing downstream creates one: report the
        skip and its reason on the completion screen, point at the Cloud Storage links,
-       and say what to do to get a folder (sign the `gdrive` CLI in and re-run, or upload
-       `./external_files/` by hand). See `references/external_files_and_drive.md` §5.
+       and give the fix, which is one command — `gcloud auth login --enable-gdrive-access`
+       and re-run, or upload `./external_files/` by hand. See
+       `references/external_files_and_drive.md` §5.
 
 4. **Provision BigQuery Dataset & Tables (Step 1/6)** (Idempotent + Knowledge Catalog Metadata):
    ```bash
@@ -700,16 +739,17 @@ Upon deployment completion, ALWAYS output the structured results containing dire
 *(Or fallback console if no app registered: `https://console.cloud.google.com/gemini-enterprise/overview?&project=${PROJECT_ID}`)*
 
 📁 **Google Drive External Sample Files** (when the deploy-time upload ran):
-- 👑 **Folder Owner**: `${DRIVE_OWNER_ACCOUNT}` (the account the `gdrive` CLI is signed in as)
-- 🔑 **Shared With**: `${GCP_ACCOUNT}` as Writer — look under "Shared with me"
+- 👑 **Folder Owner**: `${DRIVE_OWNER_ACCOUNT}` (the account that ran the deploy — switch
+  the browser to it before opening these links)
+- 🔑 **Link Sharing**: "Anyone with link (Reader)" when the organization allows it
 - 📂 **Open the Folder**: https://drive.google.com/drive/folders/${DRIVE_FOLDER_ID}
 - 📄 Audit Report (PDF, Japanese CJK Font): ${PDF_URL}
 - 📊 Supplier Ledger (Excel): ${XLSX_URL}
 - 🖼️ Simulated Document 1 (JPG): ${IMG1_URL}
 - 🖼️ Simulated Document 2 (JPG, Discrepancy Embedded): ${IMG2_URL}
-- ❗ If `drive_upload_summary.json` carries `share_error`, print that instead of implying
-  access works, and give the manual fix:
-  `gdrive mutate share <FOLDER_ID> --email ${GCP_ACCOUNT} --role writer --notify=false`.
+- ℹ️ If `drive_upload_summary.json` carries `share_error`, link sharing was refused: say
+  the owner can open the folder but the audience needs an explicit share from the Drive
+  UI, and offer the Cloud Storage links below in the meantime.
 
 📦 **External Sample Files in Cloud Storage** (always — the staging copy is unconditional):
 - 🗂️ **Browse the bucket**: https://console.cloud.google.com/storage/browser/${GCS_BUCKET_NAME}?project=${PROJECT_ID}
@@ -718,15 +758,15 @@ Upon deployment completion, ALWAYS output the structured results containing dire
   filenames, never a bare `gs://` URI on its own; `gs://` is not clickable.
 - 📂 Also on this machine: `./external_files/`
 
-📁 **When the Drive upload was skipped** (no authenticated `gdrive` CLI) — say it plainly,
-this is the only notice the user gets:
-- ℹ️ **There is no Drive copy of these documents.** Print `skip_reason` verbatim. The
-  documents themselves are complete, in Cloud Storage and `./external_files/`; only the
+📁 **When the Drive upload was skipped** (the credentials carry no Drive scope) — say it
+plainly, this is the only notice the user gets:
+- ℹ️ **There is no Drive copy of these documents.** Print `upload_skipped_reason` verbatim.
+  The documents themselves are complete, in Cloud Storage and `./external_files/`; only the
   Drive folder is missing, so a Drive or Sheets step in the demo script will find nothing.
-- 🛠️ **To get one**: sign the `gdrive` CLI in as the account that should own the folder
-  (`gdrive readonly quota --json` shows who it is now) and re-run, or upload
-  `./external_files/` to a Drive folder by hand and share it with the audience. Never
-  suggest asking the agent to do it — it cannot.
+- 🛠️ **To get one**: run `gcloud auth login --enable-gdrive-access` and re-run this script
+  (a plain `gcloud auth login` grants no Drive scope, which is why this is the usual
+  cause), or upload `./external_files/` to a Drive folder by hand and share it with the
+  audience. Never suggest asking the agent to do it — it cannot.
 
 📊 **Firestore Data Viewer Dashboard:** 👉 ${VIEWER_URL}
 🔎 **BigQuery Console:** 👉 https://console.cloud.google.com/bigquery?referrer=search&project=${PROJECT_ID}&ws=!1m4!1m3!3m2!1s${PROJECT_ID}!2s${DATASET_ID}
@@ -766,7 +806,7 @@ The template below is the base progression, before those overrides:
 #### 3. [Role Title] Cross-Source Anomaly & Risk Detection [WOW MOMENT]
 - **Tags**: `[Cross-Source WOW]` `[Drive File Binding]`
 - **Prompt Text**: (Strategic inquiry about untracked discrepancies across recent deliveries/records)
-- **Expected Outcome**: Autonomously cross-references Google Drive PDF/Excel against BigQuery tables, isolates the 5-15% discrepancy, and renders discrepancy cards and infographics.
+- **Expected Outcome**: Autonomously cross-references the external PDF/Excel against BigQuery tables, isolates the 5-15% discrepancy, and renders discrepancy cards and infographics.
 - **Watch Point**: (e.g. nobody told it to open the external report - it decided to)
 
 #### 4. [Role Title] Multi-Step Dependent Immediate Workflow [WOW MOMENT]

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
@@ -158,7 +158,7 @@ same account, because the upload uses this token. Anything else (usually `403`, 
 carrying no Drive scope, which is what a plain `gcloud auth login` gives you) means **this
 demo will have no Google Drive copy of the sample documents at all**. That is a fact the
 brief has to state, not discover at deploy time — see brief sections 3 and 5. It is also one
-command to fix, so say it now: `gcloud auth login --enable-gdrive-access`, then re-read.
+command to fix, so say it now: `gcloud auth login --enable-gdrive-access --no-launch-browser` (using `--no-launch-browser` since an agentic IDE terminal usually has no local browser), then re-read.
 
 ### Step 2.2 — Present the Demo Architecture & Data Model Plan
 
@@ -236,7 +236,7 @@ The Cloud Storage staging happens in **both** `mcp` and `rag` mode; the deploy-t
 the *only* path into any Drive. The deployed agent has no way to put them in anyone's Drive —
 v2.11.0 removed the in-conversation import, deliberately. If the user wants them in Drive and
 `DRIVE_OK` is not `200`, say so here, while it can still be sorted out
-(`gcloud auth login --enable-gdrive-access` and re-run, or upload `./external_files/` by hand
+(`gcloud auth login --enable-gdrive-access --no-launch-browser` and re-run, or upload `./external_files/` by hand
 afterwards).
 
 ### § Brief section 4 — 🤖 Agent Models & Runtime
@@ -272,7 +272,7 @@ created in every mode, and the Drive line is the one users read as a promise. Wr
 | `DRIVE_OK` | `📁 Google Drive Copy` |
 | --- | --- |
 | `200` | `Google Drive of ${GCP_ACCOUNT}` |
-| anything else | `none - these credentials have no Drive scope (fix: gcloud auth login --enable-gdrive-access)` |
+| anything else | `none - these credentials have no Drive scope (fix: gcloud auth login --enable-gdrive-access --no-launch-browser)` |
 
 Never print a Drive destination the deploy cannot reach, and never describe the copy as
 something the agent will do later — nothing after the deploy writes to a Drive. See
@@ -412,7 +412,7 @@ arrive here without that, go back and present it.
        every file to `gs://$GCS_BUCKET_NAME/` in **both** data-exploration modes — but
        there will be no Drive folder, and nothing downstream creates one: report the
        skip and its reason on the completion screen, point at the Cloud Storage links,
-       and give the fix, which is one command — `gcloud auth login --enable-gdrive-access`
+       and give the fix, which is one command — `gcloud auth login --enable-gdrive-access --no-launch-browser`
        and re-run, or upload `./external_files/` by hand. See
        `references/external_files_and_drive.md` §5.
 
@@ -763,9 +763,9 @@ plainly, this is the only notice the user gets:
 - ℹ️ **There is no Drive copy of these documents.** Print `upload_skipped_reason` verbatim.
   The documents themselves are complete, in Cloud Storage and `./external_files/`; only the
   Drive folder is missing, so a Drive or Sheets step in the demo script will find nothing.
-- 🛠️ **To get one**: run `gcloud auth login --enable-gdrive-access` and re-run this script
+- 🛠️ **To get one**: run `gcloud auth login --enable-gdrive-access --no-launch-browser` and re-run this script
   (a plain `gcloud auth login` grants no Drive scope, which is why this is the usual
-  cause), or upload `./external_files/` to a Drive folder by hand and share it with the
+  cause; `--no-launch-browser` prints the OAuth consent URL to copy into any browser when the terminal environment lacks a browser), or upload `./external_files/` to a Drive folder by hand and share it with the
   audience. Never suggest asking the agent to do it — it cannot.
 
 📊 **Firestore Data Viewer Dashboard:** 👉 ${VIEWER_URL}

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/datastore_connectors.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/datastore_connectors.md
@@ -84,8 +84,8 @@ made to work here even by hand. Do not offer either in a brief.
 ### 2.3 Google Drive DataStore — **NOT USABLE BY THIS GENERATOR**
 
 It creates cleanly, and it still cannot serve a demo built by this skill. The four reasons
-below were established against the live API in `ryotat-argolis-demo` on 2026-08-27 (the probe
-data store was deleted afterwards), not inferred from the documentation:
+below were established against the live API on 2026-08-27 (the probe data store was
+deleted afterwards), not inferred from the documentation:
 
 ```jsonc
 // POST .../locations/global/collections/default_collection/dataStores?dataStoreId=...

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/datastore_connectors.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/datastore_connectors.md
@@ -62,7 +62,12 @@ Enterprise app therefore degrades to the mcp block rather than to nothing.
 
 ---
 
-## 2. Supported DataStore Connector Types
+## 2. DataStore Connector Types
+
+`scripts/setup_datastores.py` provisions **two**, and only two: GCS (§2.1) and BigQuery (§2.2).
+Discovery Engine has more connector types, and §2.3-§2.4 describe the two people ask for by
+name — but nothing in this skill creates them, and §2.3 explains why the Drive one cannot be
+made to work here even by hand. Do not offer either in a brief.
 
 ### 2.1 Google Cloud Storage (GCS) DataStore
 - **Source**: `gs://${GCS_BUCKET_NAME}/*`
@@ -76,14 +81,50 @@ Enterprise app therefore degrades to the mcp block rather than to nothing.
 - **Indexing Options**: Searchable text fields + filterable metadata fields (dates, categories, status).
 - **Use Case**: Natural language exploration across large transaction logs, CRM records, inventory catalogs without manual SQL authoring.
 
-### 2.3 Google Drive DataStore
-- **Source**: Google Workspace Drive Folders / Shared Drives
-- **Content Type**: Google Docs, Sheets, Slides, Drive PDFs.
-- **Use Case**: Cross-referencing enterprise Drive documents directly within Gemini Enterprise.
+### 2.3 Google Drive DataStore — **NOT USABLE BY THIS GENERATOR**
 
-### 2.4 Firestore DataStore
+It creates cleanly, and it still cannot serve a demo built by this skill. The four reasons
+below were established against the live API in `ryotat-argolis-demo` on 2026-08-27 (the probe
+data store was deleted afterwards), not inferred from the documentation:
+
+```jsonc
+// POST .../locations/global/collections/default_collection/dataStores?dataStoreId=...
+{"displayName": "...", "industryVertical": "GENERIC", "solutionTypes": ["SOLUTION_TYPE_SEARCH"],
+ "contentConfig": "GOOGLE_WORKSPACE", "aclEnabled": true, "workspaceConfig": {"type": "GOOGLE_DRIVE"}}
+```
+
+1. **The agent can never read it.** Searching it with the Cloud Run runtime service account
+   returns `403 PERMISSION_DENIED: Search using service account credentials is not supported
+   for workspace datastores.` `search_datastore` runs as that service account, so the tool
+   would fail on every call. This one is decisive on its own — the data store is reachable
+   from the Gemini Enterprise UI, where the caller is the signed-in user, but not from the
+   agent this generator deploys.
+2. **It cannot be scoped to the demo's files.** There is no folder, shared-drive or query
+   parameter: `workspaceConfig.dasherCustomerId` is filled in by the server from the
+   project's own Workspace customer (`C0177...` in the probe) and the whole domain's Drive is
+   the corpus. The probe returned unrelated documents from four weeks earlier on its first
+   query, with no import call and no ingest wait. A demo would be searching the operator's
+   real Drive, which is a data-exposure problem before it is a relevance problem.
+3. **ACL is mandatory and pins the identity provider.** Omitting `aclEnabled` is rejected —
+   a data store with WORKSPACE content config is not allowed to set
+   `dataStore.aclEnabled` to false — and the created resource comes back with
+   `idpConfig.idpType: GSUITE`. Results are then
+   filtered by the querying user's Drive permissions — the demo audience sees a different
+   corpus than the presenter.
+4. **`global` only, in practice.** The same create in `asia-northeast1` fails with
+   `FAILED_PRECONDITION: IdP must be selected before creating a Data Store with
+   "dataStore.enableAcl" set to true`, i.e. it additionally needs a per-location IdP
+   configured in the project first.
+
+The supported way to put the demo's documents in front of the audience stays: stage them in
+GCS and index them with §2.1, and let the deploy-time Drive upload provide the human-facing
+Drive copy (`references/external_files_and_drive.md` §5).
+
+### 2.4 Firestore DataStore — not provisioned here
 - **Source**: Firestore Collection JSONL exports or real-time sync.
 - **Content Type**: Operational task records, incident logs, workflow state.
+- The demo reaches Firestore through the MCP toolset in both modes, never through an index —
+  task state changes while the demo runs and an index would serve stale rows.
 
 ---
 

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/deployment_and_iam.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/deployment_and_iam.md
@@ -313,7 +313,7 @@ before the first deploy.
 | `WORKER_QUEUE` | `${SERVICE_NAME}-worker` | setup | Cloud Tasks queue for background runs. |
 | `WORKER_QUEUE_LOCATION` | `us-central1` | setup | Pinned independently of `REGION` so a demo in a region without Cloud Tasks still gets durable background work. |
 | `MIN_INSTANCES` | `0` | setup | Set to `1` before a live presentation to avoid the ~20s cold start on the first message. |
-| `GCS_BUCKET_NAME` | `${PROJECT_ID}-${DOMAIN_SLUG}-${SUFFIX}-docs` | both | Created and populated with `external_files/` in `rag` mode; deleted recursively by cleanup. Defaulted rather than left unset so the unstructured half of the index exists without extra configuration when `rag` is chosen. |
+| `GCS_BUCKET_NAME` | `${PROJECT_ID}-${DOMAIN_SLUG}-${SUFFIX}-docs` | both | Created and populated with `external_files/` in **both** modes (Job 3.2b, outside the `RAG_MODE` branch) — in `mcp` mode nothing indexes those documents, but the bucket is still the only copy that outlives the machine running the skill, and the completion banner links to it. In `rag` mode it is additionally the unstructured half of the index. Deleted recursively by cleanup in both modes. |
 | `DATA_SCALE` | unset | setup | Row count to amplify the fact tables to before `bq load`, via `scripts/amplify_data.py` in Job 1.4. Unset loads the CSVs exactly as generated. `data/data_scale_spec.json`, when present, gives per-table targets and overrides this number. The step is deterministic and idempotent — the hero rows are stashed as `data/<table>.hero.csv` on the first run and every later run amplifies from the stash, never from already-amplified output — so it is safe whether or not the data phase already ran it. |
 
 #### Feature flags

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/external_files_and_drive.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/external_files_and_drive.md
@@ -108,10 +108,11 @@ the owner.
    A plain `gcloud auth login` grants `cloud-platform` and nothing else, so Drive answers
    `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT`. `generate_and_upload_external_files.py` probes
    `GET drive/v3/about?fields=user` first, which resolves the identity and the scope in
-   one call, and turns that 403 into the fix:
+   one call, and turns that 403 into the fix. Use `--no-launch-browser` because agentic
+   IDE terminals and remote development machines have no local browser to hand off to:
 
-   ```
-   gcloud auth login --enable-gdrive-access
+   ```bash
+   gcloud auth login --enable-gdrive-access --no-launch-browser
    ```
 
    | Situation | Behaviour |
@@ -158,7 +159,7 @@ the owner.
    `upload_skipped_reason` from `external_files/drive_upload_summary.json` and prints it,
    under a `📁 External Sample Files - NOT in Google Drive` heading, with what it costs (a
    Drive or Sheets step in the demo script finds nothing) and how to fix it
-   (`gcloud auth login --enable-gdrive-access` and re-run, or upload `./external_files/`
+   (`gcloud auth login --enable-gdrive-access --no-launch-browser` and re-run, or upload `./external_files/`
    by hand and share it).
 
    **This banner is the whole recovery story, by design.** v2.10.0 tried to close the gap

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/external_files_and_drive.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/external_files_and_drive.md
@@ -4,12 +4,16 @@ The GE Demo Generator synthesizes realistic external sample data files (PDF Repo
 
 Where those files end up is the part that surprises people, so it is stated up front:
 they are always written locally and staged to `gs://$GCS_BUCKET_NAME/`; the deploy-time
-`gdrive` upload puts them in the **operator's** Drive and shares that folder with the
-deploy target as Writer (§5). That upload is the **only** path into a Drive. When it does
-not run — no CLI, no CLI identity, or `SKIP_HOST_DRIVE_UPLOAD=1` — there is no Drive copy
-of these documents at all, and the deploy completion banner says so with the reason (§5.4).
-The deployed agent cannot make one: a deployment cannot write into someone else's Drive on
-its own, and sharing is how the deploy-time folder reaches the target.
+upload then puts them in the Drive of **the account running the deploy**, using the
+Drive v3 REST API with that machine's own `gcloud` access token (§5). That upload is the
+**only** path into a Drive. When it does not run — no Drive scope on the token, or
+`SKIP_DRIVE_UPLOAD=1` — there is no Drive copy of these documents at all, and the deploy
+completion banner says so with the reason and with the one command that fixes it (§5.4).
+The deployed agent cannot make one: a deployment cannot write into someone else's Drive.
+
+Nor is there an index-side route to the same documents: a Google Drive data store is created
+by Discovery Engine but cannot be read by the agent's service account, and cannot be scoped to
+a folder. See `references/datastore_connectors.md` §2.3 for the live evidence.
 
 ---
 
@@ -60,7 +64,10 @@ uv run --with "openpyxl,reportlab,pillow" python3 scripts/generate_and_upload_ex
 # Everything above is written in the demo's language and domain. The script itself
 # ships only generic placeholders - never bake a customer's content into it.
 
-# 2. Uploaded to Google Drive via gdrive CLI:
+# 2. Uploaded to Google Drive via the Drive v3 REST API, authenticated with
+#    `gcloud auth print-access-token` - no CLI to install, and the folder is
+#    owned by the account running the deploy. Re-running the deploy reuses the
+#    folder of the same name instead of creating a second one.
 # Folder: "GE Demo - <Company Name> (<Suffix>)"
 # Files:
 #   - <domain>_audit_report.pdf  -> https://drive.google.com/file/d/<PDF_ID>/view
@@ -79,63 +86,80 @@ When `enableWorkspaceMcp: true` is configured (step 1 applies to `enableWorkspac
 3. The agent can directly search the user's Drive folder for these files:
    - "Search Google Drive for the latest supplier audit report"
    - "Read the reconciliation ledger from Google Sheets and compare with operational tables"
-4. Those two prompts only find something the user's Drive can see, so they depend on the
-   deploy-time upload having run and its share having landed on the account driving the
-   demo (§5). When it did not, those two prompts come back empty and nothing recovers
-   later: check the completion banner before promising a Drive step, and give the
-   audience the Cloud Storage links instead. The agent is told the same thing, so it
-   answers "the documents are in cloud storage" rather than offering an import it cannot
-   perform.
+4. Those two prompts only find something the *signed-in user's* Drive can see, so they
+   depend on the deploy-time upload having run, and on the demo being driven by the
+   account that ran the deploy (§5). When either is untrue, those two prompts come back
+   empty and nothing recovers later: check the completion banner before promising a Drive
+   step, and give the audience the Cloud Storage links instead. The agent is told the same
+   thing, so it answers "the documents are in cloud storage" rather than offering an
+   import it cannot perform.
 
 ---
 
 ## 5. Account Ownership, Permissions & Multi-Account Access Guidance
 
-**Two different identities are in play, and they are often not the same account.**
-The *deploy target* is `gcloud config get-value account` — the account that owns the
-project and will run the demo. The *upload identity* is whoever the `gdrive` CLI is
-authenticated as, which is the operator running this skill. The CLI can only create
-files in its own Drive, so the folder belongs to the operator and the target reaches it
-through a share.
+**One identity is in play: the account `gcloud` is logged in as.** It owns the project,
+it runs the deploy, and — since v2.13.0 — it owns the Drive folder, because the upload is
+a Drive v3 REST call carrying that account's own access token. There is no second CLI, no
+second Drive, and nothing to share with the deploy target, because the deploy target *is*
+the owner.
 
-1. **Upload, then share.** `generate_and_upload_external_files.py` resolves the CLI
-   identity with `gdrive readonly quota --json` (falling back to an email match on the
-   plain output), uploads into that Drive, and — when the deploy target is a different
-   account — runs `gdrive mutate share --email <target> --role writer --notify=false`
-   on the folder:
+1. **The prerequisite is the Drive scope, and it is the only thing that usually fails.**
+   A plain `gcloud auth login` grants `cloud-platform` and nothing else, so Drive answers
+   `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT`. `generate_and_upload_external_files.py` probes
+   `GET drive/v3/about?fields=user` first, which resolves the identity and the scope in
+   one call, and turns that 403 into the fix:
+
+   ```
+   gcloud auth login --enable-gdrive-access
+   ```
 
    | Situation | Behaviour |
    | --- | --- |
-   | CLI identity == deploy target | Upload to Drive, folder owned by the target. No share needed. |
-   | CLI identity != deploy target | Upload to the operator's Drive, **share the folder with the target as Writer**. It appears under the target's "Shared with me". |
-   | CLI identity undeterminable | Skip the upload — there is no Drive to write into. |
-   | `gdrive` CLI absent | Skip the upload. |
+   | Token has the Drive scope | Create/reuse `GE Demo - <Company> (<Suffix>)`, upload the four documents, folder **owned by the deploy account**. |
+   | Token has no Drive scope, or no token at all | Skip the upload; the banner prints the re-login command above. |
+   | `SKIP_DRIVE_UPLOAD=1` | Skip the upload deliberately. |
 
-   v2.9.0 required the two identities to match and skipped otherwise, which in practice
-   meant most demos got no Drive folder at all. Sharing gives the target working links
-   without the operator having to switch accounts, so it is now the default.
+   Until v2.11.x this used an internal `gdrive` CLI authenticated as the operator, so the
+   folder was the operator's and the deploy target reached it through a share. Two
+   reasons that went: the binary is Google-internal and cannot ship in the public copy of
+   this skill, and a `google.com` → customer-domain share is frequently refused by
+   policy, which handed the target a link that 404s. Owning the folder removes both.
 
-2. **The share can fail, and that is reported, not swallowed.** Cross-domain sharing is
-   a Workspace policy decision (`google.com` → a customer domain is frequently blocked).
-   The script records the failure as `share_error` in
-   `external_files/drive_upload_summary.json`; `setup_and_deploy.sh` prints a
-   `❗ SHARING FAILED` block with the reason and the manual `gdrive mutate share`
-   command. Never print a folder link as if it worked when the share did not — the
-   target opens it and gets 403/404.
+2. **The upload is idempotent by name, folder and file both.** `files.list` with
+   `name = '<folder>' and mimeType = folder and trashed = false and 'me' in owners`
+   runs before `files.create`, so re-running the deploy reuses the folder it already made
+   rather than leaving three of them. `'me' in owners` is not decoration: without it a
+   same-named folder someone else shared with you wins the lookup, and the documents land
+   in a stranger's Drive. Each document then does the same lookup inside that folder
+   (`name = '<file>' and '<folder id>' in parents and trashed = false`) and, if it is
+   already there, is uploaded as `PATCH .../files/<id>?uploadType=multipart` instead of a
+   second `POST`. Verified against the live API: two consecutive runs leave 4 files, not
+   8, with the same file ids and a bumped `version`. Keeping the ids matters because a
+   link pasted into a demo script survives the re-deploy. (`parents` is only writable on
+   create, so the update sends the name alone.)
 
-3. **Opt-out**: `SKIP_HOST_DRIVE_UPLOAD=1` restores the old behaviour — skip the upload
-   whenever the CLI identity is not the deploy target. Use it when the operator's Drive
-   must not hold the assets at all, and accept that the demo then has no Drive copy: this
-   is a trade, not a fallback.
+3. **Link sharing is best-effort and never blocks.** After the folder exists the script
+   asks for `{"type": "anyone", "role": "reader"}` so the audience can open the links
+   without being added one by one. Plenty of organizations forbid that; the refusal is
+   recorded as `share_error` in `external_files/drive_upload_summary.json` and the banner
+   prints an `ℹ️ LINK SHARING OFF` note. This is a convenience that did not land, not the
+   old broken state — the owner can always open the folder, so the demo still works.
 
-4. **When the upload is skipped, the documents are intact but there is no Drive folder.**
+4. **Opt-out**: `SKIP_DRIVE_UPLOAD=1` skips Drive entirely, for a machine whose Drive must
+   not hold the assets. Accept that the demo then has no Drive copy: this is a trade, not
+   a fallback. (It replaces `SKIP_HOST_DRIVE_UPLOAD`, which was about a *second* identity
+   that no longer exists.)
+
+5. **When the upload is skipped, the documents are intact but there is no Drive folder.**
    They are in `./external_files` and in `gs://$GCS_BUCKET_NAME/`, which
    `setup_and_deploy.sh` stages in **every** mode (before v2.9.0 the copy sat inside the
    rag branch, so an MCP-mode demo had no bucket at all). `setup_and_deploy.sh` reads
    `upload_skipped_reason` from `external_files/drive_upload_summary.json` and prints it,
    under a `📁 External Sample Files - NOT in Google Drive` heading, with what it costs (a
-   Drive or Sheets step in the demo script finds nothing) and how to fix it (sign the
-   `gdrive` CLI in and re-run, or upload `./external_files/` by hand and share it).
+   Drive or Sheets step in the demo script finds nothing) and how to fix it
+   (`gcloud auth login --enable-gdrive-access` and re-run, or upload `./external_files/`
+   by hand and share it).
 
    **This banner is the whole recovery story, by design.** v2.10.0 tried to close the gap
    from the other end: the agent copied the documents into the signed-in user's Drive with
@@ -147,27 +171,26 @@ through a share.
    | Why it went | Detail |
    | --- | --- |
    | It uploaded the wrong things | The uploader took every object at the root of `gs://$GCS_BUCKET_NAME/`. In rag mode that root is also the datastore's corpus, so on a real demo it was 13 objects / 103 MB of the customer's own manuals, not the 4 generated samples — into an end user's personal Drive, without anyone asking for it. |
-   | The machinery outweighed the feature | Idempotency across instances and conversations needed a Firestore claim keyed on the token's email, a takeover timeout, a trashed-folder re-check and a parked announcement channel; roughly 390 lines to deliver something the deploy already does in one `gdrive` call. |
+   | The machinery outweighed the feature | Idempotency across instances and conversations needed a Firestore claim keyed on the token's email, a takeover timeout, a trashed-folder re-check and a parked announcement channel; roughly 390 lines to deliver something the deploy already does in a handful of REST calls. |
    | It paid for itself on every turn | The before-agent callback ran on all turns, and the first one blocked up to `AUTO_IMPORT_WAIT_S` (8s) waiting for the copy — a budget sized for 4 small files. |
 
    The agent's system instruction now states the same thing the banner does: the documents
-   live in cloud storage, the deploy shares the Drive folder, and if a Drive search comes
-   back empty it must say so rather than offer a copy it cannot make.
+   live in cloud storage, the deploy puts a copy in the deploying account's Drive, and if a
+   Drive search comes back empty it must say so rather than offer a copy it cannot make.
 
-5. **Reporting & Access Instructions.** Every path to the files ends in a link the
+6. **Reporting & Access Instructions.** Every path to the files ends in a link the
    reader can click; a bare `gs://` URI or a folder name is not a link.
 
    Drive (only when the upload actually ran):
-   - 👑 **Drive Owner**: the account that owns the folder
-   - 🔑 **Shared with**: the deploy target, as Writer
+   - 👑 **Drive Owner**: the account that ran the deploy
+   - 🔑 **Link sharing**: "Anyone with link (Reader)" when the org allows it; otherwise
+     the `ℹ️ LINK SHARING OFF` note, and the audience needs an explicit share
    - 📂 **Open the folder**: `https://drive.google.com/drive/folders/<FOLDER_ID>`
    - 📄 Per-file links: `https://drive.google.com/file/d/<FILE_ID>/view`
    - ⚠️ **Multi-Account Browser Warning**:
      "Make sure to switch your browser to the owner Google Account before opening the
      Google Drive links. If you are signed into multiple Google accounts, accessing the
      link with a non-owner account will fail with Permission Denied (403/404)."
-   - If owner != target, say so explicitly: the folder appears under "Shared with me"
-     for the target, and the target cannot move it into its own My Drive.
 
    Cloud Storage (always, since the staging copy always happens):
    - 🗂️ **Browse the bucket**:

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/cleanup.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/cleanup.sh
@@ -475,7 +475,7 @@ fi
 # nothing and is one click to undo if the folder turned out to hold something
 # the operator added by hand. Skipped silently when the deploy never made one,
 # or when these credentials have no Drive scope - a teardown is the wrong moment
-# to send someone through `gcloud auth login --enable-gdrive-access`.
+# to send someone through `gcloud auth login --enable-gdrive-access --no-launch-browser`.
 if [ -n "$TOKEN" ] && [ -f external_files/drive_upload_summary.json ]; then
   (
     DRIVE_FOLDER_ID=$(python3 -c \

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/cleanup.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/cleanup.sh
@@ -464,6 +464,39 @@ if [ -n "$DASH_BUCKET" ]; then
   PIDS+=($!)
 fi
 
+# 8c. Trash the Google Drive folder of external sample files (Parallel)
+# The deploy uploads the four generated documents into the deploying account's
+# own Drive and records the folder id in external_files/drive_upload_summary.json;
+# without this the folders pile up in that Drive, one per demo, long after the
+# project side is gone.
+#
+# Trashed, not deleted: this is a folder in a person's Drive, not a billed cloud
+# resource. `files.delete` is permanent and unrecoverable, while trash costs
+# nothing and is one click to undo if the folder turned out to hold something
+# the operator added by hand. Skipped silently when the deploy never made one,
+# or when these credentials have no Drive scope - a teardown is the wrong moment
+# to send someone through `gcloud auth login --enable-gdrive-access`.
+if [ -n "$TOKEN" ] && [ -f external_files/drive_upload_summary.json ]; then
+  (
+    DRIVE_FOLDER_ID=$(python3 -c \
+      'import json,sys; print(json.load(open("external_files/drive_upload_summary.json")).get("folder_id",""))' \
+      2>/dev/null || echo "")
+    if [ -n "$DRIVE_FOLDER_ID" ]; then
+      echo "📁 [Parallel] Trashing the Drive folder of sample files: ${DRIVE_FOLDER_ID}..."
+      DRIVE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+        -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" \
+        -d '{"trashed": true}' \
+        "https://www.googleapis.com/drive/v3/files/${DRIVE_FOLDER_ID}" 2>/dev/null || true)
+      if [ "$DRIVE_CODE" = "200" ]; then
+        echo "   ✅ Drive folder moved to Trash (recoverable there for 30 days)."
+      else
+        echo "   ⚠️  Drive folder not trashed (HTTP ${DRIVE_CODE}) - remove it by hand if it is still there."
+      fi
+    fi
+  ) &
+  PIDS+=($!)
+fi
+
 # 9. Delete Cloud Scheduler jobs & the Cloud Tasks worker queue (Parallel)
 # Scheduler jobs are created by the agent at runtime, one per scheduled task
 # ("<DEMO_ID>-sched-<task_id>"), so there is no fixed list to delete - they have

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/generate_and_upload_external_files.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/generate_and_upload_external_files.py
@@ -48,7 +48,7 @@ from pathlib import Path
 DRIVE_API = "https://www.googleapis.com/drive/v3"
 DRIVE_UPLOAD_API = "https://www.googleapis.com/upload/drive/v3"
 FOLDER_MIME = "application/vnd.google-apps.folder"
-REAUTH_HINT = "gcloud auth login --enable-gdrive-access"
+REAUTH_HINT = "gcloud auth login --enable-gdrive-access --no-launch-browser"
 
 def run_cmd(cmd, check=False):
     """Run a shell command and return stdout."""
@@ -403,7 +403,7 @@ def get_drive_identity(token: str):
     it carries the Drive scope, which is the failure everyone hits. A plain
     `gcloud auth login` grants cloud-platform and nothing else, so Drive returns
     403 ACCESS_TOKEN_SCOPE_INSUFFICIENT and the fix is a re-login with
-    --enable-gdrive-access. Saying that here is the difference between a demo
+    --enable-gdrive-access --no-launch-browser. Saying that here is the difference between a demo
     that is one command from having its documents in Drive and one whose
     operator concludes the feature is broken.
     """

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/generate_and_upload_external_files.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/generate_and_upload_external_files.py
@@ -25,17 +25,30 @@
 
 """
 Generates external demo files (PDF Audit Report, Excel Spreadsheet Ledger, Simulated Scanned Images)
-and uploads them directly to Google Drive, ensuring full writer/reader permissions are granted
-to the deployer account (the active gcloud account, or GCP_ACCOUNT / DRIVE_SHARE_ACCOUNT).
+and uploads them to the Google Drive of the deploy target - the active gcloud account.
+
+The upload talks to the Drive v3 REST API with the access token `gcloud` already
+holds, so there is no CLI to install and no second identity: the folder is owned
+by the same account that owns the demo, which removes the cross-domain share that
+used to fail more often than it worked. The one prerequisite is the Drive scope,
+which a plain `gcloud auth login` does not grant - see get_drive_identity().
 """
 
 import os
-import re
 import sys
 import json
+import mimetypes
 import subprocess
 import argparse
+import urllib.error
+import urllib.parse
+import urllib.request
 from pathlib import Path
+
+DRIVE_API = "https://www.googleapis.com/drive/v3"
+DRIVE_UPLOAD_API = "https://www.googleapis.com/upload/drive/v3"
+FOLDER_MIME = "application/vnd.google-apps.folder"
+REAUTH_HINT = "gcloud auth login --enable-gdrive-access"
 
 def run_cmd(cmd, check=False):
     """Run a shell command and return stdout."""
@@ -349,44 +362,159 @@ def get_active_account() -> str:
     return os.environ.get("GCP_ACCOUNT") or os.environ.get("USER") or "current user"
 
 
-_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+def drive_access_token() -> str:
+    """The gcloud access token, or '' when gcloud cannot mint one."""
+    out, code = run_cmd("gcloud auth print-access-token")
+    return out.strip() if code == 0 else ""
 
 
-def get_gdrive_identity(gdrive_bin: str) -> str:
-    """The account the gdrive CLI is authenticated as, or '' when unknown.
+def drive_request(token: str, method: str, url: str, body=None, content_type="", raw=b""):
+    """One Drive v3 call. Returns (parsed_json_or_{}, status, error_text).
 
-    Worth two attempts: an identity that cannot be read at all means the CLI is
-    not signed in and the upload is skipped, and a Drive folder that never
-    appears is a worse outcome than the parse being a little loose. The value is
-    also what the banner reports as the folder's OWNER, which is the account the
-    operator has to be signed in as to open the links.
-    `--json` is the contract; the plain output is read for an email address
-    only when the JSON shape is not what this expects.
+    Errors are values, not exceptions: every caller has something useful to do
+    with a failure - name it in the skip reason, record it as share_error, or
+    carry on without a link - and none of them should take the document
+    generation down with them.
     """
-    out, code = run_cmd(f"{gdrive_bin} readonly quota --json")
-    if code == 0 and out:
+    data = raw if raw else (json.dumps(body).encode("utf-8") if body is not None else None)
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if data is not None:
+        req.add_header("Content-Type", content_type or "application/json; charset=UTF-8")
+    try:
+        with urllib.request.urlopen(req, timeout=120) as res:
+            payload = res.read().decode("utf-8", "replace")
+            return (json.loads(payload) if payload.strip() else {}), res.status, ""
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")
         try:
-            email = json.loads(out).get("user", {}).get("emailAddress", "")
-            if email:
-                return email.strip()
+            message = json.loads(detail).get("error", {}).get("message", "")
         except Exception:
-            pass
-        found = _EMAIL_RE.search(out)
-        if found:
-            return found.group(0)
-    out, code = run_cmd(f"{gdrive_bin} readonly quota")
-    if code == 0 and out:
-        found = _EMAIL_RE.search(out)
-        if found:
-            return found.group(0)
-    return ""
+            message = ""
+        return {}, e.code, (message or detail.strip().splitlines()[0] if detail.strip() else str(e))[:300]
+    except Exception as e:  # DNS, proxy, timeout
+        return {}, 0, str(e)[:300]
+
+
+def get_drive_identity(token: str):
+    """(email, skip_reason) for the Drive the token can write into.
+
+    `about.get` is the whole pre-flight: it answers who the token is AND whether
+    it carries the Drive scope, which is the failure everyone hits. A plain
+    `gcloud auth login` grants cloud-platform and nothing else, so Drive returns
+    403 ACCESS_TOKEN_SCOPE_INSUFFICIENT and the fix is a re-login with
+    --enable-gdrive-access. Saying that here is the difference between a demo
+    that is one command from having its documents in Drive and one whose
+    operator concludes the feature is broken.
+    """
+    if not token:
+        return "", ("no gcloud access token is available on this machine "
+                    f"(run: {REAUTH_HINT})")
+    info, status, err = drive_request(token, "GET", f"{DRIVE_API}/about?fields=user")
+    if status == 200:
+        email = (info.get("user") or {}).get("emailAddress", "").strip()
+        if email:
+            return email, ""
+        return "", "the Drive API returned no user for these credentials"
+    if status == 403 and "scope" in (err or "").lower():
+        return "", ("the gcloud credentials have no Google Drive scope - "
+                    f"run `{REAUTH_HINT}` and re-run this script")
+    if status in (401, 403):
+        return "", f"Google Drive refused these credentials ({status}: {err})"
+    return "", f"the Drive API could not be reached ({status or 'no response'}: {err})"
+
+
+def drive_escape_query(value: str) -> str:
+    """Escape a literal for a Drive `q` string.
+
+    Company names with an apostrophe would otherwise terminate the quoted term
+    early, and the query stops meaning what it says.
+    """
+    return value.replace("\\", "\\\\").replace("'", "\\'")
+
+
+def drive_find_folder(token: str, name: str) -> str:
+    """The id of a non-trashed folder this account OWNS with this exact name, or ''.
+
+    `'me' in owners` matters: without it a folder someone else happened to share
+    under the same name wins the search, and the upload then writes the demo
+    documents into a stranger's Drive.
+    """
+    q = (f"name = '{drive_escape_query(name)}' and mimeType = '{FOLDER_MIME}' "
+         "and trashed = false and 'me' in owners")
+    url = f"{DRIVE_API}/files?" + urllib.parse.urlencode(
+        {"q": q, "fields": "files(id)", "pageSize": "1"})
+    info, status, _ = drive_request(token, "GET", url)
+    files = info.get("files") or []
+    return files[0].get("id", "") if status == 200 and files else ""
+
+
+def drive_find_child(token: str, name: str, parent_id: str) -> str:
+    """The id of a non-trashed file already called `name` inside `parent_id`, or ''.
+
+    The folder is found by name, so a second deploy of the same suffix - a heal,
+    a retry, a re-run after editing the content - lands in the folder that is
+    already there. Without this lookup it would collect a second copy of all
+    four documents every time. Replacing the file instead also keeps its id, so
+    a link already pasted into a demo script still resolves.
+    """
+    if not parent_id:
+        return ""
+    q = (f"name = '{drive_escape_query(name)}' and '{parent_id}' in parents "
+         "and trashed = false")
+    url = f"{DRIVE_API}/files?" + urllib.parse.urlencode(
+        {"q": q, "fields": "files(id)", "pageSize": "1"})
+    info, status, _ = drive_request(token, "GET", url)
+    files = info.get("files") or []
+    return files[0].get("id", "") if status == 200 and files else ""
+
+
+def drive_upload_file(token: str, path: str, parent_id: str):
+    """Upload one file into parent_id with a multipart/related request.
+
+    Returns (file_id, error). The error travels back because a folder full of
+    nothing is the one outcome that must not be reported as success, and only
+    the caller can see that every file failed the same way.
+
+    A file of the same name already in the folder is replaced rather than
+    duplicated - see drive_find_child(). `parents` is only writable on create,
+    so the update sends the name alone.
+
+    The four sample documents are a few hundred KB in total, so a single
+    multipart request is the right shape - a resumable session would be three
+    round trips per file to protect against an interruption that costs one
+    second to retry.
+    """
+    name = os.path.basename(path)
+    existing_id = drive_find_child(token, name, parent_id)
+    metadata = {"name": name}
+    if parent_id and not existing_id:
+        metadata["parents"] = [parent_id]
+    mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+    boundary = "ge-demo-external-files-boundary"
+    with open(path, "rb") as fh:
+        content = fh.read()
+    body = b"".join([
+        f"--{boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n".encode("utf-8"),
+        json.dumps(metadata).encode("utf-8"),
+        f"\r\n--{boundary}\r\nContent-Type: {mime}\r\n\r\n".encode("utf-8"),
+        content,
+        f"\r\n--{boundary}--\r\n".encode("utf-8"),
+    ])
+    if existing_id:
+        method, url = "PATCH", f"{DRIVE_UPLOAD_API}/files/{existing_id}?uploadType=multipart&fields=id"
+    else:
+        method, url = "POST", f"{DRIVE_UPLOAD_API}/files?uploadType=multipart&fields=id"
+    info, status, err = drive_request(
+        token, method, url,
+        content_type=f"multipart/related; boundary={boundary}", raw=body)
+    if status == 200 and info.get("id"):
+        return info["id"], ""
+    print(f"    ⚠️ Upload failed ({status}): {err}", file=sys.stderr)
+    return "", f"{status}: {err}"
 
 def upload_to_google_drive(company_name: str, suffix: str, files_to_upload: list) -> dict:
-    """Creates a Google Drive folder and uploads all external demo files, granting access to the target account."""
-    gdrive_bin = "/google/bin/releases/gemini-agents-gdrive/gdrive"
-    if not os.path.exists(gdrive_bin):
-        gdrive_bin = "gdrive"
-
+    """Creates a Google Drive folder and uploads all external demo files into the deploy target's Drive."""
     target_account = get_active_account()
     folder_name = f"GE Demo - {company_name} ({suffix})"
     
@@ -400,99 +528,77 @@ def upload_to_google_drive(company_name: str, suffix: str, files_to_upload: list
     shared_permissions = []
     share_error = ""
 
-    # Check if gdrive CLI is operational and check its authenticated identity
-    check_out, check_code = run_cmd(f"{gdrive_bin} --version")
-    gdrive_account = get_gdrive_identity(gdrive_bin) if check_code == 0 else ""
+    # The upload runs as the deploy target itself.
+    #
+    # `gcloud` is already authenticated as the account that owns the demo, so
+    # the folder is OWNED by that account and there is nothing to share with it.
+    # Until v2.13.0 this used a separate CLI authenticated as the operator, which
+    # meant every cross-account demo depended on a Drive share landing - and a
+    # google.com -> customer-domain share is frequently refused by policy, so the
+    # target got a link that 404s. Owning the folder outright removes that whole
+    # class of failure along with the "Shared with me" caveats.
+    #
+    # SKIP_DRIVE_UPLOAD=1 stays out of Drive entirely; the documents then live in
+    # ./external_files/ and the bucket, and the deploy banner says so.
+    skip_drive = os.environ.get("SKIP_DRIVE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
+    token = "" if skip_drive else drive_access_token()
+    drive_account, identity_error = ("", "SKIP_DRIVE_UPLOAD is set") if skip_drive \
+        else get_drive_identity(token)
 
-    # Upload whenever the CLI can, and SHARE with the deploy target.
-    #
-    # Whatever the gdrive CLI creates is OWNED by the account the CLI is
-    # authenticated as - the operator running this skill - so when the operator
-    # and the deploy target are different accounts the target gets the folder
-    # under "Shared with me" rather than owning it. That is the accepted
-    # trade-off: a folder the target can open on the day of the demo beats a
-    # bucket nobody looks in. v2.9.0 tried the strict version of this rule
-    # (upload only when the two identities are provably the same) and the usual
-    # outcome was no Drive folder at all.
-    #
-    # SKIP_HOST_DRIVE_UPLOAD=1 restores the strict behaviour for a target whose
-    # tenant must not see operator-owned files; the documents then live only in
-    # ./external_files/ and the bucket, and the deploy banner says so - there is
-    # no agent-side path that puts them in a Drive.
-    # ALLOW_HOST_DRIVE_UPLOAD is now the default and kept only so old runbooks
-    # and .env files do not break.
-    skip_host_drive = os.environ.get("SKIP_HOST_DRIVE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
-    should_use_gdrive = False
-    skip_reason = ""
-    if check_code != 0:
-        skip_reason = "the gdrive CLI is not available in this environment"
-    elif not gdrive_account:
-        skip_reason = ("the gdrive CLI is not authenticated, so there is no Drive to upload into")
-    elif skip_host_drive and gdrive_account.lower() != (target_account or "").lower():
-        skip_reason = (f"SKIP_HOST_DRIVE_UPLOAD is set and the gdrive CLI is authenticated as "
-                       f"{gdrive_account}, not as the deploy target {target_account}")
-    else:
-        should_use_gdrive = True
-        if target_account and gdrive_account.lower() != target_account.lower():
-            print(f"ℹ️ Uploading as [{gdrive_account}] and sharing with the deploy target.")
-            print(f"  {target_account} gets Writer access and finds the folder under 'Shared with me'.")
+    should_upload = bool(drive_account)
+    skip_reason = "" if should_upload else identity_error
 
     if skip_reason:
         print(f"ℹ️ Skipping the Google Drive upload: {skip_reason}.")
         print("  Demo files are kept in ./external_files/ and staged to GCS instead.")
-        print("  The deployed agent can still import them into the end user's own Drive on request.")
+        print("  Nothing after this step can create a Drive copy - it is a deploy-time step.")
 
-    if should_use_gdrive:
-        mkdir_out, code = run_cmd(f"{gdrive_bin} mutate mkdir '{folder_name}' --json")
-        if code == 0 and mkdir_out:
-            try:
-                folder_info = json.loads(mkdir_out)
-                folder_id = folder_info.get("id", "")
-            except Exception:
-                pass
-
-        if not folder_id:
-            search_out, _ = run_cmd(f"{gdrive_bin} readonly search --name-exact '{folder_name}' --json")
-            try:
-                search_info = json.loads(search_out)
-                if isinstance(search_info, list) and len(search_info) > 0:
-                    folder_id = search_info[0].get("id", "")
-            except Exception:
-                pass
+    if should_upload:
+        # Idempotent by name: a re-run of the deploy reuses the folder it made
+        # the first time rather than leaving the operator with three of them.
+        folder_id = drive_find_folder(token, folder_name)
+        if folder_id:
+            print(f"  ♻️ Reusing the existing Drive folder '{folder_name}'.")
+        else:
+            info, status, err = drive_request(
+                token, "POST", f"{DRIVE_API}/files?fields=id",
+                body={"name": folder_name, "mimeType": FOLDER_MIME})
+            folder_id = info.get("id", "")
+            if not folder_id:
+                skip_reason = f"the Drive folder could not be created ({status}: {err})"
+                should_upload = False
+                print(f"  ⚠️ {skip_reason}")
 
         if folder_id:
             folder_url = f"https://drive.google.com/drive/folders/{folder_id}"
-            print(f"  ✅ Folder Created: {folder_url}")
+            print(f"  ✅ Folder ready: {folder_url}")
 
-            # Explicitly grant writer permissions to the target deployer account
-            if target_account and "@" in target_account:
-                print(f"  🔑 Granting Writer permissions to target account '{target_account}'...")
-                share_out, share_code = run_cmd(f"{gdrive_bin} mutate share '{folder_id}' --email '{target_account}' --role writer --notify=false --json")
-                if share_code == 0:
-                    shared_permissions.append(f"{target_account} (Writer/Editor)")
-                    print(f"  ✅ Permission granted: {target_account} (Writer/Editor)")
-                else:
-                    # Usually a cross-domain sharing policy. The folder exists
-                    # and the operator owns it; the target simply cannot open it
-                    # yet, and the banner has to say so rather than print a link
-                    # that 404s for the person the demo is for.
-                    share_error = (share_out or "unknown error").strip().splitlines()[-1][:300]
-                    print(f"  ⚠️ Could not grant email share: {share_out}")
-
-            # Also enable link sharing as reader for frictionless demo access
-            link_share_out, link_share_code = run_cmd(f"{gdrive_bin} mutate share '{folder_id}' --type anyone --role reader --json")
-            if link_share_code == 0:
+            # Link sharing is a convenience for the demo audience, not a
+            # requirement: the owner can always open it. Organizations routinely
+            # forbid "anyone with the link", so a refusal is recorded and the
+            # run continues - it is not the failed share of the old design,
+            # where the target could not open its own demo documents.
+            _, status, err = drive_request(
+                token, "POST",
+                f"{DRIVE_API}/files/{folder_id}/permissions?sendNotificationEmail=false",
+                body={"type": "anyone", "role": "reader"})
+            if status == 200:
                 shared_permissions.append("Anyone with link (Reader)")
                 print("  ✅ Link sharing enabled: Anyone with link (Reader)")
+            else:
+                share_error = f"{status}: {err}"
+                print(f"  ℹ️ Link sharing not enabled ({share_error}). "
+                      f"{drive_account} can still open the folder.")
 
-    # owner_account is the account that actually OWNS the Drive resources, which
-    # is the gdrive CLI's identity and not necessarily the deploy target. The
-    # deploy banner prints this as "Drive Owner Account" and tells the operator
-    # which Google account to be signed in as, so naming the target here sent
-    # people to an account that only had the folder shared with it - or, when
-    # nothing was uploaded at all, to a folder that does not exist.
+    # owner_account is the account that actually OWNS the Drive resources. The
+    # deploy banner prints it as "Drive Owner Account" and tells the operator
+    # which Google account to be signed in as, so it must stay empty when
+    # nothing was uploaded - otherwise the banner sends people to a folder that
+    # does not exist. Since v2.13.0 the owner is the token's own identity, which
+    # is normally the deploy target; they can still differ if `gcloud config
+    # get-value account` is not the account that minted the token.
     results = {
-        "owner_account": (gdrive_account or target_account) if should_use_gdrive else "",
+        "owner_account": drive_account if folder_url else "",
         "target_account": target_account,
         "upload_skipped_reason": skip_reason,
         "shared_permissions": shared_permissions,
@@ -503,29 +609,25 @@ def upload_to_google_drive(company_name: str, suffix: str, files_to_upload: list
         "uploaded_files": []
     }
 
+    uploaded = 0
+    upload_error = ""
     for file_path in files_to_upload:
         if not os.path.exists(file_path):
             continue
         fname = os.path.basename(file_path)
         file_id = ""
         file_url = ""
-        
-        if folder_id and should_use_gdrive:
+
+        if folder_id and should_upload:
             print(f"  📤 Uploading '{fname}' to Google Drive...")
-            parent_arg = f"--parent '{folder_id}'" if folder_id else ""
-            upload_cmd = f"{gdrive_bin} mutate upload '{file_path}' {parent_arg} --json"
-            out, code = run_cmd(upload_cmd)
-            
-            if code == 0 and out:
-                try:
-                    res_obj = json.loads(out)
-                    file_id = res_obj.get("id", "")
-                except Exception:
-                    pass
+            file_id, upload_err = drive_upload_file(token, file_path, folder_id)
             if file_id:
+                uploaded += 1
                 file_url = f"https://drive.google.com/file/d/{file_id}/view"
                 print(f"    ✅ Link: {file_url}")
-        
+            else:
+                upload_error = upload_error or upload_err
+
         results["uploaded_files"].append({
             "fileName": fname,
             "fileId": file_id,
@@ -533,20 +635,33 @@ def upload_to_google_drive(company_name: str, suffix: str, files_to_upload: list
             "localPath": os.path.abspath(file_path)
         })
 
+    # An empty folder is not a Drive copy. The folder create and the uploads are
+    # separate permissions - a service-account token, for instance, may create
+    # folders all day and have no storage quota to put anything in them - so
+    # reporting the folder URL after every upload failed hands the demo a link
+    # to nothing. Report it as no Drive copy, with the upload's own error, and
+    # keep folder_id so cleanup.sh still trashes the empty folder.
+    if should_upload and folder_id and uploaded == 0:
+        skip_reason = f"the Drive folder was created but every upload failed ({upload_error})"
+        results["upload_skipped_reason"] = skip_reason
+        results["folder_url"] = ""
+        results["owner_account"] = ""
+        folder_url = ""
+        print(f"  ⚠️ {skip_reason}")
+
     print("\n" + "-" * 80)
     print(f"👤 Target Account     : {target_account}")
     print(f"📂 Folder Link        : {folder_url or 'Stored Locally in ./external_files/'}")
     print(f"🔑 Permissions Granted: {', '.join(shared_permissions) if shared_permissions else 'Local file store'}")
     if folder_url:
         print(f"👑 Drive Owner        : {results['owner_account']}")
-        print(f"⚠️ ACCESS INSTRUCTION : Switch browser to Google Account [{target_account}] before opening links.")
-        if results["owner_account"].lower() != target_account.lower():
-            print("                        The folder is SHARED with that account, not owned by it -")
-            print(f"                        it appears under 'Shared with me' for {target_account}.")
+        print(f"⚠️ ACCESS INSTRUCTION : Switch browser to Google Account [{results['owner_account']}] before opening links.")
+        if results["owner_account"].lower() != (target_account or "").lower():
+            print(f"                        Note: the deploy target is {target_account}, a different account.")
+            print(f"                        Share the folder with it from the Drive UI as {results['owner_account']}.")
         if share_error:
-            print(f"❗ SHARE FAILED       : {target_account} cannot open the folder yet ({share_error}).")
-            print(f"                        Share it by hand from the Drive UI as {results['owner_account']},")
-            print("                        or have the agent import the documents into that user's own Drive.")
+            print(f"ℹ️ LINK SHARING OFF   : 'anyone with the link' was refused ({share_error}).")
+            print("                        The owner can open the folder; share it explicitly for others.")
     print("-" * 80 + "\n")
 
     return results

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
@@ -24,7 +24,7 @@
 
 
 # =============================================================================
-# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.11.2)
+# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.13.0)
 # Automatically audits 8 infrastructure layers and heals discrepancies in real time:
 #   1. BigQuery Dataset & Tables (Row counts, _id column for DataStores, schema metadata)
 #   2. Firestore Collection & Seeding (Task queue documents >= 3)

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
@@ -1799,7 +1799,7 @@ elif [ ! -z "$DRIVE_SKIP_REASON" ]; then
   echo "   copy for you - it is a deploy-time step."
   echo "   Almost always the fix is one command - a plain 'gcloud auth login' grants no"
   echo "   Drive scope, so run:"
-  echo "     gcloud auth login --enable-gdrive-access"
+  echo "     gcloud auth login --enable-gdrive-access --no-launch-browser"
   echo "   and re-run this script. Otherwise upload ./external_files/ to a Drive folder"
   echo "   by hand and share it with your audience."
 fi

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
@@ -819,11 +819,11 @@ PID_BQ=$!
       --suffix "$SUFFIX" \
       $EXT_SPEC_ARG \
       --outdir "./external_files" >"$EXT_LOG" 2>&1 || true
-    # The folder is owned by whoever the gdrive CLI is signed in as - a CLI owns
-    # whatever it creates - and the deploy target is added as Writer. When the
-    # CLI is absent or unauthenticated the upload is skipped entirely, which is
-    # not an error, but announcing "uploaded to Google Drive" either way sent
-    # operators looking for a folder that was never created.
+    # The upload runs against Drive v3 with this machine's gcloud token, so the
+    # folder is owned by the account deploying the demo. It is skipped when that
+    # token has no Drive scope, which is not an error, but announcing "uploaded
+    # to Google Drive" either way sent operators looking for a folder that was
+    # never created.
     if grep -q '"folder_url": "http' external_files/drive_upload_summary.json 2>/dev/null; then
       echo "  ✅ External sample files generated and uploaded to Google Drive."
     else
@@ -1778,23 +1778,15 @@ if [ ! -z "$DRIVE_FOLDER_URL" ]; then
     echo "📄 Uploaded Files:"
     echo "$DRIVE_FILES_SUMMARY"
   fi
+  echo "⚠️ ACCESS INSTRUCTION:"
+  echo "   Make sure your browser is currently switched to Google Account [${DRIVE_OWNER_ACCOUNT}]"
+  echo "   when opening the Google Drive folder/file links above to avoid permission (403/404) errors."
   if [ ! -z "$DRIVE_SHARE_ERROR" ]; then
-    echo "❗ SHARING FAILED     : ${GCP_ACCOUNT} cannot open the folder yet."
-    echo "   Reason: ${DRIVE_SHARE_ERROR}"
-    echo "   ACTION REQUIRED - the agent cannot fix this for you. Signed in as"
-    echo "   [${DRIVE_OWNER_ACCOUNT}], either share the folder from the Drive UI or run:"
-    echo "     gdrive mutate share --email ${GCP_ACCOUNT} --role writer --notify=false <FOLDER_ID>"
-    echo "   Until then, use the Cloud Storage links below - they work for anyone with"
+    echo "ℹ️ LINK SHARING OFF   : 'anyone with the link' was refused (${DRIVE_SHARE_ERROR})."
+    echo "   [${DRIVE_OWNER_ACCOUNT}] owns the folder and can open it; that is usually a"
+    echo "   Workspace policy, so share it with your audience explicitly from the Drive UI,"
+    echo "   or use the Cloud Storage links below - they work for anyone with"
     echo "   storage.objects.get on the project."
-  elif [ "${DRIVE_OWNER_ACCOUNT}" != "${GCP_ACCOUNT}" ]; then
-    echo "⚠️ ACCESS INSTRUCTION:"
-    echo "   [${DRIVE_OWNER_ACCOUNT}] OWNS this folder and [${GCP_ACCOUNT}] has Writer access,"
-    echo "   so it appears under 'Shared with me' for the deploy account. Open the links"
-    echo "   as either of those two accounts; any other account gets 403/404."
-  else
-    echo "⚠️ ACCESS INSTRUCTION:"
-    echo "   Make sure your browser is currently switched to Google Account [${DRIVE_OWNER_ACCOUNT}]"
-    echo "   when opening the Google Drive folder/file links above to avoid permission (403/404) errors."
   fi
 elif [ ! -z "$DRIVE_SKIP_REASON" ]; then
   echo ""
@@ -1805,9 +1797,11 @@ elif [ ! -z "$DRIVE_SKIP_REASON" ]; then
   echo "   machine under ./external_files/. Only the Drive copy is missing, so a Drive or"
   echo "   Sheets step in the demo script will find nothing. The agent cannot create that"
   echo "   copy for you - it is a deploy-time step."
-  echo "   To get one, sign the gdrive CLI in as the account that should own the folder"
-  echo "   (check with: gdrive readonly quota --json) and re-run this script, or upload"
-  echo "   ./external_files/ to a Drive folder by hand and share it with your audience."
+  echo "   Almost always the fix is one command - a plain 'gcloud auth login' grants no"
+  echo "   Drive scope, so run:"
+  echo "     gcloud auth login --enable-gdrive-access"
+  echo "   and re-run this script. Otherwise upload ./external_files/ to a Drive folder"
+  echo "   by hand and share it with your audience."
 fi
 if [ ! -z "$GCS_CONSOLE_URL" ]; then
   echo ""

--- a/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
@@ -26,7 +26,7 @@ happened.
 So this gate holds four facts, in three files:
 
   1. the documents are staged to gs://$GCS_BUCKET_NAME/ in EVERY mode - until
-     v2.9.0 the copy sat inside the `RAG_MODE` branch, so an mcp-mode demo had
+     v2.9.0 the copy sat inside the `RAG_MODE` branch, so a demo in mcp mode had
      no bucket at all, and that bucket is now the only copy that outlives the
      operator's machine;
   2. the upload runs against the REST API with a gcloud token and no external
@@ -214,7 +214,7 @@ def main():
             name not in tools_src and name not in agent_src and name not in setup_src,
             "no %s" % name)
     # DRIVE_FOLDER_URL survives as a shell variable - the banner parses the
-    # summary into it - but it must not reach the container any more.
+    # summary into it - but it must not reach the container anymore.
     failures += check(",DRIVE_FOLDER_URL=" not in setup_src
                       and "DRIVE_FOLDER_URL" not in tools_src
                       and "DRIVE_FOLDER_URL" not in agent_src,

--- a/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gates where the demo's sample documents end up, and how that is reported (v2.13.0).
+
+There is exactly ONE route into a Google Drive: the deploy-time upload, which
+since v2.13.0 calls Drive v3 with this machine's own `gcloud` token, so the
+folder is owned by the account deploying the demo. A deployment cannot write
+into someone else's Drive, and since v2.11.0 the agent no longer tries either -
+the in-chat import is gone. That makes the deploy the only place the documents
+can land and the completion banner the only place the user is told what
+happened.
+
+So this gate holds four facts, in three files:
+
+  1. the documents are staged to gs://$GCS_BUCKET_NAME/ in EVERY mode - until
+     v2.9.0 the copy sat inside the `RAG_MODE` branch, so an mcp-mode demo had
+     no bucket at all, and that bucket is now the only copy that outlives the
+     operator's machine;
+  2. the upload runs against the REST API with a gcloud token and no external
+     CLI. Two things are gated here: no `gdrive` binary comes back (it is a
+     Google-internal tool, and its path leaked into the published copy of this
+     skill), and the one thing that route really can fail on - the token
+     carrying no Drive scope - is reported with the re-login that fixes it;
+  3. every destination is reported as a link a reader can click - a bare gs://
+     URI is not one, and neither is a folder name - and when there is NO Drive
+     copy the banner says so, with the reason and with what to do about it;
+  4. the in-chat import stays deleted. It uploaded whatever sat at the bucket
+     root, which in rag mode is the customer's indexed corpus rather than the
+     four generated samples, into an end user's personal Drive without being
+     asked. Nothing may quietly reintroduce it - not the tool, not the
+     unprompted callback, not the Firestore claim, not DRIVE_FOLDER_URL.
+
+Fact 1 is exercised, not pattern-matched: the job block is sliced out of the
+script and run under bash with a stubbed gcloud, once per mode.
+
+    python3 test_external_files_wiring.py
+"""
+import ast
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.abspath(__file__))
+SETUP = os.path.join(REPO, "skills/ge-demo-generator/templates/setup_and_deploy.sh")
+TOOLS = os.path.join(REPO, "skills/ge-demo-generator/templates/tools.py")
+AGENT = os.path.join(REPO, "skills/ge-demo-generator/templates/agent.py")
+GEN = os.path.join(REPO, "skills/ge-demo-generator/templates/scripts/"
+                         "generate_and_upload_external_files.py")
+
+# The one command that turns a scope-less token into a working Drive upload.
+# Both the script and the deploy banner have to print it verbatim, because
+# "authorize Drive" sends people to the Cloud console, where it is not.
+REAUTH_HINT = "gcloud auth login --enable-gdrive-access"
+
+# Every name the deleted feature was made of. None of them may come back.
+RETIRED = [
+    "import_demo_files_to_my_drive",
+    "maybe_auto_import_demo_files",
+    "_drive_import_once",
+    "_drive_import_run",
+    "_drive_import_thread",
+    "AUTO_IMPORT_DEMO_FILES",
+    "AUTO_IMPORT_WAIT_S",
+    "_drive_imports",
+]
+
+# gcloud and python3 never run for real here; every invocation is one log line.
+PRELUDE = """
+# Upper case on purpose: nothing here runs for real, and a lowercase
+# project-id-shaped literal reads as a real project to a secret scanner.
+PROJECT_ID=STUB_PROJECT_ID
+REGION=asia-northeast1
+SELECTED_APP_ID=stub-app
+SELECTED_LOC=global
+TOKEN=stub-token
+SERVICE_NAME=stub-svc
+DATASET_ID=stub_ds
+# Logged to a file, not stdout: the script sends most of these to /dev/null.
+gcloud() { echo "gcloud $*" >> "$CALL_LOG"; }
+python3() { echo "python3 $*" >> "$CALL_LOG"; }
+"""
+
+# name, RAG_MODE, GCS_BUCKET_NAME, must appear, must NOT appear
+CASES = [
+    ("mcp mode stages the documents", "0", "demo-docs",
+     ["buckets create gs://demo-docs", "storage cp -r external_files/"], ["setup_datastores.py"]),
+    ("rag mode stages them and indexes", "1", "demo-docs",
+     ["buckets create gs://demo-docs", "storage cp -r external_files/", "setup_datastores.py"], []),
+    ("no bucket name, nothing staged", "0", "",
+     [], ["buckets create", "storage cp"]),
+]
+
+
+def slice_job(src):
+    """The Job 3.2b subshell, from its banner to the line that backgrounds it."""
+    start = src.index("# Job 3.2b:")
+    end = src.index("\n) &\n", start) + len("\n) &\n")
+    return src[start:end]
+
+
+def run_case(job, rag_mode, bucket):
+    """Run the job in a throwaway tree that has the files it looks for."""
+    with tempfile.TemporaryDirectory() as _dir:
+        os.mkdir(os.path.join(_dir, "external_files"))
+        open(os.path.join(_dir, "external_files", "audit.pdf"), "w").close()
+        os.mkdir(os.path.join(_dir, "scripts"))
+        open(os.path.join(_dir, "scripts", "setup_datastores.py"), "w").close()
+        log = os.path.join(_dir, "calls.log")
+        script = "CALL_LOG=%s\nRAG_MODE=%s\nGCS_BUCKET_NAME=%s\n%s\n%s\nwait\n" % (
+            log, rag_mode, bucket, PRELUDE, job)
+        subprocess.run(["bash", "-e"], input=script, text=True,
+                       capture_output=True, check=False, cwd=_dir)
+        return open(log, encoding="utf-8").read() if os.path.exists(log) else ""
+
+
+def check(cond, label, detail=""):
+    print("  %-4s %-52s %s" % ("ok" if cond else "FAIL", label, detail))
+    return 0 if cond else 1
+
+
+def banner_branch(src):
+    """The `no Drive copy` arm of the completion banner."""
+    marker = 'elif [ ! -z "$DRIVE_SKIP_REASON" ]; then'
+    if marker not in src:
+        return ""
+    start = src.index(marker)
+    return src[start:src.index("\nfi\n", start)]
+
+
+def main():
+    failures = 0
+    setup_src = open(SETUP, encoding="utf-8").read()
+    tools_src = open(TOOLS, encoding="utf-8").read()
+    agent_src = open(AGENT, encoding="utf-8").read()
+    gen_src = open(GEN, encoding="utf-8").read()
+    job = slice_job(setup_src)
+
+    print("1. the sample documents are staged to GCS in every mode")
+    for name, rag_mode, bucket, expected, forbidden in CASES:
+        log = run_case(job, rag_mode, bucket)
+        missing = [e for e in expected if e not in log]
+        leaked = [f for f in forbidden if f in log]
+        failures += check(not missing and not leaked, name,
+                          ("missing %s " % missing if missing else "")
+                          + ("unexpected %s" % leaked if leaked else ""))
+    failures += check(
+        re.search(r'^CR_ENV_VARS="\$\{CR_ENV_VARS\},GCS_BUCKET_NAME=\$\{GCS_BUCKET_NAME\}"$',
+                  setup_src, re.M) is not None,
+        "the bucket name reaches the container",
+        "so the deployed service still records where they are")
+
+    print("\n2. the upload is Drive v3 + a gcloud token, with no external CLI")
+    failures += check("https://www.googleapis.com/drive/v3" in gen_src
+                      and "gcloud auth print-access-token" in gen_src,
+                      "the folder is created with the deploy account's own token",
+                      "so it owns the folder and needs no share")
+    for name, src in (("the upload script", gen_src), ("setup_and_deploy.sh", setup_src)):
+        failures += check(
+            "/google/bin/" not in src
+            and not re.search(r"gdrive (mutate|readonly|--version)", src)
+            and not re.search(r"gdrive_bin|gdrive CLI", src),
+            "no gdrive CLI in %s" % name,
+            "it is Google-internal; its path leaked into the public copy")
+    failures += check(REAUTH_HINT in gen_src,
+                      "a token with no Drive scope names the re-login that fixes it",
+                      "a plain `gcloud auth login` does not grant it")
+    failures += check("share_error" in gen_src and '"share_error": share_error' in gen_src,
+                      "a refused link-share is recorded, not swallowed",
+                      "'anyone with the link' is often blocked by policy")
+    failures += check("SKIP_DRIVE_UPLOAD" in gen_src,
+                      "SKIP_DRIVE_UPLOAD opts back out of the upload")
+    failures += check("upload_skipped_reason" in gen_src,
+                      "a skipped upload carries its reason into the summary")
+
+    print("\n3. every destination is reported, and a missing Drive copy is announced")
+    failures += check("https://storage.cloud.google.com/${GCS_BUCKET_NAME}/" in setup_src,
+                      "each staged file gets an openable https link",
+                      "gs:// is not something anyone can click")
+    failures += check(
+        "https://console.cloud.google.com/storage/browser/${GCS_BUCKET_NAME}" in setup_src,
+        "and the bucket itself opens in the console")
+    quick = setup_src.split("Quick Access Links")[-1] if "Quick Access Links" in setup_src else ""
+    failures += check("${DRIVE_FOLDER_URL}" in quick and "${GCS_CONSOLE_URL}" in quick,
+                      "both show up in the Quick Access Links block")
+    failures += check("${DRIVE_OWNER_ACCOUNT}" in setup_src
+                      and "LINK SHARING OFF" in setup_src,
+                      "the banner names the owner, and a refused link-share")
+    skip_branch = banner_branch(setup_src)
+    failures += check("${DRIVE_SKIP_REASON}" in skip_branch,
+                      "no Drive copy: the banner prints the reason",
+                      "this is the only notice the user gets")
+    failures += check(REAUTH_HINT in skip_branch and "external_files/" in skip_branch,
+                      "and says how to get one",
+                      "re-login with the Drive scope, or upload by hand")
+
+    print("\n4. the in-chat import stays deleted")
+    for name in RETIRED:
+        failures += check(
+            name not in tools_src and name not in agent_src and name not in setup_src,
+            "no %s" % name)
+    # DRIVE_FOLDER_URL survives as a shell variable - the banner parses the
+    # summary into it - but it must not reach the container any more.
+    failures += check(",DRIVE_FOLDER_URL=" not in setup_src
+                      and "DRIVE_FOLDER_URL" not in tools_src
+                      and "DRIVE_FOLDER_URL" not in agent_src,
+                      "DRIVE_FOLDER_URL is not passed to Cloud Run",
+                      "nothing in the runtime reads it")
+    tree = ast.parse(tools_src)
+    gate = None
+    for node in tree.body:
+        if isinstance(node, ast.If) and "ENABLE_WORKSPACE_MCP" in ast.dump(node.test) \
+                and any(isinstance(n, ast.FunctionDef) and n.name == "_ma_drive_multipart"
+                        for n in node.body):
+            gate = node
+    # The uploader helpers outlived the import: save_deliverables_to_drive is
+    # nested under this same gate and still needs them.
+    failures += check(gate is not None,
+                      "the Drive uploader helpers stay under the Workspace gate",
+                      "save_deliverables_to_drive is their remaining consumer")
+    callback = next((n for n in ast.walk(ast.parse(agent_src))
+                     if isinstance(n, ast.FunctionDef)
+                     and n.name == "_inject_completed_tasks"), None)
+    failures += check(callback is not None and "drive" not in ast.unparse(callback).lower(),
+                      "the before-agent callback does no Drive work",
+                      "it runs on every turn, in front of the user's reply")
+    failures += check("cloud storage" in agent_src.lower()
+                      and "do NOT offer to copy them into the user's" in agent_src,
+                      "the agent is told to say so instead of offering a copy")
+
+    if failures:
+        print("\n%d check(s) FAILED" % failures)
+        return 1
+    print("\nExternal files wiring: all checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
+++ b/search/gemini-enterprise/ge-demo-generator/test_external_files_wiring.py
@@ -65,7 +65,7 @@ GEN = os.path.join(REPO, "skills/ge-demo-generator/templates/scripts/"
 # The one command that turns a scope-less token into a working Drive upload.
 # Both the script and the deploy banner have to print it verbatim, because
 # "authorize Drive" sends people to the Cloud console, where it is not.
-REAUTH_HINT = "gcloud auth login --enable-gdrive-access"
+REAUTH_HINT = "gcloud auth login --enable-gdrive-access --no-launch-browser"
 
 # Every name the deleted feature was made of. None of them may come back.
 RETIRED = [


### PR DESCRIPTION
## Description

The GE Demo Generator skill generates external documents for a demo — a PDF contract, an Excel workbook, scanned invoice images — and used to place them in Google Drive by shelling out to a Google-internal `gdrive` CLI. Outside that environment the command simply is not there, so the demo only ever got the Cloud Storage copies and the Drive part of the story silently disappeared.

This replaces that call with the Drive v3 REST API, authenticated with the token `gcloud` already holds.

- `about.get` names the account that will own the copies, and the deploy reports it, so nobody has to guess whose Drive the documents landed in.
- A plain `gcloud auth login` carries no Drive scope. The script detects that and prints the `--enable-gdrive-access` re-login rather than failing halfway through the upload.
- The upload is idempotent by name. The folder is looked up before it is created and each document is replaced in place (`PATCH upload/drive/v3/files/<id>`), so a heal or a re-run leaves four files rather than eight, and a link already pasted into a demo script still resolves.
- A folder whose uploads all failed is reported as an error instead of as a link to an empty folder.
- Cleanup trashes the folder rather than deleting it, so a mistake is recoverable from the owner's bin.

Verified end to end against the live API: folder create and reuse, 4/4 multipart uploads with byte-identical sizes and correct mime types, `anyone`/`reader` sharing, a second run reusing both the folder and the four file ids, and cleanup moving the folder to the bin.

`test_external_files_wiring.py` is new and pins the properties that are easy to lose in a later edit: the scope prerequisite, the empty-folder guard, the idempotent re-run and trash-don't-delete cleanup. It runs with `python3 test_external_files_wiring.py` and needs no cloud access.

`allow.txt` gains `GSUITE` (a Discovery Engine `idpType` enum value) and `REAUTH` (from the `REAUTH_HINT` constant).

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] You are listed as the author in your notebook or README file.
- [x] Your account is listed in [`CODEOWNERS`](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/.github/CODEOWNERS) for the file(s).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format).
- [x] Appropriate docs were updated (if necessary)