### PR TITLE
feat(ge-demo-generator): update default model to Gemini 3.8 Flash and announce agent skill (v12.4-public)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -79,6 +79,7 @@ apikeys
 apixaban
 apk
 approv
+appsscript
 appuser
 appyaml
 apredict
@@ -148,6 +149,7 @@ Ayyappa
 backstory
 backticks
 bagchi
+Bahasa
 Bakkali
 bargap
 barista
@@ -251,6 +253,7 @@ Camry
 cands
 Canlaws
 Caprese
+CAPTCH
 carbonara
 Carcante
 cardio
@@ -279,6 +282,7 @@ cer
 cfbundle
 cfo
 chatbots
+chatmcp
 CHECKOV
 CHENNAI
 chipset
@@ -333,6 +337,7 @@ colorway
 colurna
 colvis
 colwidth
+contextvar
 Cómo
 Condesa
 Connectez
@@ -420,6 +425,7 @@ deepeval
 DeepEval
 deepseek
 defn
+DELET
 deliv
 Demis
 Demme
@@ -429,6 +435,8 @@ demouser
 denorm
 dente
 Depatmint
+derailed
+derails
 Derpanis
 DERs
 descgen
@@ -438,6 +446,7 @@ Dexin
 dflags
 dflt
 dfs
+Dgektczl
 DHH
 diffable
 diffed
@@ -481,6 +490,7 @@ draig
 Dreesen
 drilldown
 drinkware
+drivemcp
 droid
 dropbtn
 dropdown
@@ -596,6 +606,8 @@ expr
 extfiles
 faa
 facecolor
+Failsafe
+failsafe
 Fairall
 faiss
 FAISS
@@ -646,6 +658,7 @@ FLX
 fmeasure
 fmeta
 FMWK
+Foauth
 Folmer
 fontane
 fontdict
@@ -685,6 +698,7 @@ Fushimi
 futur
 fval
 fx
+FYWWN
 Gabeira
 Gacrux
 gaeta
@@ -757,6 +771,7 @@ gke
 GKE
 Gleyber
 glowin
+gmailmcp
 gmaps
 Gmb
 GmbH
@@ -1043,6 +1058,7 @@ keypair
 Keypair
 KFBI
 kfp
+Kfuy
 Khanh
 khz
 kickstart
@@ -1054,6 +1070,7 @@ KMEANS
 knative
 KNN
 kok
+kokkai
 Kongre
 konnte
 kotlin
@@ -1180,6 +1197,7 @@ Manh
 manquez
 Manyata
 mapbox
+mapstools
 marp
 Masaru
 maskmode
@@ -1325,6 +1343,7 @@ ndd
 NDEBUG
 ndocs
 nec
+Nederlands
 neering
 neighbouring
 neil
@@ -1503,6 +1522,7 @@ pfas
 pgadmin
 PGHOST
 pgid
+Pgnpk
 PGPORT
 PGUSER
 pgvector
@@ -1556,6 +1576,7 @@ Popken
 popleft
 Porat
 PORTFILE
+Portugu
 postictal
 powerups
 PPO
@@ -1613,6 +1634,7 @@ Qantas
 qas
 QEDC
 qjson
+QKYV
 QLo
 qlog
 qlogger
@@ -1621,6 +1643,7 @@ QPM
 qqq
 qrel
 qrels
+Qsxq
 quadrotor
 qubit
 qubits
@@ -1781,6 +1804,7 @@ seatback
 Segfault
 SEK
 Selam
+SELEC
 selectbox
 selfie
 selftext
@@ -1968,6 +1992,7 @@ tcard
 tcd
 TCEHY
 teardowns
+telematics
 telework
 tema
 tempfile
@@ -2095,6 +2120,7 @@ uncomment
 uncommented
 uncommenting
 und
+undary
 undescribed
 undeterminable
 undst
@@ -2329,6 +2355,7 @@ Yuzuru
 zakarid
 Zakarids
 zaxis
+ZBOA
 Zemeckis
 zfill
 zfq
@@ -2347,4 +2374,5 @@ Zoomably
 Zosyn
 Zscaler
 Zuv
+Zvrm
 ZWSP

--- a/search/gemini-enterprise/ge-demo-generator/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/README.md
@@ -11,7 +11,7 @@ The **Gemini Enterprise Demo Generator** is a low-code web application built on 
 - **Reality-Grounded Demos**: The tool provisions actual BigQuery analytics, Google Maps grounding, and Firestore persistence databases for a raw, living demo experience.
 
 ### ⚙️ Technical Features
-- **Triple-Agent Autonomous Architecture**: Features a multi-agent execution framework powered by **Gemini 3.7 Flash** by default. Consists of a coordinator (`root_agent`) for chat, simple retrieval, and A2UI card rendering; an analytical sub-agent (`deep_analysis_agent`) for complex inline calculations; and a standalone background worker (`background_agent`) run asynchronously for long-running background tasks and recurring cron scheduled tasks. Models are configurable via `--model-analysis-agent` and `--model-root-agent` CLI flags.
+- **Triple-Agent Autonomous Architecture**: Features a multi-agent execution framework powered by **Gemini 3.8 Flash** by default. Consists of a coordinator (`root_agent`) for chat, simple retrieval, and A2UI card rendering; an analytical sub-agent (`deep_analysis_agent`) for complex inline calculations; and a standalone background worker (`background_agent`) run asynchronously for long-running background tasks and recurring cron scheduled tasks. Models are configurable via `--model-analysis-agent` and `--model-root-agent` CLI flags.
 - **Autonomous Workflow Pipelines & Guardrails**: Incorporates advanced background pipelines for both workflow-based operations (`SCAN -> ANALYZE -> PLAN -> EXECUTE -> VERIFY -> REPORT` with human-in-the-loop escalations) and deep analytical tasks. All background tasks are protected by an **Anti-Shallow Guard** self-check to ensure rigorous statistical results and extensive data tool coverage.
 - **MCP Server Catalog**: A curated catalog of pre-configured MCP servers (Government & Legal, Finance, Social, Japan-Specific, Environment & Weather, Google Official) with one-click add, recipe bundles, and custom URL import.
 - **A2UI v0.9 + Material Catalog**: Streams interactive dashboards, data tables, Vega-Lite charts, sandboxed HTML panels, and confirmation cards using the A2UI SDK (`a2ui-agent-sdk`) on **A2UI v0.9** with the Gemini Enterprise **composite catalog** (`Material*` components plus `Canvas`, `IFrameSrcdoc`, `VegaChart`, `GcbpTable`), delivered via `<a2ui-json>` tags in model responses. Integrates rich Welcome Card onboarding and step-by-step Workflow Execution Plan patterns.
@@ -209,7 +209,7 @@ A complete setup is **two properties**: `PROJECT_ID` and `LOG_SHEET_URL`. Everyt
 | Property | Default | Description |
 |---|---|---|
 | `LOCATION` | `global` | Vertex AI Agent Platform API location (e.g., `us-central1`, `global`) |
-| `MODEL` | `gemini-3.7-flash` | Gemini model name for data generation |
+| `MODEL` | `gemini-3.8-flash` | Gemini model name for data generation |
 | `GITHUB_TOKEN` | (unset) | GitHub personal access token used for GitHub API calls when importing custom MCP servers from a repository URL. Only needed for private repos or to avoid unauthenticated rate limits |
 
 **Development and administration** — for working on this sample, not for running it. If you are deploying the app to give demos, skip these entirely:
@@ -296,7 +296,7 @@ When a user generates a demo through the web UI, the tool:
    - Provisions Firestore with operational documents
    - Deploys a **Data Viewer** web app (Flask on Cloud Run Functions Gen2)
    - Scaffolds an ADK agent project with MCP toolsets, A2UI support, and an A2A FastAPI server exposing a chat agent (`root_agent` and `deep_analysis_agent` sub-agent) and a background worker (`background_agent` via `/execute_task` runner)
-   - Defaults to **Gemini 3.7 Flash** for all three agents, with support for model override via `--model-analysis-agent` and `--model-root-agent` CLI flags
+   - Defaults to **Gemini 3.8 Flash** for all three agents, with support for model override via `--model-analysis-agent` and `--model-root-agent` CLI flags
    - Automatically builds a container image and deploys the Agent FastAPI server to **Cloud Run** (with `--min-instances 0` to control standby costs).
    - Provisions IAM bindings and environment configurations automatically.
    - Discovers any existing Gemini Enterprise Apps in your project and registers the newly deployed Cloud Run agent automatically.
