### PR TITLE
fix(ge-demo-generator): stop escaping the system instruction into a quoted heredoc (v11.95-public)

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/AGENTS.md
+++ b/search/gemini-enterprise/ge-demo-generator/AGENTS.md
@@ -83,6 +83,11 @@ Dockerfile assembly, deployment). Inside those JS template literals:
   newline disappears from the output). Use it only intentionally.
 - Quoted heredocs (`cat <<'X'`) pass content through verbatim; unquoted
   heredocs (`cat <<X`) expand `$VAR` at run time.
+- Because a quoted heredoc is verbatim, content bound for one must **not** be
+  pre-escaped. The shell does not strip the backslashes back off; they land in
+  the written file. The system instruction was escaped this way for a quoted
+  heredoc until v11.95-public, so every `$`, backtick and backslash reached the
+  model with a stray backslash in front of it. Escape for the heredoc you have.
 
 ### 2.3 ADK instruction template engine hazard (applies to agent.py)
 

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v11.93-public',
+  APP_VERSION: 'v11.95-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -2704,13 +2704,6 @@ function generateSetupScript(params) {
   const constraintsTxt = constraintLines.map(line => line.text).join('\n');
 
 
-  const escapedInstruction = systemInstruction
-    .replace(/\\/g, '\\\\\\\\')
-    .replace(/'/g, "'\\''")
-    .replace(/\{/g, '{{')
-    .replace(/\}/g, '}}')
-    .replace(/\n/g, '\\n');
-
   // == Managed Autonomous Agent (Antigravity) generation-time assets ==
   // Craft skills come from this repo's demo-skills/ dir (main branch, fetched
   // at generation time; fail-soft) and are emitted as quoted heredocs. The
@@ -3000,8 +2993,14 @@ Requirements:
     firestoreCommands += `fi\n\n`;
   }
 
-  // Robustly escape instruction for an unquoted bash heredoc
-  const rawInstruction = systemInstruction.replace(/[\\$`]/g, match => '\\' + match);
+  // The instruction is emitted into a QUOTED heredoc (__GE_INSTRUCTION_EOF__),
+  // which suppresses parameter expansion, command substitution and backslash
+  // processing alike, so it must NOT be escaped. Escaping it is not undone by
+  // the shell: the added backslashes land in generated_instruction.md, which
+  // agent.py reads verbatim, so the model is told "\$5,000" and "C:\\path"
+  // instead of what the plan actually said. The comment this replaces named an
+  // unquoted heredoc; the heredoc has been quoted for as long as it existed.
+  const rawInstruction = systemInstruction;
 
   // Per-demo MCP server config consumed by the static agent_template runtime
   // (tools.get_custom_mcp_toolsets / get_slack_mcp_toolset and the numbered


### PR DESCRIPTION
## What

`generateSetupScript` escapes the generated system instruction before writing it
into the demo project:

```js
// Robustly escape instruction for an unquoted bash heredoc
const rawInstruction = systemInstruction.replace(/[\\$`]/g, match => '\\' + match);
```

The comment names the assumption. The heredoc violates it — it has always been
**quoted**:

```
cat <<'__GE_INSTRUCTION_EOF__' > adk_agent/app/generated_instruction.md
${rawInstruction}
__GE_INSTRUCTION_EOF__
```

A quoted delimiter suppresses parameter expansion, command substitution and
backslash processing alike, so the shell never takes those backslashes back off.
They land in `generated_instruction.md`, and `agent_template/adk_agent/app/agent.py`
reads that file verbatim into the system instruction.

## Effect

The model reads a mangled instruction — worse the more shell-ish or Windows-ish
the demo's prose is. Measured by putting one instruction through
`generateSetupScript` on both sides and diffing the generated script:

```
-Budget is \$5,000; use \`bq\` on C:\\path.
+Budget is $5,000; use `bq` on C:\path.
```

Those two lines and the version banner are the script's only differences.
Running the emitted heredoc confirms `generated_instruction.md` now contains the
instruction as written.

Not a crash, which is why it survived: the deploy succeeds and the agent starts.

## Also in this PR

`escapedInstruction` (a fifth escaping scheme applied to the same string, a few
hundred lines above) is unused — no reference anywhere in the repo. Removed.

`AGENTS.md` §2.2 already said quoted heredocs pass content through verbatim; it
now states the corollary that tripped this up, that content bound for one must
not be pre-escaped.

## Verification

- `node --check` on `Code.gs`
- generated setup script `bash -n` clean
- generated script diff against `main` is the instruction line + the version banner only
- spelling pre-checked offline against the repo's baseline vocabulary and
  `line_forbidden.patterns`: no new tokens, no forbidden-pattern hits
