### PR TITLE
feat: give the Gemini Enterprise Demo Generator agent template the datastore connector

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -756,6 +756,24 @@ instruction = (
 # so is what makes the difference. Two contradictory rules in a 100k-token prompt
 # do not resolve in favour of the later one, they resolve at random, so there is
 # deliberately no competing METADATA-FIRST rule anywhere above this block.
+#
+# RAG mode additionally needs the wiring to actually exist. The mode says what
+# was asked for; DEFAULT_DATASTORE_ID / GEMINI_ENTERPRISE_APP_ID say what the
+# deploy managed to wire. Pointing the model at an unbacked search_datastore
+# trades a slow answer for a failed one, so an un-wired rag deployment
+# degrades to the mcp block rather than to nothing.
+_DATA_EXPLORATION_MODE = os.environ.get("DATA_EXPLORATION_MODE", "").strip().lower()
+if not _DATA_EXPLORATION_MODE:
+    # Older deployments carry the boolean instead.
+    _DATA_EXPLORATION_MODE = (
+        "rag" if os.environ.get("ENABLE_DATASTORE_CONNECTORS", "").lower()
+        in ("true", "1", "yes") else "mcp"
+    )
+_RAG_WIRED = bool(
+    os.environ.get("DEFAULT_DATASTORE_ID", "").strip()
+    or os.environ.get("GEMINI_ENTERPRISE_APP_ID", "").strip()
+)
+
 _ONE_QUERY_RULE = (
     "ONE QUERY, NOT SEVERAL (MANDATORY). Before calling `execute_sql`, work out every "
     "figure the answer needs and fetch them ALL in a single statement - conditional "
@@ -784,33 +802,94 @@ _NO_NARRATION_RULE = (
     "a business question, not for a query plan.\n"
 )
 
-instruction += (
-    "\n\n--- DATA EXPLORATION: ANSWER IN ONE CALL (MANDATORY) ---\n"
-    "Three paths, listed in ascending cost. Pick the cheapest one that can actually "
-    "answer the question asked, and never walk further down the list for practice.\n\n"
-    "PATH 0 - ANSWER FROM THIS PROMPT. Zero calls, instant. The data-asset catalog above "
-    "already names every table, every column and its business meaning. Any question about "
-    "WHAT DATA EXISTS or what you are able to analyse is answered from it directly.\n"
-    "PATH 1 - SQL: `execute_sql`. One call. The catalog above IS your schema, so a figure "
-    "question needs no metadata expedition first - write the query and run it.\n"
-    "PATH 2 - CATALOG: `search_entries` / `lookup_entry` / `lookup_context`, then SQL. Two "
-    "extra round trips before the user sees anything.\n\n"
-    "ROUTING:\n"
-    "- \"What data do you have\", \"what can you analyse\" -> PATH 0. Zero tool calls.\n"
-    "- EVERYTHING that touches actual records - a lookup by name or id, a profile, an "
-    "aggregate, a comparison, a ranking, a trend, a filter over a date or numeric range, "
-    "a join, or any write -> PATH 1, directly. Do not stop at PATH 2 on the way.\n"
-    "- PATH 2 ONLY when the question is about the metadata itself, when a column you need "
-    "is not described above, or when `execute_sql` failed and you need the real schema to "
-    "fix it.\n\n"
-    + _ONE_QUERY_RULE + _PARALLEL_CALLS_RULE +
-    "ANSWER THE QUESTION THAT WAS ASKED. \"Tell me about X\" asks who or what X is - ONE "
-    "query for that record's own row, NOT a full analytical work-up. Offer the sales "
-    "trend, the customer mix and the ranking as follow-up buttons; run them when the user "
-    "presses one.\n\n"
-    + _NO_NARRATION_RULE +
-    "--- END DATA EXPLORATION ---\n"
-)
+if _DATA_EXPLORATION_MODE == "rag" and _RAG_WIRED:
+    instruction += (
+        "\n\n--- RAG-PREFERRED DATA EXPLORATION: SEARCH READS, COMPUTE WITH SQL (MANDATORY) ---\n"
+        "Reads go to the search index first. SQL is for the two things the index cannot "
+        "do - compute a figure, and change a record. Four paths, listed in ascending cost. "
+        "Pick the cheapest one that can actually answer the question asked, and never walk "
+        "further down the list for practice.\n\n"
+        "PATH 0 - ANSWER FROM THIS PROMPT. Zero calls, instant. The data-asset catalog above "
+        "already names every table, every column and its business meaning. Any question about "
+        "WHAT DATA EXISTS or what you are able to analyse is answered from it directly.\n"
+        "PATH 1 - SEARCH (the default for reads): `search_datastore`. One call, typically "
+        "under a second. It searches a single index built over BOTH the structured tables and "
+        "the documents, reports and spreadsheets staged for this demo. For a document it "
+        "returns snippets with citations; for a table row it returns THAT ROW'S OWN STORED "
+        "FIELDS - the record's identifiers, attributes, targets, dates and amounts, ready to "
+        "quote.\n"
+        "PATH 2 - SQL: `execute_sql`. One call. The catalog above IS your schema, so a figure "
+        "question needs no metadata expedition first - write the query and run it.\n"
+        "PATH 3 - CATALOG: `search_entries` / `lookup_entry` / `lookup_context`, then SQL. Two "
+        "extra round trips before the user sees anything.\n\n"
+        "ROUTING:\n"
+        "- \"What data do you have\", \"what can you analyse\" -> PATH 0. Zero tool calls.\n"
+        "- EVERY read that is not a computation -> PATH 1. Lookups by name, id or keyword; "
+        "\"what do we have on X\"; \"find the manual/report/spec covering Y\"; the opening "
+        "exploratory question of a conversation; anything a person would answer by searching "
+        "rather than by calculating.\n"
+        "- NAMED-ENTITY FIRST TOUCH (the bullet most often broken). The user names ONE thing - "
+        "a store, a tenant, a customer, a campaign, a part, a document - and asks an open "
+        "question about it: \"tell me about X\", \"what do we know about X\", \"give me X's "
+        "profile\", \"what can you tell me on X\". That is PATH 1: exactly ONE "
+        "`search_datastore` call, then answer from what comes back. Opening such a turn with "
+        "`execute_sql` is a DEFECT, and it is still a defect when the profile you had in mind "
+        "contains numbers - the record's own stored fields come back in that one call. "
+        "Answer the question that was actually asked: \"tell me about X\" asks who or what X "
+        "is, NOT for a full analytical work-up. Offer the sales trend, the customer mix and "
+        "the ranking as follow-up buttons; run them when the user presses one.\n"
+        "- ANY figure the user will read as a number - an aggregate, a comparison, a variance, "
+        "a ranking, a trend, a filter over a date or numeric range, a join, or any write -> "
+        "PATH 2, directly. Do not stop at PATH 3 on the way.\n"
+        "- PATH 3 ONLY when the question is about the metadata itself, when a column you need "
+        "is not described above, or when `execute_sql` failed and you need the real schema to "
+        "fix it.\n"
+        "- Escalate from PATH 1 the moment the snippets do not actually answer the question. "
+        "Escalating costs one extra call; guessing from a snippet costs the demo.\n\n"
+        + _ONE_QUERY_RULE + _PARALLEL_CALLS_RULE +
+        "TWO HARD RULES:\n"
+        "1. WRITES NEVER USE PATH 1. Every INSERT / UPDATE / DELETE / MERGE and every "
+        "Firestore write goes through the MCP toolsets. `search_datastore` is read-only.\n"
+        "2. DERIVED NUMBERS COME FROM SQL. Anything you COMPUTE - a sum, count, average, "
+        "share, ranking, trend, variance, or any figure spanning more than one record - MUST "
+        "come from `execute_sql` or the Firestore tools, never from a search result. So must "
+        "any record created or changed during this conversation: the index lags the tables, so "
+        "a row written a minute ago may not be indexed yet. A SINGLE named record's own stored "
+        "fields, returned by PATH 1, are the source of record and you may quote them as they "
+        "stand - that is what PATH 1 is for. Use PATH 1 to find WHAT to compute on; use SQL to "
+        "compute it.\n\n"
+        "If `search_datastore` errors or returns nothing, fall back to SQL and answer the "
+        "question. " + _NO_NARRATION_RULE +
+        "--- END RAG-PREFERRED DATA EXPLORATION ---\n"
+    )
+else:
+    instruction += (
+        "\n\n--- DATA EXPLORATION: ANSWER IN ONE CALL (MANDATORY) ---\n"
+        "Three paths, listed in ascending cost. Pick the cheapest one that can actually "
+        "answer the question asked, and never walk further down the list for practice.\n\n"
+        "PATH 0 - ANSWER FROM THIS PROMPT. Zero calls, instant. The data-asset catalog above "
+        "already names every table, every column and its business meaning. Any question about "
+        "WHAT DATA EXISTS or what you are able to analyse is answered from it directly.\n"
+        "PATH 1 - SQL: `execute_sql`. One call. The catalog above IS your schema, so a figure "
+        "question needs no metadata expedition first - write the query and run it.\n"
+        "PATH 2 - CATALOG: `search_entries` / `lookup_entry` / `lookup_context`, then SQL. Two "
+        "extra round trips before the user sees anything.\n\n"
+        "ROUTING:\n"
+        "- \"What data do you have\", \"what can you analyse\" -> PATH 0. Zero tool calls.\n"
+        "- EVERYTHING that touches actual records - a lookup by name or id, a profile, an "
+        "aggregate, a comparison, a ranking, a trend, a filter over a date or numeric range, "
+        "a join, or any write -> PATH 1, directly. Do not stop at PATH 2 on the way.\n"
+        "- PATH 2 ONLY when the question is about the metadata itself, when a column you need "
+        "is not described above, or when `execute_sql` failed and you need the real schema to "
+        "fix it.\n\n"
+        + _ONE_QUERY_RULE + _PARALLEL_CALLS_RULE +
+        "ANSWER THE QUESTION THAT WAS ASKED. \"Tell me about X\" asks who or what X is - ONE "
+        "query for that record's own row, NOT a full analytical work-up. Offer the sales "
+        "trend, the customer mix and the ranking as follow-up buttons; run them when the user "
+        "presses one.\n\n"
+        + _NO_NARRATION_RULE +
+        "--- END DATA EXPLORATION ---\n"
+    )
 
 # --- Conditional Data Viewer integration ---
 _viewer_url = os.environ.get("DATA_VIEWER_URL", "")
@@ -1256,6 +1335,11 @@ _all_tools = [t for t in _all_tools if t is not None]
 _all_tools.append(tools.write_operational_alert)
 _all_tools.append(tools.save_document_to_db)
 _all_tools.append(tools.publish_dashboard)
+# Only offered in rag mode, and only once the index is actually wired. A tool the
+# model can see is a tool it will eventually try, and in mcp mode every such call
+# is a wasted round trip that ends in an error.
+if _DATA_EXPLORATION_MODE == "rag" and _RAG_WIRED:
+    _all_tools.append(tools.search_datastore)
 
 # --- Background task management tools ---
 _all_tools.append(tools.background_task_tool)

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -4522,3 +4522,170 @@ if os.environ.get("ENABLE_MANAGED_AGENT") == "1":
             if _errors:
                 _out["problems"] = _errors
             return _out
+
+
+# DataStore ids that DATASTORE_SCOPE_IDS names but the engine does not actually
+# carry. The engine rejects the WHOLE search with a 400 if the scope mentions one
+# of these, so the first such rejection records the offender here and every later
+# call skips it. Populated at most once per process.
+_DATASTORE_SCOPE_DROPPED = set()
+
+
+def search_datastore(
+    query: str,
+    datastore_id: str = "",
+    filter_expr: str = "",
+    page_size: int = 5,
+    tool_context: ToolContext = None
+) -> dict:
+    """FAST PATH. One sub-second call against a single Discovery Engine index built over
+    BOTH the enterprise documents (PDF, Excel, Word, scanned images, manuals, reports) AND
+    the transaction tables. Prefer this over the catalog-then-SQL route, which costs four
+    to five model round trips before the user sees anything.
+
+    USE WHEN: looking something up by name, id or keyword; "what do we have on X" / "tell me
+    about X"; finding the manual, spec or report that covers Y; profiling ONE named record
+    (a store, a customer, a campaign, a part) from its own stored fields; the opening
+    exploratory question of a conversation - anything a person would answer by searching
+    rather than by calculating.
+
+    DO NOT USE WHEN: the answer is DERIVED - an aggregate over many rows (sum, count,
+    average, ranking, trend, share, variance), a join across tables, or anything you have to
+    compute. Use execute_sql for those. Also use execute_sql for any record created or
+    changed during this conversation: this index LAGS the tables. It cannot write anything.
+
+    Args:
+        query: Natural language query (e.g. "trunk route detour procedure", "Q3 audit discrepancies").
+        datastore_id: Optional specific DataStore ID to search. If omitted, searches this
+            demo's own DataStores on the Gemini Enterprise engine.
+        filter_expr: Optional filter expression (e.g., 'category: ANY("audit", "finance")').
+        page_size: Maximum number of search results to return (default: 5).
+
+    Returns:
+        dict containing search results, extractive answers, snippet text, and document reference links.
+    """
+    import os, re, json, urllib.request, urllib.error
+    import google.auth
+    from google.auth.transport.requests import Request
+
+    _project_id = os.environ.get("PROJECT_ID") or os.environ.get("GOOGLE_CLOUD_PROJECT", "")
+    _location = os.environ.get("DATASTORE_LOCATION", "global")
+    _target_ds = datastore_id or os.environ.get("DEFAULT_DATASTORE_ID", "")
+
+    if not _project_id:
+        return {"status": "error", "message": "PROJECT_ID environment variable not set."}
+
+    _ep = "discoveryengine.googleapis.com" if _location == "global" else f"{_location}-discoveryengine.googleapis.com"
+    _collection = f"projects/{_project_id}/locations/{_location}/collections/default_collection"
+
+    # DATASTORE_SCOPE_IDS confines the engine-wide search to the DataStores this
+    # deployment created. A Gemini Enterprise app is routinely shared by several
+    # demos, and unscoped the engine ranks by relevance across ALL of them - a
+    # generic query like "gold tier customers" then answers out of a NEIGHBOURING
+    # demo's customer table, which reads as this demo returning wrong data. Left
+    # unset the behaviour is the old engine-wide search, so an app whose extra
+    # DataStores are deliberate keeps working.
+    _scope_ids = []
+    if _target_ds:
+        _search_url = f"https://{_ep}/v1alpha/{_collection}/dataStores/{_target_ds}/servingConfigs/default_search:search"
+    else:
+        _app_id = os.environ.get("GEMINI_ENTERPRISE_APP_ID", "")
+        if _app_id:
+            _search_url = f"https://{_ep}/v1alpha/{_collection}/engines/{_app_id}/servingConfigs/default_search:search"
+            _scope_ids = [
+                _s.strip() for _s in os.environ.get("DATASTORE_SCOPE_IDS", "").split(",")
+                if _s.strip() and _s.strip() not in _DATASTORE_SCOPE_DROPPED
+            ]
+        else:
+            return {"status": "error", "message": "No datastore_id provided and neither DEFAULT_DATASTORE_ID nor GEMINI_ENTERPRISE_APP_ID is configured."}
+
+    try:
+        _creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+        _creds.refresh(Request())
+        _token = _creds.token
+    except Exception as _auth_err:
+        return {"status": "error", "message": f"Failed to acquire Google Cloud auth token: {str(_auth_err)}"}
+
+    _payload = {
+        "query": query,
+        "pageSize": max(1, min(page_size, 10)),
+        "contentSearchSpec": {
+            "snippetSpec": {"returnSnippet": True},
+            "summarySpec": {"summaryResultCount": 3, "includeCitations": True},
+            "extractiveContentSpec": {"maxExtractiveAnswerCount": 1, "maxExtractiveSegmentCount": 2}
+        }
+    }
+    if filter_expr:
+        _payload["filter"] = filter_expr
+    if _scope_ids:
+        _payload["dataStoreSpecs"] = [{"dataStore": f"{_collection}/dataStores/{_i}"} for _i in _scope_ids]
+
+    def _post(_body):
+        _req = urllib.request.Request(
+            _search_url,
+            data=json.dumps(_body).encode("utf-8"),
+            headers={
+                "Authorization": f"Bearer {_token}",
+                "Content-Type": "application/json; charset=utf-8"
+            },
+            method="POST"
+        )
+        with urllib.request.urlopen(_req, timeout=30) as _resp:
+            return json.loads(_resp.read().decode("utf-8"))
+
+    try:
+        try:
+            _resp_data = _post(_payload)
+        except urllib.error.HTTPError as _scope_err:
+            # A DataStore named in the scope that is not attached to the engine
+            # fails the entire request. Remember which ones, so this costs one
+            # extra round trip once rather than on every search, and retry with
+            # what is left - unscoped if nothing is.
+            if _scope_err.code != 400 or not _scope_ids:
+                raise
+            _body_txt = _scope_err.read().decode("utf-8", errors="replace")
+            if "data_store_specs" not in _body_txt:
+                raise
+            _bad = set(re.findall(r"dataStores/([A-Za-z0-9_-]+)", _body_txt))
+            if not _bad:
+                raise
+            _DATASTORE_SCOPE_DROPPED.update(_bad)
+            _scope_ids = [_i for _i in _scope_ids if _i not in _bad]
+            if _scope_ids:
+                _payload["dataStoreSpecs"] = [{"dataStore": f"{_collection}/dataStores/{_i}"} for _i in _scope_ids]
+            else:
+                _payload.pop("dataStoreSpecs", None)
+            _resp_data = _post(_payload)
+
+        _results = []
+        for item in _resp_data.get("results", []):
+            _doc = item.get("document", {})
+            _struct_data = _doc.get("structData", {})
+            _derived = _doc.get("derivedStructData", {})
+            _snippets = [s.get("snippet", "") for s in _derived.get("snippets", []) if s.get("snippet")]
+            _extractive_answers = [a.get("content", "") for a in _derived.get("extractive_answers", []) if a.get("content")]
+            _extractive_segments = [s.get("content", "") for s in _derived.get("extractive_segments", []) if s.get("content")]
+            _title = _derived.get("title", "") or _struct_data.get("title", "") or _doc.get("name", "").split("/")[-1]
+            _link = _derived.get("link", "") or _struct_data.get("link", "") or _doc.get("name", "")
+            _results.append({
+                "title": _title,
+                "link": _link,
+                "snippets": _snippets,
+                "extractive_answers": _extractive_answers,
+                "extractive_segments": _extractive_segments,
+                "data": _struct_data
+            })
+        _summary = _resp_data.get("summary", {}).get("summaryText", "")
+        return {
+            "status": "success",
+            "query": query,
+            "total_size": _resp_data.get("totalSize", len(_results)),
+            "summary": _summary,
+            "results": _results
+        }
+    except urllib.error.HTTPError as _http_err:
+        _err_body = _http_err.read().decode("utf-8", errors="replace")
+        return {"status": "error", "code": _http_err.code, "message": f"Discovery Engine Search API error: {_err_body[:300]}"}
+    except Exception as _e:
+        return {"status": "error", "message": f"Search failed: {str(_e)}"}
+


### PR DESCRIPTION
# Description

`agent_template/` and `skills/ge-demo-generator/templates/` under
`search/gemini-enterprise/ge-demo-generator/` are two copies of the same agent
runtime — the first is what the Web UI's generated setup script fetches and
deploys, the second is what the Agent Skill deploys. They have drifted.

The skill copy implements the **datastore connector**: `DATA_EXPLORATION_MODE=rag`
routes reads through a Discovery Engine index via a `search_datastore` tool,
falling back to SQL for computation and writes. The agent template does not
implement it at all — even though the repo's own reference docs already describe
the mode as part of the agent's behaviour:

- `skills/ge-demo-generator/references/deployment_and_iam.md` — "`agent.py` reads
  it to pick its routing block and to decide whether to register
  `search_datastore` at all"
- `skills/ge-demo-generator/references/datastore_connectors.md`

This PR brings the missing piece across, taken verbatim from the copy already in
this repository:

| File | Change |
| --- | --- |
| `agent_template/adk_agent/app/tools.py` | Appends `_DATASTORE_SCOPE_DROPPED` and `search_datastore`, byte-for-byte from `skills/ge-demo-generator/templates/tools.py`. |
| `agent_template/adk_agent/app/agent.py` | Adds the `_DATA_EXPLORATION_MODE` / `_RAG_WIRED` resolution, the rag-mode instruction block, and the guarded `_all_tools.append(tools.search_datastore)`. |

No other divergence between the two copies is touched.

## Why this is safe for existing deployments

Nothing changes unless a deployment opts in, and no deployment created by the Web
UI can opt in today — `DATA_EXPLORATION_MODE` appears nowhere in `app/Code.gs`.

- The mode resolves to `mcp` when `DATA_EXPLORATION_MODE` is unset, and `rag`
  additionally requires `DEFAULT_DATASTORE_ID` or `GEMINI_ENTERPRISE_APP_ID` to be
  wired. A deployment that sets neither takes the `else:` branch.
- That `else:` branch is the block that was already there. Its 27 lines are
  byte-identical to the text they replace; the only change is the indentation
  required by the `if`/`else`.
- An un-wired `rag` deployment degrades to the `mcp` block rather than to a tool
  the index cannot serve.
- Both new module-level names in `agent.py` are unconditional, and
  `search_datastore` and `_DATASTORE_SCOPE_DROPPED` are unconditional at module
  level in `tools.py`, so no flag combination can leave a reference undefined.
  `search_datastore`'s only free names are `ToolContext` (imported at the top of
  the file) and `_DATASTORE_SCOPE_DROPPED`.
- Both files pass `py_compile`. They carry `# ruff: noqa`, as before.

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/GoogleCloudPlatform/generative-ai/blob/main/CONTRIBUTING.md).
- [x] Ensure the tests and linter pass.
- [ ] If you are creating a new notebook/sample — not applicable; this changes existing files.