@@ -612,12 +612,12 @@ When the user runs the generated setup script in Cloud Shell, the following arch
 
 #### Agent Architecture
 
-The synthesized agent uses a **triple-agent/multi-agent autonomous execution** architecture to achieve high-depth operational execution alongside optimal latency and cost. The architecture features three specialized agent instances, all utilizing **Gemini 3.7 Flash** by default for rapid response and high token efficiency:
+The synthesized agent uses a **triple-agent/multi-agent autonomous execution** architecture to achieve high-depth operational execution alongside optimal latency and cost. The architecture features three specialized agent instances, all utilizing **Gemini 3.8 Flash** by default for rapid response and high token efficiency:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  root_agent (LlmAgent — Coordinator)                         │
-│  Model: gemini-3.7-flash (AGENT_MODEL_LITE)                  │
+│  Model: gemini-3.8-flash (AGENT_MODEL_LITE)                  │
 │  Role: Chat coordinator, simple queries, A2UI card builder    │
 │  Instruction: Generated system prompt + A2UI schema          │
 │               + Background-First Routing Rules               │
@@ -633,7 +633,7 @@ The synthesized agent uses a **triple-agent/multi-agent autonomous execution** a
 │                                                              │
 │  ┌──────────────────────────────────────────────────────┐    │
 │  │  deep_analysis_agent (LlmAgent — Analytical Sub)     │    │
-│  │  Model: gemini-3.7-flash (AGENT_MODEL)                │    │
+│  │  Model: gemini-3.8-flash (AGENT_MODEL)                │    │
 │  │  Role: Complex inline multi-step reasoning            │    │
 │  │  Tools: Same shared toolset                           │    │
 │  │  Transfer: Returns to root_agent on completion        │    │
@@ -647,7 +647,7 @@ The synthesized agent uses a **triple-agent/multi-agent autonomous execution** a
 
 ┌──────────────────────────────────────────────────────────────┐
 │  background_agent (LlmAgent — Standalone Worker)              │
-│  Model: gemini-3.7-flash (AGENT_MODEL)                       │
+│  Model: gemini-3.8-flash (AGENT_MODEL)                       │
 │  Role: Autonomous background operations & deep analysis       │
 │  Instruction: Main instruction + Pipeline guardrails         │
 │               + Anti-Shallow Guard (no UI / no transfers)    │
@@ -863,7 +863,7 @@ graph TD
 The setup script deploys the agent directly to Google Cloud Run and supports model overrides and automated cleanup via CLI flags:
 
 ```bash
-# Default models (gemini-3.7-flash)
+# Default models (gemini-3.8-flash)
 bash setup-demo-xxx.sh
 
 # Override models
@@ -938,7 +938,7 @@ After running the setup script, the following directory structure is created:
 
 1. **Prompt**: The user says in Gemini Enterprise: *"Approve safety issue #104 and log update notes."*
 2. **A2A Routing**: Gemini Enterprise sends the message via A2A JSON-RPC to the Cloud Run FastAPI server.
-3. **Model Announcement**: The server emits a `🧠 Model: gemini-3.7-flash` status event in the thinking accordion.
+3. **Model Announcement**: The server emits a `🧠 Model: gemini-3.8-flash` status event in the thinking accordion.
 4. **Reasoning**: The `root_agent` identifies a write request and plans to use the Firestore MCP toolset.
 5. **Confirmation**: The agent renders an A2UI confirmation card (via `<a2ui-json>` tags) showing before/after data with Approve/Reject buttons and an `updateDataModel` for pre-populated fields.
 6. **User Approval**: The user clicks "Approve" in the interactive card, which sends an action DataPart (`action.event.name` plus a `context.prompt` string) back to the agent.

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -1180,13 +1180,13 @@ _RETRY_OPTIONS = types.HttpRetryOptions(
 
 # Pro model — used by deep_analysis_agent for complex multi-step reasoning
 gemini_pro_model = Gemini(
-    model=os.environ.get("AGENT_MODEL", "gemini-3.7-flash"),
+    model=os.environ.get("AGENT_MODEL", "gemini-3.8-flash"),
     retry_options=_RETRY_OPTIONS
 )
 
 # Flash-Lite model — used by root_agent (coordinator) for most interactions
 gemini_lite_model = Gemini(
-    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash"),
+    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash"),
     retry_options=_RETRY_OPTIONS
 )
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/fast_api_app.py
@@ -1606,7 +1606,7 @@ async def _classify_for_preflight(text, prev_user_text=""):
             vertexai=True, location=_loc, project=project_id,
             http_options={"api_version": "v1"},
         )
-        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash")
+        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash")
         _prompt = PREFLIGHT_CLASSIFIER_PROMPT + chr(10) + chr(10)
         if prev_user_text:
             _prompt = (_prompt + "PREVIOUS USER MESSAGE (language reference only - NOT the request):"
@@ -1661,7 +1661,7 @@ async def _localize_ui_strings(_defaults, _language_sample):
             vertexai=True, location=_loc, project=project_id,
             http_options={"api_version": "v1"},
         )
-        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash")
+        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash")
         _prompt = (
             "Rewrite every VALUE of the JSON object below in the SAME LANGUAGE as the SAMPLE MESSAGE, "
             "keeping the meaning, the register and any leading emoji. Keep every {placeholder} "
@@ -2104,13 +2104,13 @@ def _heal_session_events(session, force_aggressive=False):
     #   - force_aggressive=True (emergency, after a token-overflow ClientError)
     #   - the root model is a lightweight model (flash-lite) — always compact
     #   - the measured context size exceeds the char budget. Heavier models
-    #     (3.7-flash / pro) keep FULL context UNTIL near the limit, so normal
+    #     (3.8-flash / pro) keep FULL context UNTIL near the limit, so normal
     #     large reports are never trimmed — only runaway contexts are.
     # Char-based by design: generated-image bytes are NOT stored in history
     # (generate_image stashes them in session.state), so the real bloat is
     # text — SQL result sets, MCP payloads, multi-turn accumulation.
     # =========================================================================
-    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash").lower()
+    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash").lower()
     _is_lite = "lite" in _root_model
 
     def _event_char_size(_ev):
@@ -3442,8 +3442,8 @@ class AdkAgentToA2AExecutor(A2aAgentExecutor):
         # Maps agent name → model string for the thinking accordion header.
         # =============================================================================
         _agent_model_map = {
-            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash"),
-            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.7-flash"),
+            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash"),
+            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.8-flash"),
         }
         _model_announced = set()  # Track which agents have been announced
 

--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/tools.py
@@ -1237,7 +1237,7 @@ async def publish_dashboard(html: str, title: str, tool_context: ToolContext) ->
 if os.environ.get("ENABLE_COMPUTER_USE") == "1":
 
     # =====================================================================
-    # Computer Use (browser agent) -- Gemini 3.7 Flash built-in computer_use
+    # Computer Use (browser agent) -- Gemini 3.8 Flash built-in computer_use
     # tool driven over a self-hosted headless Chromium (Playwright). Adapted
     # from the official reference impl (github.com/google-gemini/
     # computer-use-preview, Apache-2.0): same generate_content loop, action
@@ -1570,11 +1570,11 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
             return {"status": "error", "detail": "Playwright is not installed in this environment: " + str(_imp)}
 
         client = genai_client.Client(vertexai=True, location=location, project=project)
-        # gemini-3.7-flash supports the Computer Use tool (3.6-flash did not,
+        # gemini-3.8-flash supports the Computer Use tool (3.6-flash did not,
         # which is why this used to be pinned to 3.5-flash). Kept on its own
         # COMPUTER_USE_MODEL override rather than AGENT_MODEL, since a custom
         # --model-analysis-agent may point at a model without Computer Use.
-        model = os.environ.get("COMPUTER_USE_MODEL", "gemini-3.7-flash")
+        model = os.environ.get("COMPUTER_USE_MODEL", "gemini-3.8-flash")
         cfg = types.GenerateContentConfig(
             temperature=1.0, top_p=0.95, top_k=40, max_output_tokens=8192,
             tools=[types.Tool(computer_use=types.ComputerUse(environment=types.Environment.ENVIRONMENT_BROWSER))],

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -21,7 +21,7 @@
  *
  * ── What Gets Generated ──────────────────────────────────────────────
  *   • Synthetic business data (BigQuery tables + optional Firestore docs)
- *   • Dual-model ADK agent (Gemini 3.7 Flash root + deep analysis sub-agent)
+ *   • Dual-model ADK agent (Gemini 3.8 Flash root + deep analysis sub-agent)
  *   • MCP toolsets — BigQuery, Maps, Firestore, Google Workspace (Gmail,
  *     Drive, Calendar, Chat, People), plus arbitrary GitHub MCP servers
  *   • A2A (Agent-to-Agent) server with A2UI interactive components
@@ -97,11 +97,11 @@ const SCRIPT_PROPS = PropertiesService.getScriptProperties();
 const CONFIG = {
   PROJECT_ID: SCRIPT_PROPS.getProperty('PROJECT_ID'),
   LOCATION: SCRIPT_PROPS.getProperty('LOCATION') || 'global',
-  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.7-flash',
+  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.8-flash',
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v12.3-public',
+  APP_VERSION: 'v12.4-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -176,7 +176,7 @@ function doGet() {
 
   template.projectId = CONFIG.PROJECT_ID;
   template.userEmail = Session.getActiveUser().getEmail();
-  template.generatorModel = CONFIG.MODEL || 'gemini-3.7-flash';
+  template.generatorModel = CONFIG.MODEL || 'gemini-3.8-flash';
   
   return template.evaluate()
     .setTitle('Gemini Enterprise Demo Generator')
@@ -358,7 +358,7 @@ function initializeProject(projectId, logSheetUrl) {
   const newProps = {
     PROJECT_ID: projectId, 
     LOCATION: currentProps.LOCATION || 'global',
-    MODEL: currentProps.MODEL || 'gemini-3.7-flash',
+    MODEL: currentProps.MODEL || 'gemini-3.8-flash',
     LOG_SHEET_URL: logSheetUrl || currentProps.LOG_SHEET_URL || ''
   };
   
@@ -847,7 +847,7 @@ function planAndGenerateData(userGoal, options) {
   }
   if (options.enableComputerUse) {
     prompt += `\n- **🖥️ COMPUTER USE (BROWSER AGENT) AVAILABLE**:
-    - The agent can operate a real headless web browser (Gemini 3.7 Flash Computer Use) to navigate, click, type, fill forms and extract data from sites that have NO API: competitor public pages, supplier/partner portals, government/regulatory sites, public data sources, and internal web apps. Browser runs happen as autonomous background tasks and the user can watch the live session.
+    - The agent can operate a real headless web browser (Gemini 3.8 Flash Computer Use) to navigate, click, type, fill forms and extract data from sites that have NO API: competitor public pages, supplier/partner portals, government/regulatory sites, public data sources, and internal web apps. Browser runs happen as autonomous background tasks and the user can watch the live session.
     - You MUST leverage this capability when generating the 'businessInstruction' and 'demoGuide' (prompts).
     - In 'businessInstruction', mention that the agent can autonomously browse external websites via a browser-automation background task to gather or act on data that has no API.
     - You MUST design at least TWO prompts (out of the 7 required) in the 'demoGuide' that explicitly ask the agent to browse an external website or portal to accomplish the goal.
@@ -3727,9 +3727,9 @@ show_usage() {
   echo ""
   echo "Options:"
   echo "  --model-analysis-agent, -m <MODEL>  Set the deep analysis agent model"
-  echo "                                      (default: gemini-3.7-flash)"
+  echo "                                      (default: gemini-3.8-flash)"
   echo "  --model-root-agent <MODEL>          Set the root orchestration agent model"
-  echo "                                      (default: gemini-3.7-flash)"
+  echo "                                      (default: gemini-3.8-flash)"
   echo "  --cleanup, -c                       Delete all provisioned demo resources"
   echo "  --yes, -y                           Skip confirmation prompts (non-interactive use)"
   echo "  --help, -h                          Show this help message and exit"
@@ -3745,8 +3745,8 @@ show_usage() {
 
 
 # --- Argument Parsing ---
-AGENT_MODEL="gemini-3.7-flash"
-AGENT_MODEL_LITE="gemini-3.7-flash"
+AGENT_MODEL="gemini-3.8-flash"
+AGENT_MODEL_LITE="gemini-3.8-flash"
 ROOT_MODEL_CLI_OVERRIDE=false
 CLEANUP_MODE=false
 AUTO_CONFIRM=false
@@ -4263,14 +4263,14 @@ while true; do
     # --- Model Selection Flow ---
     echo ""
     echo "🧠 Configure Chat & Orchestration Model (root_agent):"
-    echo "   - root_agent (Chat/UI): Uses 'gemini-3.7-flash' by default."
-    echo "   - deep_analysis_agent (Reasoning): Uses 'gemini-3.7-flash'."
+    echo "   - root_agent (Chat/UI): Uses 'gemini-3.8-flash' by default."
+    echo "   - deep_analysis_agent (Reasoning): Uses 'gemini-3.8-flash'."
     echo ""
     echo "   You can choose 'gemini-3.5-flash-lite' for the root_agent."
     echo "   While it yields simpler and more concise responses, it provides"
     echo "   much faster and snappier interactions for routine chat."
     echo "   For complex tasks requiring deep analysis, the root_agent can"
-    echo "   still delegate the work to the deep_analysis_agent (3.7-flash)."
+    echo "   still delegate the work to the deep_analysis_agent (3.8-flash)."
     echo ""
     read -p "▶ Use lightweight gemini-3.5-flash-lite for root_agent? (Y/n): " CHOOSE_LITE
     CHOOSE_LITE=\$(echo "\$CHOOSE_LITE" | tr -d '\\r\\n\\t ')
@@ -4284,8 +4284,8 @@ while true; do
       AGENT_MODEL_LITE="gemini-3.5-flash-lite"
       echo "   ✅ Configured root_agent to use: gemini-3.5-flash-lite"
     else
-      AGENT_MODEL_LITE="gemini-3.7-flash"
-      echo "   ℹ️  Keeping default root_agent: gemini-3.7-flash"
+      AGENT_MODEL_LITE="gemini-3.8-flash"
+      echo "   ℹ️  Keeping default root_agent: gemini-3.8-flash"
     fi
     echo ""
     # Directly proceed to deployment steps after configuration is complete

--- a/search/gemini-enterprise/ge-demo-generator/app/index.html
+++ b/search/gemini-enterprise/ge-demo-generator/app/index.html
@@ -906,6 +906,20 @@ limitations under the License.
     }
 
     /* Feature Notification Modal */
+    #agentSkillModal {
+      display: none;
+      position: fixed;
+      inset: 0;
+      z-index: 220;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      background: rgba(15, 23, 42, 0.85);
+      backdrop-filter: blur(10px);
+    }
+    #agentSkillModal.show {
+      display: flex;
+    }
     #featureNotifyModal {
       display: none;
       position: fixed;
@@ -1380,6 +1394,13 @@ limitations under the License.
         <div class="px-3 mt-8 mb-4">
           <h3 class="text-[10px] font-bold text-gray-500 uppercase tracking-widest">Resources</h3>
         </div>
+        <button onclick="openAgentSkillModal()" class="nav-item w-full text-left flex items-center justify-between group">
+          <span class="flex items-center">
+            <svg class="w-3.5 h-3.5 mr-1.5 inline-block text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+            Agent Skill
+          </span>
+          <span class="px-1.5 py-0.5 rounded text-[8px] font-bold bg-gradient-to-r from-sky-500/20 to-fuchsia-500/20 text-sky-300 border border-sky-500/30 group-hover:border-sky-400 transition-colors">NEW</span>
+        </button>
         <button onclick="openOnboarding()" class="nav-item w-full text-left flex items-center">
           <svg class="w-3.5 h-3.5 mr-1.5 inline-block text-sky-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -1429,7 +1450,10 @@ limitations under the License.
             <!-- Fade Slides Container -->
             <div class="relative flex-1 h-[28px] text-xs text-gray-200 self-center flex items-center">
               <div class="banner-slide absolute inset-0 transition-all duration-500 ease-in-out opacity-100 flex items-center">
-                <span>⚡ <strong>Default Model Updated:</strong> The default agent model has been upgraded to <strong>Gemini 3.7 Flash</strong>, delivering blazing fast speed and advanced reasoning capabilities out of the box!</span>
+                <span>🚀 <strong>Native Agent Skill Released:</strong> GE Demo Generator is now available for AI coding agents (Antigravity, Claude Code, Codex, Cursor)! Run via <code class="px-1 py-0.5 rounded bg-black/40 text-sky-300 font-mono text-[11px]">/ge-demo-generator</code>. <button onclick="openAgentSkillModal()" class="text-sky-400 underline font-bold cursor-pointer hover:text-sky-300 focus:outline-none">Learn more</button></span>
+              </div>
+              <div class="banner-slide absolute inset-0 transition-all duration-500 ease-in-out opacity-0 pointer-events-none flex items-center">
+                <span>⚡ <strong>Default Model Updated:</strong> The default agent model has been upgraded to <strong>Gemini 3.8 Flash</strong>, delivering state-of-the-art reasoning, coding, and autonomous agent capabilities out of the box!</span>
               </div>
               <div class="banner-slide absolute inset-0 transition-all duration-500 ease-in-out opacity-0 pointer-events-none flex items-center">
                 <span>🧪 <strong>Agent Sandbox (Code Execution):</strong> Next '26 — Secure Python sandbox for advanced analysis, NLP & data science. <a href="https://docs.cloud.google.com/gemini-enterprise-agent-platform/scale/sandbox/code-execution-overview" target="_blank" class="text-sky-400 underline cursor-pointer hover:text-sky-300 focus:outline-none">Learn more</a></span>
@@ -2164,7 +2188,7 @@ limitations under the License.
                       <div class="w-8 h-4 bg-gray-700 rounded-full peer peer-checked:bg-sky-500 transition-all after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:rounded-full after:h-3 after:w-3 after:transition-all peer-checked:after:translate-x-4"></div>
                     </div>
                   </label>
-                  <p class="text-[10px] text-gray-500 leading-snug flex-1">Let the agent operate a real Chromium browser (<a href="https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/computer-use" target="_blank" rel="noopener" class="text-sky-400 hover:underline">Gemini 3.7 Flash Computer Use</a>) to run no-API websites. Watchable via a live-view link + in-chat screenshots.</p>
+                  <p class="text-[10px] text-gray-500 leading-snug flex-1">Let the agent operate a real Chromium browser (<a href="https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/computer-use" target="_blank" rel="noopener" class="text-sky-400 hover:underline">Gemini 3.8 Flash Computer Use</a>) to run no-API websites. Watchable via a live-view link + in-chat screenshots.</p>
                 </div>
               </div>
             </div>
@@ -2183,7 +2207,7 @@ limitations under the License.
             </div>
             <div class="flex items-center gap-2 text-[10px] text-gray-400">
               <span>Model:</span>
-              <span class="px-2 py-0.5 rounded bg-sky-500/10 border border-sky-500/20 font-mono text-sky-400 font-semibold"><?= typeof generatorModel !== 'undefined' ? generatorModel : 'gemini-3.7-flash' ?></span>
+              <span class="px-2 py-0.5 rounded bg-sky-500/10 border border-sky-500/20 font-mono text-sky-400 font-semibold"><?= typeof generatorModel !== 'undefined' ? generatorModel : 'gemini-3.8-flash' ?></span>
             </div>
           </div>
 
@@ -2794,11 +2818,11 @@ limitations under the License.
   <div id="toast">Copied to clipboard!</div>
 
   <script>
-    const GENERATOR_MODEL = '<?= typeof generatorModel !== "undefined" ? generatorModel : "gemini-3.7-flash" ?>';
+    const GENERATOR_MODEL = '<?= typeof generatorModel !== "undefined" ? generatorModel : "gemini-3.8-flash" ?>';
     const CURRENT_USER_EMAIL = '<?= typeof userEmail !== "undefined" ? userEmail : "" ?>';
     
     function formatModelName(modelId) {
-      if (!modelId) return 'Gemini 3.7 Flash';
+      if (!modelId) return 'Gemini 3.8 Flash';
       return modelId
         .split('-')
         .map(word => word.charAt(0).toUpperCase() + word.slice(1))
@@ -3584,7 +3608,7 @@ limitations under the License.
     // Premium Synthesis and Bundling Carousel and Timer Logic
     const SYNTHESIS_TIPS = [
       {
-        heading: "⚡ with Gemini 3.7 Flash",
+        heading: "⚡ with Gemini 3.8 Flash",
         body: "Using Google's latest model to synthesize domain models, SQL queries, and reasoning paths in seconds."
       },
       {
@@ -6381,6 +6405,231 @@ limitations under the License.
     </div>
   </div>
 
+  <!-- Agent Skill Announcement Modal -->
+  <div id="agentSkillModal">
+    <div class="glass max-w-4xl w-full rounded-3xl p-6 sm:p-8 border border-white/10 shadow-2xl fade-in relative flex flex-col max-h-[90vh]">
+      <!-- Close Button -->
+      <button onclick="closeAgentSkillModal()" aria-label="Close" class="absolute top-5 right-5 text-gray-400 hover:text-white focus:outline-none focus:ring-2 focus:ring-sky-500/50 rounded-lg p-1.5 transition-colors z-10">
+        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+      </button>
+
+      <!-- Header -->
+      <div class="text-center mb-5 flex-shrink-0">
+        <div class="w-12 h-12 rounded-2xl bg-gradient-to-br from-sky-500 via-indigo-500 to-fuchsia-500 flex items-center justify-center text-white mx-auto mb-2.5 shadow-lg shadow-sky-500/25" style="animation: featureShimmer 4s ease-in-out infinite; background-size: 200% auto;">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+        </div>
+        <div class="flex items-center justify-center gap-2 mb-1">
+          <span class="feature-badge">⚡ Native Agent Skill Release</span>
+        </div>
+        <h2 class="text-xl sm:text-2xl font-bold text-white mb-1">GE Demo Generator for AI Agents</h2>
+        <p class="text-gray-300 text-xs sm:text-sm max-w-xl mx-auto leading-relaxed">
+          Generate, customize, and deploy complete domain-tailored Gemini Enterprise demo environments directly inside your AI coding assistant.
+        </p>
+      </div>
+
+      <!-- Scrollable Content Wrapper -->
+      <div class="relative flex-1 min-h-0 flex flex-col mb-4">
+        <div class="flex-1 overflow-y-auto pr-1 modal-scrollable-content">
+          <div class="modal-scrollable-inner space-y-5">
+
+            <!-- Section 1: 2-Step Workflow (Step 1: Choose Install Method, Step 2: Common Run Command) -->
+            <div class="space-y-3">
+              <!-- Section Heading -->
+              <div class="flex items-center gap-2 px-1">
+                <span class="text-xs font-bold text-gray-300 uppercase tracking-wider flex items-center gap-1.5">
+                  <span>🚀</span> Quick Setup &amp; Execution
+                </span>
+                <div class="flex-1 h-px bg-white/10"></div>
+              </div>
+
+              <!-- Step 1: Install Options (Platform-specific) -->
+              <div class="space-y-2">
+                <div class="flex items-center justify-between px-1">
+                  <div class="flex items-center gap-2">
+                    <span class="px-2 py-0.5 text-[10px] font-extrabold rounded-md bg-sky-500/20 text-sky-300 border border-sky-500/30 uppercase tracking-wider">STEP 1</span>
+                    <h3 class="text-xs sm:text-sm font-bold text-white">Install the skill into your assistant <span class="text-gray-400 text-xs font-normal">(One-time setup)</span></h3>
+                  </div>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-3.5">
+                  <!-- Option 1: AI Coding Assistants (Prompt-based) -->
+                  <div class="bg-gradient-to-b from-purple-500/10 to-slate-900/60 border border-purple-500/30 rounded-2xl p-4 sm:p-5 flex flex-col justify-between relative overflow-hidden group hover:border-purple-500/50 transition-all space-y-3.5">
+                    <div class="space-y-3">
+                      <!-- Track Header -->
+                      <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2">
+                          <span class="text-xl">🌐</span>
+                          <div>
+                            <h4 class="text-sm font-bold text-white">Antigravity / Claude / Codex / Cursor</h4>
+                            <p class="text-[10px] text-purple-300/80">Universal AI Coding Harnesses</p>
+                          </div>
+                        </div>
+                        <span class="px-2 py-0.5 text-[9px] font-bold rounded-full bg-purple-500/20 text-purple-300 border border-purple-500/30 uppercase">Universal</span>
+                      </div>
+
+                      <p class="text-[11px] text-gray-300 leading-relaxed">
+                        Copy this instruction and send it to your AI agent in chat:
+                      </p>
+
+                      <!-- Action Prompt Box -->
+                      <div class="flex items-center justify-between bg-black/60 rounded-xl p-2 border border-purple-500/30">
+                        <span class="text-[11px] text-purple-200 truncate font-mono pl-1">Install skill from GCP/generative-ai...</span>
+                        <button onclick="copyInstallPrompt()" id="copyInstallPromptBtn" class="ml-2 px-3 py-1.5 bg-purple-500/20 hover:bg-purple-500/30 text-purple-300 text-[10px] font-bold rounded-lg border border-purple-500/30 transition-all flex items-center gap-1 flex-shrink-0 active:scale-95">
+                          <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                          <span>Copy Prompt</span>
+                        </button>
+                      </div>
+                    </div>
+
+                    <!-- Footer hint -->
+                    <div class="pt-3 border-t border-white/5 flex items-center justify-between text-[10px] text-gray-400">
+                      <span>Public repo: <a href="https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator" target="_blank" class="text-purple-300 underline font-mono">GCP/generative-ai</a></span>
+                      <span class="text-[9px] text-gray-500">Open Source</span>
+                    </div>
+                  </div>
+
+                  <!-- Option 2: GitHub Repository & Source -->
+                  <div class="bg-gradient-to-b from-sky-500/10 to-slate-900/60 border border-sky-500/30 rounded-2xl p-4 sm:p-5 flex flex-col justify-between relative overflow-hidden group hover:border-sky-500/50 transition-all space-y-3.5">
+                    <div class="space-y-3">
+                      <!-- Track Header -->
+                      <div class="flex items-center justify-between">
+                        <div class="flex items-center gap-2">
+                          <span class="text-xl">📦</span>
+                          <div>
+                            <h4 class="text-sm font-bold text-white">Skill Source &amp; Instructions</h4>
+                            <p class="text-[10px] text-sky-300/80">GoogleCloudPlatform/generative-ai</p>
+                          </div>
+                        </div>
+                        <span class="px-2 py-0.5 text-[9px] font-bold rounded-full bg-sky-500/20 text-sky-300 border border-sky-500/30 uppercase">GitHub</span>
+                      </div>
+
+                      <p class="text-[11px] text-gray-300 leading-relaxed">
+                        Explore the open-source SKILL.md, workflow templates, scripts, and documentation:
+                      </p>
+
+                      <!-- Action Button -->
+                      <a href="https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator" target="_blank" class="w-full py-2.5 px-3 bg-sky-500 hover:bg-sky-400 text-white text-xs font-bold rounded-xl shadow-md shadow-sky-500/20 transition-all flex items-center justify-center gap-1.5 active:scale-98">
+                        <span>View on GitHub</span>
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
+                      </a>
+                    </div>
+
+                    <!-- Footer hint -->
+                    <div class="pt-3 border-t border-white/5 flex items-center justify-between text-[10px] text-gray-400">
+                      <span>License: <span class="text-sky-300 font-mono">Apache 2.0</span></span>
+                      <span class="text-[9px] text-gray-500">Ready to Clone / Fork</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- Step 2: Unified Universal Run Command (Full-Width Card) -->
+              <div class="bg-gradient-to-r from-emerald-950/40 via-slate-900/60 to-teal-950/40 border border-emerald-500/30 rounded-2xl p-4 sm:p-5 space-y-3">
+                <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-1.5">
+                  <div class="flex items-center gap-2">
+                    <span class="px-2 py-0.5 text-[10px] font-extrabold rounded-md bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 uppercase tracking-wider">STEP 2</span>
+                    <h4 class="text-xs sm:text-sm font-bold text-white">Run in chat <span class="text-emerald-400 font-normal text-xs">(Common command across all assistants)</span></h4>
+                  </div>
+                  <span class="text-[10px] text-emerald-400 font-semibold flex items-center gap-1">
+                    <span class="w-1.5 h-1.5 rounded-full bg-emerald-400 animate-pulse"></span>
+                    Interactive Chat Execution
+                  </span>
+                </div>
+
+                <div class="flex items-center justify-between bg-black/80 rounded-xl p-2.5 sm:p-3 border border-emerald-500/30">
+                  <code class="text-xs sm:text-sm text-emerald-300 font-mono font-bold truncate pl-1">/ge-demo-generator &lt;company_domain_or_custom_scenario&gt;</code>
+                  <button onclick="copySkillCommand()" id="copySkillCmdBtn" class="ml-3 px-3.5 py-1.5 bg-emerald-500 hover:bg-emerald-400 text-slate-950 text-xs font-bold rounded-lg shadow-md shadow-emerald-500/20 transition-all flex items-center gap-1.5 flex-shrink-0 active:scale-95">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                    <span>Copy Command</span>
+                  </button>
+                </div>
+
+                <p class="text-[11px] text-gray-300 leading-relaxed">
+                  Pass any domain (e.g. <span class="text-white font-mono font-semibold">example.com</span>, <span class="text-white font-mono font-semibold">retail-sample.co.jp</span>) or custom scenario. Your agent will converse to refine requirements, synthesize BigQuery data &amp; Google Drive files, and deploy the entire solution to Cloud Run in ~10 minutes.
+                </p>
+              </div>
+
+            </div>
+
+            <!-- Section 2: Key Capabilities (4 Scannable Visual Cards) -->
+            <div>
+              <div class="flex items-center gap-2 mb-3 px-1">
+                <span class="text-xs font-bold text-gray-300 uppercase tracking-wider flex items-center gap-1.5">
+                  <span>💡</span> Why Use the Agent Skill?
+                </span>
+                <div class="flex-1 h-px bg-white/10"></div>
+              </div>
+
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <!-- Highlight 1: Bring Your Own Data -->
+                <div class="bg-black/30 border border-white/5 rounded-2xl p-4 space-y-1.5 hover:border-white/10 transition-colors">
+                  <div class="flex items-center gap-2">
+                    <span class="w-6 h-6 rounded-lg bg-sky-500/15 text-sky-400 flex items-center justify-center text-xs font-bold">📂</span>
+                    <h4 class="text-xs font-bold text-white">"Bring Your Own Data" &amp; Drive</h4>
+                  </div>
+                  <p class="text-[11px] text-gray-300 leading-relaxed">
+                    Provide real custom datasets (500K+ BigQuery rows) or direct Google Drive links. The skill indexes internal PDFs into DataStores with exact citations.
+                  </p>
+                </div>
+
+                <!-- Highlight 2: Interactive Customization -->
+                <div class="bg-black/30 border border-white/5 rounded-2xl p-4 space-y-1.5 hover:border-white/10 transition-colors">
+                  <div class="flex items-center gap-2">
+                    <span class="w-6 h-6 rounded-lg bg-violet-500/15 text-violet-400 flex items-center justify-center text-xs font-bold">💬</span>
+                    <h4 class="text-xs font-bold text-white">Conversational Customization</h4>
+                  </div>
+                  <p class="text-[11px] text-gray-300 leading-relaxed">
+                    Iterate directly in chat to refine narratives, modify Mermaid ER diagrams, or combine multiple complex workflows into a unified multi-agent setup.
+                  </p>
+                </div>
+
+                <!-- Highlight 3: Full Stack in ~10 Mins -->
+                <div class="bg-black/30 border border-white/5 rounded-2xl p-4 space-y-1.5 hover:border-white/10 transition-colors">
+                  <div class="flex items-center gap-2">
+                    <span class="w-6 h-6 rounded-lg bg-emerald-500/15 text-emerald-400 flex items-center justify-center text-xs font-bold">⚡</span>
+                    <h4 class="text-xs font-bold text-white">~10 min Deploy &amp; Self-Healing</h4>
+                  </div>
+                  <p class="text-[11px] text-gray-300 leading-relaxed">
+                    Automates Cloud Run, BigQuery MCP, Workspace OAuth, and Sandbox code execution with an 8-layer verification &amp; self-healing engine.
+                  </p>
+                </div>
+
+                <!-- Highlight 4: Production A2UI & Playbook -->
+                <div class="bg-black/30 border border-white/5 rounded-2xl p-4 space-y-1.5 hover:border-white/10 transition-colors">
+                  <div class="flex items-center gap-2">
+                    <span class="w-6 h-6 rounded-lg bg-fuchsia-500/15 text-fuchsia-400 flex items-center justify-center text-xs font-bold">🎯</span>
+                    <h4 class="text-xs font-bold text-white">Production A2UI &amp; 7-Step Playbook</h4>
+                  </div>
+                  <p class="text-[11px] text-gray-300 leading-relaxed">
+                    Renders rich A2UI MaterialCards, dynamic VegaCharts, live Operations Viewer, and outputs a localized 7-step customer demo script.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+          </div>
+          <!-- Spacer -->
+          <div class="h-4 flex-shrink-0"></div>
+        </div>
+      </div>
+
+      <!-- Footer (Fixed) -->
+      <div class="flex-shrink-0 flex flex-col sm:flex-row sm:items-center justify-between gap-3 pt-3 border-t border-white/5">
+        <span class="text-[10px] text-gray-500 text-center sm:text-left">Available for Google Cloud teams, partners &amp; customers</span>
+        <div class="flex items-center justify-center sm:justify-end gap-2">
+          <button onclick="closeAgentSkillModal()" class="px-4 py-2 rounded-xl bg-white/5 hover:bg-white/10 text-xs font-semibold text-gray-300 hover:text-white transition-colors">
+            Close
+          </button>
+          <a href="https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator" target="_blank" class="px-4 py-2 feature-shimmer-btn text-white text-xs font-bold rounded-xl shadow-lg shadow-sky-500/20 transition-all flex items-center gap-1.5">
+            <span>View Skill on GitHub</span>
+            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
   <!-- Feature Notification Modal -->
   <div id="featureNotifyModal">
     <div class="glass max-w-2xl w-full rounded-3xl p-7 border border-white/10 shadow-2xl fade-in relative flex flex-col max-h-[90vh]">
@@ -6397,16 +6646,44 @@ limitations under the License.
           <span class="feature-badge">🚀 Major Update</span>
         </div>
         <h2 class="text-xl font-bold text-white mb-1">What's New</h2>
-        <p class="text-gray-400 text-xs">3 new capabilities to elevate your demos</p>
+        <p class="text-gray-400 text-xs">4 new capabilities to elevate your demos</p>
       </div>
 
       <!-- Scrollable Content Wrapper -->
       <div class="relative flex-1 min-h-0 flex flex-col mb-6">
         <!-- Scrollable Content -->
         <div class="flex-1 overflow-y-auto pr-1 modal-scrollable-content pt-3 premium-mask-fade">
-          <div class="modal-scrollable-inner">
+          <div class="modal-scrollable-inner space-y-3.5">
 
-      <!-- Feature 1: Managed Agents API (Antigravity) - Autonomous Long-Horizon Agent -->
+      <!-- Feature 1: Native Agent Skill in AI Coding Harnesses -->
+      <div class="feature-card">
+        <div class="flex gap-3">
+          <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-gradient-to-br from-emerald-500/15 to-teal-500/15 flex items-center justify-center text-emerald-400 border border-emerald-500/20">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path></svg>
+          </div>
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center justify-between gap-2 mb-0.5">
+              <h4 class="text-sm font-bold text-white">Native Agent Skill (<span class="text-emerald-400 font-mono text-xs">/ge-demo-generator</span>)</h4>
+              <span class="px-2 py-0.5 text-[9px] font-bold rounded-full bg-emerald-500/20 text-emerald-300 border border-emerald-500/30 flex-shrink-0">NEW</span>
+            </div>
+            <p class="text-[11px] text-gray-200 leading-relaxed mb-2.5">
+              The entire GE Demo Generator experience is now natively available as an agent skill for <span class="font-bold text-emerald-400">Antigravity</span>, <span class="font-bold text-emerald-400">Claude Code</span>, <span class="font-bold text-emerald-400">Codex</span>, and <span class="font-bold text-emerald-400">Cursor</span>. Conversational requirements discovery, <span class="font-bold text-teal-300">Bring Your Own Data</span> (PDF, Excel, scanned files uploaded to Google Drive), BigQuery &amp; Firestore synthesis, self-healing Cloud Run deployment in ~10 mins, and localized 7-step customer demo scripts.
+            </p>
+            <div class="flex flex-wrap items-center gap-2">
+              <button onclick="closeFeatureNotify(false); openAgentSkillModal();" class="px-2.5 py-1 rounded-lg bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-300 hover:text-emerald-200 border border-emerald-500/30 text-[11px] font-semibold transition-all flex items-center gap-1">
+                <span>📖 Setup Guide &amp; Command</span>
+                <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path></svg>
+              </button>
+              <a href="https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator" target="_blank" class="px-2.5 py-1 rounded-lg bg-white/5 hover:bg-white/10 text-gray-300 hover:text-white border border-white/10 text-[11px] font-medium transition-all flex items-center gap-1">
+                <span>📂 Skill Source on GitHub</span>
+                <svg class="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path></svg>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Feature 2: Managed Agents API (Antigravity) - Autonomous Long-Horizon Agent -->
       <div class="feature-card mb-4">
         <div class="flex gap-3">
           <div class="flex-shrink-0 w-10 h-10 rounded-xl bg-gradient-to-br from-fuchsia-500/15 to-violet-500/15 flex items-center justify-center text-fuchsia-400 border border-fuchsia-500/20">
@@ -6468,7 +6745,7 @@ limitations under the License.
   </div>
 
   <script>
-    const FEATURE_NOTIFY_KEY = 'feature_v7_whats_new_dismissed';
+    const FEATURE_NOTIFY_KEY = 'feature_skill_release_v2_dismissed';
 
     function maybeShowFeatureNotify() {
       if (localStorage.getItem(FEATURE_NOTIFY_KEY)) return;
@@ -6492,9 +6769,65 @@ limitations under the License.
       if (modal) modal.classList.add('show');
     }
 
+    function openAgentSkillModal() {
+      const modal = document.getElementById('agentSkillModal');
+      if (modal) modal.classList.add('show');
+    }
+
+    function closeAgentSkillModal() {
+      const modal = document.getElementById('agentSkillModal');
+      if (modal) modal.classList.remove('show');
+    }
+
+    function copySkillCommand() {
+      const cmd = '/ge-demo-generator <company_domain_or_custom_scenario>';
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(cmd).then(() => {
+          if (typeof showToast === 'function') {
+            showToast('Copied: ' + cmd);
+          }
+          ['copySkillCmdBtn'].forEach(id => {
+            const btn = document.getElementById(id);
+            if (btn) {
+              const original = btn.innerHTML;
+              btn.innerHTML = '<svg class="w-3 h-3 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg><span class="text-emerald-400 font-bold">Copied!</span>';
+              setTimeout(() => { btn.innerHTML = original; }, 2000);
+            }
+          });
+        }).catch(() => {
+          if (typeof showToast === 'function') showToast('Failed to copy');
+        });
+      } else if (typeof showToast === 'function') {
+        showToast(cmd);
+      }
+    }
+
+    function copyInstallPrompt() {
+      const prompt = 'Install the skill from https://github.com/GoogleCloudPlatform/generative-ai/tree/main/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator';
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(prompt).then(() => {
+          if (typeof showToast === 'function') {
+            showToast('Install prompt copied!');
+          }
+          const btn = document.getElementById('copyInstallPromptBtn');
+          if (btn) {
+            const original = btn.innerHTML;
+            btn.innerHTML = '<svg class="w-3 h-3 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg><span class="text-emerald-400 font-bold">Copied!</span>';
+            setTimeout(() => { btn.innerHTML = original; }, 2000);
+          }
+        }).catch(() => {
+          if (typeof showToast === 'function') showToast('Failed to copy');
+        });
+      } else if (typeof showToast === 'function') {
+        showToast(prompt);
+      }
+    }
+
     // Close on ESC
     window.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
+        const skillModal = document.getElementById('agentSkillModal');
+        if (skillModal && skillModal.classList.contains('show')) closeAgentSkillModal();
         const modal = document.getElementById('featureNotifyModal');
         if (modal && modal.classList.contains('show')) closeFeatureNotify(false);
       }
@@ -6505,6 +6838,12 @@ limitations under the License.
       if (e.target === document.getElementById('featureNotifyModal')) closeFeatureNotify(false);
     });
 
+    const agentSkillEl = document.getElementById('agentSkillModal');
+    if (agentSkillEl) {
+      agentSkillEl.addEventListener('click', (e) => {
+        if (e.target === agentSkillEl) closeAgentSkillModal();
+      });
+    }
   </script>
 
 

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/Code.gs
@@ -35,7 +35,7 @@ const SCRIPT_PROPS = PropertiesService.getScriptProperties();
 const CONFIG = {
   PROJECT_ID: SCRIPT_PROPS.getProperty('PROJECT_ID'),
   LOCATION: SCRIPT_PROPS.getProperty('LOCATION') || 'global',
-  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.7-flash',
+  MODEL: SCRIPT_PROPS.getProperty('MODEL') || 'gemini-3.8-flash',
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
   APP_VERSION: 'v1.9-public',
@@ -68,7 +68,7 @@ function doGet(e) {
   template.appVersion = CONFIG.APP_VERSION;
   template.projectId = CONFIG.PROJECT_ID;
   template.userEmail = Session.getActiveUser().getEmail();
-  template.generatorModel = CONFIG.MODEL || 'gemini-3.7-flash';
+  template.generatorModel = CONFIG.MODEL || 'gemini-3.8-flash';
 
   let webAppUrl = '';
   try {
@@ -115,7 +115,7 @@ function initializeProject(projectId) {
   const newProps = {
     PROJECT_ID: projectId,
     LOCATION: currentProps.LOCATION || 'global',
-    MODEL: currentProps.MODEL || 'gemini-3.7-flash'
+    MODEL: currentProps.MODEL || 'gemini-3.8-flash'
   };
 
   scriptProps.setProperties(newProps);

--- a/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
+++ b/search/gemini-enterprise/ge-demo-generator/ge-demo-generator-lite/README.md
@@ -35,7 +35,7 @@ deployment; the root project's `clasp push` does not include it.
    not the repo root one).
 3. Set Script Properties via the editor: run `initializeProject(projectId)` — or set
    `PROJECT_ID` manually. Optional: `LOCATION` (default `global`), `MODEL`
-   (default `gemini-3.7-flash`).
+   (default `gemini-3.8-flash`).
 4. Deploy as a Web App with **Execute as: User accessing the web app** and **Access: anyone
    in your domain** (matches `appsscript.json`).
 5. Each user grants Drive/Docs/Sheets/Slides + Vertex AI Agent Platform consent on first open, and needs

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
@@ -3,12 +3,12 @@ name: ge-demo-generator
 description: Synthesizes and deploys complete, domain-specific Gemini Enterprise demo environments directly to Google Cloud. Use when the user asks to create an AI agent demo for any customer domain (e.g. 'example.com', 'example.co.jp', 'example.de', 'example.fr' - any company, any industry, any region) or business goal, generate realistic BigQuery/Firestore sample datasets, create external demo files (PDF, Excel, scanned images), stage them in Cloud Storage and upload them to the deploying account's Google Drive, scaffold ADK multi-agent architectures with MCP tools and A2UI cards, deploy to Cloud Run, publish to Gemini Enterprise, and generate 7 structured demo prompts in any language. Confirms the requirements interactively and presents a demo architecture & data model plan (Mermaid ER diagram, external file lineage, target project) for approval before anything is deployed. Also triggered by /ge-demo-generator.
 metadata:
   author: Google Cloud Customer Engineering
-  version: 2.14.4
+  version: 2.14.5
 ---
 
-# GE Demo Generator Skill (v2.14.4)
+# GE Demo Generator Skill (v2.14.5)
 
-Synthesizes production-grade, domain-tailored AI agent demo environments using **Gemini 3.7 Flash** for reasoning and **Gemini 3.1 Flash Image** for visual generation, adhering to a strict **6-step infrastructure dependency graph**, rich **A2UI interactive component streaming**, **Google Workspace OAuth authorization**, **external sample files staged in Cloud Storage and, when the credentials carry the Drive scope, in the deploying account's Google Drive**, **7 structured demo prompts**, and **global multilingual localization (i18n/l10n)**.
+Synthesizes production-grade, domain-tailored AI agent demo environments using **Gemini 3.8 Flash** for reasoning and **Gemini 3.1 Flash Image** for visual generation, adhering to a strict **6-step infrastructure dependency graph**, rich **A2UI interactive component streaming**, **Google Workspace OAuth authorization**, **external sample files staged in Cloud Storage and, when the credentials carry the Drive scope, in the deploying account's Google Drive**, **7 structured demo prompts**, and **global multilingual localization (i18n/l10n)**.
 
 ---
 
@@ -243,7 +243,7 @@ afterwards).
 
 - **Agent Name (`DEMO_DISPLAY_NAME`)**: Concise 2–4 word domain role (e.g. `TWG Tea Retail Operations Director`, `Mercari Trust & Safety Specialist`). Registered in Gemini Enterprise as `${DEMO_DISPLAY_NAME} (${SERVICE_NAME})`, matching the Web UI (GAS) version.
 - **Description (`DEMO_DESCRIPTION`)**: Concrete, professional 1–2 sentence mission summary specifying the business domain, core datasets, and operational goals (e.g. `Orchestrates boutique inventory balancing, central commissary replenishment, and plantation harvest orders across Singapore.`). Matches `oneSentenceSummary` in the Web UI (GAS).
-- **Reasoning / orchestration**: **`gemini-3.7-flash`** for all agent instances (Root Coordinator, Deep Analysis Sub-Agent, Background Worker).
+- **Reasoning / orchestration**: **`gemini-3.8-flash`** for all agent instances (Root Coordinator, Deep Analysis Sub-Agent, Background Worker).
 - **Image generation**: **`gemini-3.1-flash-image`** (with localized prompt reinforcement and GCS artifact persistence).
 - **Code execution**: Agent Engine Sandbox (`us-central1` — fixed, not `$REGION`).
 - **UI**: Gemini Enterprise A2UI v0.9 composite catalog (name the components this demo will actually lean on — `MaterialTable`, `VegaChart`, `MaterialCard`).
@@ -472,7 +472,7 @@ ge-demo-<domain>-<suffix>/
 │   ├── __init__.py            # empty; makes adk_agent importable as a package
 │   └── app/
 │       ├── __init__.py
-│       ├── agent.py           # Triple-Agent (gemini-3.7-flash) + Code Executor + A2UI System Prompts
+│       ├── agent.py           # Triple-Agent (gemini-3.8-flash) + Code Executor + A2UI System Prompts
 │       ├── tools.py           # MCP Toolsets + gemini-3.1-flash-image generate_image tool
 │       ├── part_converters.py # A2A <-> Gen AI DataPart Converters
 │       ├── fast_api_app.py    # A2A Server + A2UI StreamParser + Token Middleware + /execute_task

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/multi_agent_architecture.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/multi_agent_architecture.md
@@ -1,22 +1,22 @@
 # Multi-Agent Architecture & Routing Reference
 
-The synthesized demo agent employs a **Triple-Agent Architecture** built on the Google Agent Development Kit (ADK) and **Gemini 3.7 Flash**:
+The synthesized demo agent employs a **Triple-Agent Architecture** built on the Google Agent Development Kit (ADK) and **Gemini 3.8 Flash**:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  root_agent (Coordinator + A2UI Builder)                     │
-│  Model: gemini-3.7-flash (AGENT_MODEL_LITE)                  │
+│  Model: gemini-3.8-flash (AGENT_MODEL_LITE)                  │
 │  Role: Main conversation, greetings, simple queries,         │
 │        building A2UI cards, routing to sub-agents.           │
 │                                                              │
 │  Sub-Agents:                                                 │
 │  ├── deep_analysis_agent (Inline Analytical Sub-Agent)       │
-│  │   Model: gemini-3.7-flash (AGENT_MODEL)                   │
+│  │   Model: gemini-3.8-flash (AGENT_MODEL)                   │
 │  │   Role: Complex inline multi-step analytical reasoning.   │
 │  │   Transfer: Returns control to root_agent on completion.  │
 │  │                                                           │
 │  └── background_agent (Standalone Async Worker)              │
-│      Model: gemini-3.7-flash (AGENT_MODEL)                   │
+│      Model: gemini-3.8-flash (AGENT_MODEL)                   │
 │      Role: Deep batch operations & long-running pipelines.   │
 │      Trigger: Invoked via /execute_task endpoint.            │
 └──────────────────────────────────────────────────────────────┘
@@ -69,7 +69,7 @@ The worker is prohibited from shallow hand-waving. It MUST:
 ## 3. ADK Configuration Best Practices
 
 1. **Model Selection**:
-   - Standard: `gemini-3.7-flash` (Highest quality, native reasoning, sub-second latency across all agent tiers).
+   - Standard: `gemini-3.8-flash` (Highest quality, native reasoning, sub-second latency across all agent tiers).
 
 2. **Placeholder Escaping Rule**:
    - In agent instructions (`base_instruction`), NEVER use `{variable_name}` or `{{variable_name}}`. ADK's `inject_session_state` regex matches all `{...}` and will crash with `KeyError`.

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/agent.py
@@ -1202,13 +1202,13 @@ _RETRY_OPTIONS = types.HttpRetryOptions(
 
 # Pro model — used by deep_analysis_agent for complex multi-step reasoning
 gemini_pro_model = Gemini(
-    model=os.environ.get("AGENT_MODEL", "gemini-3.7-flash"),
+    model=os.environ.get("AGENT_MODEL", "gemini-3.8-flash"),
     retry_options=_RETRY_OPTIONS
 )
 
 # Flash-Lite model — used by root_agent (coordinator) for most interactions
 gemini_lite_model = Gemini(
-    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash"),
+    model=os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash"),
     retry_options=_RETRY_OPTIONS
 )
 

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/fast_api_app.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/fast_api_app.py
@@ -1606,7 +1606,7 @@ async def _classify_for_preflight(text, prev_user_text=""):
             vertexai=True, location=_loc, project=project_id,
             http_options={"api_version": "v1"},
         )
-        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash")
+        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash")
         _prompt = PREFLIGHT_CLASSIFIER_PROMPT + chr(10) + chr(10)
         if prev_user_text:
             _prompt = (_prompt + "PREVIOUS USER MESSAGE (language reference only - NOT the request):"
@@ -1661,7 +1661,7 @@ async def _localize_ui_strings(_defaults, _language_sample):
             vertexai=True, location=_loc, project=project_id,
             http_options={"api_version": "v1"},
         )
-        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash")
+        _model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash")
         _prompt = (
             "Rewrite every VALUE of the JSON object below in the SAME LANGUAGE as the SAMPLE MESSAGE, "
             "keeping the meaning, the register and any leading emoji. Keep every {placeholder} "
@@ -2104,13 +2104,13 @@ def _heal_session_events(session, force_aggressive=False):
     #   - force_aggressive=True (emergency, after a token-overflow ClientError)
     #   - the root model is a lightweight model (flash-lite) — always compact
     #   - the measured context size exceeds the char budget. Heavier models
-    #     (3.7-flash / pro) keep FULL context UNTIL near the limit, so normal
+    #     (3.8-flash / pro) keep FULL context UNTIL near the limit, so normal
     #     large reports are never trimmed — only runaway contexts are.
     # Char-based by design: generated-image bytes are NOT stored in history
     # (generate_image stashes them in session.state), so the real bloat is
     # text — SQL result sets, MCP payloads, multi-turn accumulation.
     # =========================================================================
-    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash").lower()
+    _root_model = os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash").lower()
     _is_lite = "lite" in _root_model
 
     def _event_char_size(_ev):
@@ -3442,8 +3442,8 @@ class AdkAgentToA2AExecutor(A2aAgentExecutor):
         # Maps agent name → model string for the thinking accordion header.
         # =============================================================================
         _agent_model_map = {
-            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.7-flash"),
-            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.7-flash"),
+            'root_agent': os.environ.get("AGENT_MODEL_LITE", "gemini-3.8-flash"),
+            'deep_analysis_agent': os.environ.get("AGENT_MODEL", "gemini-3.8-flash"),
         }
         _model_announced = set()  # Track which agents have been announced
 

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
@@ -24,7 +24,7 @@
 
 
 # =============================================================================
-# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.14.4)
+# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.14.5)
 # Automatically audits 8 infrastructure layers and heals discrepancies in real time:
 #   1. BigQuery Dataset & Tables (Row counts, _id column for DataStores, schema metadata)
 #   2. Firestore Collection & Seeding (Task queue documents >= 3)

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
@@ -1011,8 +1011,8 @@ CR_ENV_VARS="${CR_ENV_VARS},ENABLE_MANAGED_AGENT=${ENABLE_MANAGED_AGENT}"
 # Picks agent.py's data-exploration routing block, and gates whether
 # search_datastore is registered at all.
 CR_ENV_VARS="${CR_ENV_VARS},DATA_EXPLORATION_MODE=${DATA_EXPLORATION_MODE}"
-CR_ENV_VARS="${CR_ENV_VARS},AGENT_MODEL=${AGENT_MODEL:-gemini-3.7-flash}"
-CR_ENV_VARS="${CR_ENV_VARS},AGENT_MODEL_LITE=${AGENT_MODEL_LITE:-gemini-3.7-flash}"
+CR_ENV_VARS="${CR_ENV_VARS},AGENT_MODEL=${AGENT_MODEL:-gemini-3.8-flash}"
+CR_ENV_VARS="${CR_ENV_VARS},AGENT_MODEL_LITE=${AGENT_MODEL_LITE:-gemini-3.8-flash}"
 if [ "$ENABLE_MANAGED_AGENT" = "1" ]; then
   # MANAGED_AGENT_ID is the whole switch on the tool side: the delegation tools
   # check it before the flag and report "unavailable" when it is blank, so an
@@ -1773,7 +1773,7 @@ if [ ! -z "$AGENT_ID" ]; then
   echo "🆔 Agent ID:          ${AGENT_ID}"
 fi
 echo "📝 Description:       ${ACTUAL_DESCRIPTION:-${DEMO_DESCRIPTION:-Operational AI Agent}}"
-echo "🧠 Reasoning Model:   gemini-3.7-flash"
+echo "🧠 Reasoning Model:   gemini-3.8-flash"
 echo "🎨 Image Gen Model:   gemini-3.1-flash-image"
 echo ""
 echo "🗄️ Data Resources"

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/tools.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/tools.py
@@ -1258,7 +1258,7 @@ async def publish_dashboard(html: str, title: str, tool_context: ToolContext) ->
 if os.environ.get("ENABLE_COMPUTER_USE") == "1":
 
     # =====================================================================
-    # Computer Use (browser agent) -- Gemini 3.7 Flash built-in computer_use
+    # Computer Use (browser agent) -- Gemini 3.8 Flash built-in computer_use
     # tool driven over a self-hosted headless Chromium (Playwright). Adapted
     # from the official reference impl (github.com/google-gemini/
     # computer-use-preview, Apache-2.0): same generate_content loop, action
@@ -1591,11 +1591,11 @@ if os.environ.get("ENABLE_COMPUTER_USE") == "1":
             return {"status": "error", "detail": "Playwright is not installed in this environment: " + str(_imp)}
 
         client = genai_client.Client(vertexai=True, location=location, project=project)
-        # gemini-3.7-flash supports the Computer Use tool (3.6-flash did not,
+        # gemini-3.8-flash supports the Computer Use tool (3.6-flash did not,
         # which is why this used to be pinned to 3.5-flash). Kept on its own
         # COMPUTER_USE_MODEL override rather than AGENT_MODEL, since a custom
         # --model-analysis-agent may point at a model without Computer Use.
-        model = os.environ.get("COMPUTER_USE_MODEL", "gemini-3.7-flash")
+        model = os.environ.get("COMPUTER_USE_MODEL", "gemini-3.8-flash")
         cfg = types.GenerateContentConfig(
             temperature=1.0, top_p=0.95, top_k=40, max_output_tokens=8192,
             tools=[types.Tool(computer_use=types.ComputerUse(environment=types.Environment.ENVIRONMENT_BROWSER))],


### PR DESCRIPTION
### Summary
- Updates default reasoning models across Web UI, setup scripts, agent templates, and Agent Skill definition to **Gemini 3.8 Flash**
- Adds Agent Skill announcement banner and modal to the Web UI
- Fixes spelling candidates and updates spelling allow list
- Bumps application version to **v12.4-public** and skill version to **v2.14.5**

### Verification
- Full validation suite and public CI gates passed locally (ShellCheck, shfmt, hadolint, forbidden-patterns, spelling, version-parity, code-gs-parity)
- Live Vertex AI API inference tested successfully with `gemini-3.8-flash`