### PR TITLE
fix(ge-demo-generator): warn that the first message after a deploy can fail, and offer a warm instance (v12.9-public)

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v12.4-public',
+  APP_VERSION: 'v12.9-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -542,7 +542,13 @@ function generateDemo(userGoal, options = {}) {
     // experience, provisioning is parallelized and fail-soft, and no
     // allowlist is required. The UI toggle allows opting out per demo.
     enableManagedAgent: true,
-    enableWorkspaceAuth: false
+    enableWorkspaceAuth: false,
+    // Cloud Run scale-to-zero is the default and the reason an idle demo costs
+    // nothing; see the deploy block for why max-instances is pinned to 1. The
+    // toggle exists because the trade-off lands on exactly one message - the
+    // first one after an idle gap - and that is often the one an audience
+    // watches. MIN_INSTANCES in the environment still overrides either way.
+    keepWarm: false
   };
   options = { ...defaultOptions, ...options };
   
@@ -632,6 +638,7 @@ function generateDemo(userGoal, options = {}) {
     result.enableComputerUse = options.enableComputerUse || false;
     result.enableManagedAgent = options.enableManagedAgent || false;
     result.enableWorkspaceAuth = options.enableWorkspaceAuth || false;
+    result.keepWarm = options.keepWarm || false;
 
     result.setupScript = generateSetupScript({
       datasetId: datasetId,
@@ -652,6 +659,7 @@ function generateDemo(userGoal, options = {}) {
       enableComputerUse: options.enableComputerUse,
       enableManagedAgent: options.enableManagedAgent,
       enableWorkspaceAuth: options.enableWorkspaceAuth,
+      keepWarm: options.keepWarm,
       metadata: planResult.metadata
     });
     result.steps.push({ step: 4, status: 'completed', message: 'Generation complete' });
@@ -2442,7 +2450,7 @@ function buildDataAssetCatalog_(tables) {
 }
 
 function generateSetupScript(params) {
-  const { datasetId, systemInstruction, businessInstruction, referenceDate, publicDatasetId, suffix, tables, firestore, userGoal, dirName, agentShortName, oneSentenceSummary, operatingModel, enableWorkspaceMcp, enableComputerUse, enableManagedAgent, enableWorkspaceAuth, metadata } = params;
+  const { datasetId, systemInstruction, businessInstruction, referenceDate, publicDatasetId, suffix, tables, firestore, userGoal, dirName, agentShortName, oneSentenceSummary, operatingModel, enableWorkspaceMcp, enableComputerUse, enableManagedAgent, enableWorkspaceAuth, keepWarm, metadata } = params;
 
   // Derived feature gates (see AGENTS.md section 14):
   // - workspaceAuthEnabled: the GE OAuth authorization (user token) exists.
@@ -4228,7 +4236,7 @@ while true; do
   echo "📂 Demo Asset Directory: ~/${dirName}"
   echo "🧠 Agent Models:   root_agent: \$AGENT_MODEL_LITE / deep_analysis_agent: \$AGENT_MODEL"
   echo "🧪 Code Sandbox:   ✅ Enabled (Agent Runtime)"
-  ${ enableComputerUse ? `echo "🖥️ Computer Use:   ✅ Enabled (Browser Agent)"\n` : ''}${ enableManagedAgent ? `echo "🤖 Managed Agent:  ✅ Enabled (Antigravity autonomous sandbox - provisioned in parallel with setup)"\n` : ''}${ enableWorkspaceMcp ? `echo "🔌 Google Workspace MCP: Enabled"\n` : ''}${ (enableWorkspaceAuth && !enableWorkspaceMcp) ? `echo "🔐 Workspace Auth: ✅ Enabled (user OAuth, no MCP servers)"\n` : ''}${mcpBanner}echo "========================================================="
+  ${ enableComputerUse ? `echo "🖥️ Computer Use:   ✅ Enabled (Browser Agent)"\n` : ''}${ enableManagedAgent ? `echo "🤖 Managed Agent:  ✅ Enabled (Antigravity autonomous sandbox - provisioned in parallel with setup)"\n` : ''}${ enableWorkspaceMcp ? `echo "🔌 Google Workspace MCP: Enabled"\n` : ''}${ (enableWorkspaceAuth && !enableWorkspaceMcp) ? `echo "🔐 Workspace Auth: ✅ Enabled (user OAuth, no MCP servers)"\n` : ''}${ keepWarm ? 'echo "🔥 Warm Instance:  ✅ Enabled (min-instances 1 - no cold start, billed while idle)"\n' : ''}${mcpBanner}echo "========================================================="
   
   # --yes is advertised as "skip confirmation prompts (non-interactive use)", so
   # it has to skip this one too. Without the break, "read" gets EOF, returns
@@ -5498,6 +5506,7 @@ GOOGLE_API_USE_CLIENT_CERTIFICATE=false
 GOOGLE_CLOUD_LOCATION="global"
 DEMO_DATASET="${datasetId}"
 FS_COLLECTION="${fsCollection}"
+FIRESTORE_COLLECTION="${fsCollection}"
 REFERENCE_DATE="${referenceDate}"
 PUBLIC_DATASET_ID="${publicDatasetId || ''}"
 ENABLE_WORKSPACE_MCP=${enableWorkspaceMcp ? '1' : '0'}
@@ -5751,6 +5760,7 @@ ${ (params.importedMcpList || []).some(m => m.type === 'remote' && (m.auth_type 
   ${ (() => {
     let envVars = [
       "GOOGLE_CLOUD_PROJECT=\$PROJECT_ID",
+      "PROJECT_ID=\$PROJECT_ID",
       "GOOGLE_CLOUD_LOCATION=global",
       "GEMINI_AUTHORIZATION_ID=\$AUTH_ID",
       "ADK_ENABLE_MCP_GRACEFUL_ERROR_HANDLING=1",
@@ -5763,6 +5773,7 @@ ${ (params.importedMcpList || []).some(m => m.type === 'remote' && (m.auth_type 
       `BIGQUERY_DATASET=${datasetId}`,
       `DEMO_DATASET=${datasetId}`,
       `FS_COLLECTION=${fsCollection}`,
+      `FIRESTORE_COLLECTION=${fsCollection}`,
       `REFERENCE_DATE=${referenceDate}`,
       `PUBLIC_DATASET_ID=${publicDatasetId || ''}`,
       `ENABLE_WORKSPACE_MCP=${enableWorkspaceMcp ? '1' : '0'}`,
@@ -5872,7 +5883,20 @@ ${ (params.importedMcpList || []).some(m => m.type === 'remote' && (m.auth_type 
     // "Application startup complete" and the turn took 37s end to end against
     // 9-13s warm, i.e. roughly +25s on that first message only. Export
     // MIN_INSTANCES=1 before running the script to keep a warm instance for a
-    // live presentation.
+    // live presentation, or tick "Keep one instance warm" in Advanced Settings
+    // to have that baked in here.
+    //
+    // The toggle raises the baseline rather than rewriting the line below,
+    // because the environment has to keep the last word in BOTH directions: an
+    // operator who exports MIN_INSTANCES=0 on a demo built while the toggle was
+    // on gets scale-to-zero, and one who exports 1 on a demo built while it was
+    // off gets a warm instance. The :- default only fills an unset or empty
+    // value, so the line below leaves whatever this set alone.
+    //
+    // A plain '...' string, not a template literal: this block interpolates
+    // nothing, and in single quotes "$MIN_INSTANCES" is already literal - one
+    // fewer escaping layer than the \$ the line below still needs.
+    deployCmd += keepWarm ? '\n# Advanced Settings asked for a warm instance: no cold start on the first\n# message, at the price of one always-on 8Gi/2vCPU instance for as long as the\n# demo exists. Export MIN_INSTANCES=0 to put this demo back on scale-to-zero.\nif [ -z "$MIN_INSTANCES" ]; then\n  MIN_INSTANCES=1\nfi\n' : '';
     deployCmd += `\n# Scale-to-zero unless the operator asked for a warm instance\nMIN_INSTANCES="\${MIN_INSTANCES:-0}"\n`;
 
     if (optionalSecrets.length > 0) {
@@ -6339,6 +6363,10 @@ ${params.importedMcpList.map((mcp, idx) => {
     if [ ! -z "\$CONFIG_ID" ]; then
       echo "💬 Start Chatting with Your Agent:"
       echo "   👉 https://vertexaisearch.cloud.google.com/home/cid/\$CONFIG_ID/r/agent/\$AGENT_ID/session/-"
+      echo "   ⚠️  The FIRST message right after a deploy can come back as an error."
+      echo "      Gemini Enterprise takes up to ~90 seconds to start routing to a brand"
+      echo "      new agent, and a cold Cloud Run instance can refuse one request while"
+      echo "      it starts. Both are transient - send the message again."
     else
       echo "💬 Start Chatting in Gemini Enterprise:"
       echo "   👉 https://console.cloud.google.com/gemini-enterprise/locations/\$SELECTED_LOC/engines/\$SELECTED_APP_ID/overview/dashboard?project=\$PROJECT_ID"

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/SKILL.md
@@ -3,10 +3,10 @@ name: ge-demo-generator
 description: Synthesizes and deploys complete, domain-specific Gemini Enterprise demo environments directly to Google Cloud. Use when the user asks to create an AI agent demo for any customer domain (e.g. 'example.com', 'example.co.jp', 'example.de', 'example.fr' - any company, any industry, any region) or business goal, generate realistic BigQuery/Firestore sample datasets, create external demo files (PDF, Excel, scanned images), stage them in Cloud Storage and upload them to the deploying account's Google Drive, scaffold ADK multi-agent architectures with MCP tools and A2UI cards, deploy to Cloud Run, publish to Gemini Enterprise, and generate 7 structured demo prompts in any language. Confirms the requirements interactively and presents a demo architecture & data model plan (Mermaid ER diagram, external file lineage, target project) for approval before anything is deployed. Also triggered by /ge-demo-generator.
 metadata:
   author: Google Cloud Customer Engineering
-  version: 2.14.5
+  version: 2.15.0
 ---
 
-# GE Demo Generator Skill (v2.14.5)
+# GE Demo Generator Skill (v2.15.0)
 
 Synthesizes production-grade, domain-tailored AI agent demo environments using **Gemini 3.8 Flash** for reasoning and **Gemini 3.1 Flash Image** for visual generation, adhering to a strict **6-step infrastructure dependency graph**, rich **A2UI interactive component streaming**, **Google Workspace OAuth authorization**, **external sample files staged in Cloud Storage and, when the credentials carry the Drive scope, in the deploying account's Google Drive**, **7 structured demo prompts**, and **global multilingual localization (i18n/l10n)**.
 
@@ -130,7 +130,12 @@ with a stated default so the user can answer "all defaults" in three words:
    (Workspace OAuth when the scenario touches Gmail/Drive/Calendar, `rag` when it turns on
    documents rather than numbers, `dataScale` when the narrative claims enterprise volume),
    and say the rest keep their defaults. Keep the *question* short — brief section 6 lists
-   every option with its resolved value, so nothing is hidden by asking about a few.
+   every option with its resolved value, so nothing is hidden by asking about a few. Add
+   **a warm Cloud Run instance** (`MIN_INSTANCES=1`) to that question whenever the user has
+   named a date, an audience or a live session: it is the one option that is about the
+   *presentation* rather than the demo, and the only thing that removes the cold start — and
+   the occasional cold-start error — from the first message. Offer it with its price in the
+   same breath (see brief section 6).
 4. **Target environment** — only if what `gcloud` reports (read it now, see below) is not
    obviously the project the user means.
 
@@ -308,6 +313,26 @@ something the agent will do later — nothing after the deploy writes to a Drive
 Only list the options that are on, plus the two or three the demo is a plausible candidate
 for. A user reading eight defaults they did not ask about is a user who skims the whole brief.
 
+**One more switch, and it is deliberately not in that table** — it is not an `.env` key and it
+changes nothing inside the container. Cloud Run scales this demo to zero when nobody is talking
+to it, which is why an idle demo costs nothing, and why the first message after an idle gap
+waits ~20-25s for a cold start and can come back as an error instead: Cloud Run sometimes
+refuses a request outright while the container is still starting. Deploying with
+`MIN_INSTANCES=1` — the environment variable `setup_and_deploy.sh` reads in Step 4/6, exported
+before the deploy runs — keeps one instance always up and removes both.
+
+State it as a line under the table when you offer it, with the price attached rather than in a
+footnote:
+
+> 🔥 **Warm instance** — `MIN_INSTANCES=1` · default `0` (scale-to-zero). No cold start and no
+> cold-start error on the first message. **Cost:** one 8 GiB / 2 vCPU instance is then billed
+> continuously for as long as the demo exists — not just during the presentation.
+
+The honest default is `0`: for a demo deployed now and shown next week, sending the first
+message twice is far cheaper than a week of idle billing. It is also not a decision that has to
+be made now — it is read at deploy time, so re-running the deploy with the variable set (or
+unset) flips an existing demo either way.
+
 ### § The gate — ask once, then stop
 
 Close the message with a single explicit question, in the demo's language, that (a) names what
@@ -316,8 +341,8 @@ Enterprise registration (Phases 3-7) — and (b) leaves the door open for late c
 
 > Shall I proceed with this design and run the synthetic data generation, Google Drive upload,
 > Cloud Run deployment and Gemini Enterprise registration (Phases 3-7) in one pass? Let me know
-> if you want any option enabled (Google Workspace OAuth, RAG mode, data scale, …) or any part
-> of the model changed.
+> if you want any option enabled (Google Workspace OAuth, RAG mode, data scale, a warm Cloud
+> Run instance for a live session, …) or any part of the model changed.
 
 One question, not a second round of Step 2.1: everything else was settled before the brief was
 written, and a gate that re-opens five decisions is a gate nobody clears.
@@ -610,6 +635,7 @@ Follow the optimized dependency sequence with local pre-flight checks and fast b
    # setup_and_deploy.sh assembles this; see references/deployment_and_iam.md for the
    # complete table and for which variables are applied later, in Step 5.
    MIN_INSTANCES="${MIN_INSTANCES:-0}"   # export MIN_INSTANCES=1 to stay warm for a live demo
+                                         # (brief section 6 - it bills while idle, so ask first)
    gcloud run deploy "$SERVICE_NAME" \
      --source . \
      --region "$REGION" \
@@ -745,6 +771,7 @@ Upon deployment completion, ALWAYS output the structured results containing dire
 
 💬 **Start Chatting with Your Agent (Direct Chat Link):**
 👉 https://vertexaisearch.cloud.google.com/home/cid/${CONFIG_ID}/r/agent/${AGENT_ID}/session/-
+⚠️ The FIRST message right after a deploy can come back as an error. Gemini Enterprise takes up to ~90 seconds to start routing to a brand new agent, and a cold Cloud Run instance can refuse one request while it starts. Both are transient — send the message again.
 
 💻 **Gemini Enterprise Console (Overview):**
 👉 https://console.cloud.google.com/gemini-enterprise/locations/${SELECTED_LOC}/engines/${SELECTED_APP_ID}/overview/dashboard?&project=${PROJECT_ID}

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/deployment_and_iam.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/references/deployment_and_iam.md
@@ -157,9 +157,13 @@ gcloud run deploy "$SERVICE_NAME" \
 SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" --region="$REGION" --format="value(status.url)")
 ```
 
-Scale-to-zero is the default: an idle demo should not bill for a warm instance. The cost is a
-~20s cold start on the first message after an idle gap, so export `MIN_INSTANCES=1` before a
-live presentation.
+Scale-to-zero is the default: an idle demo should not bill for a warm instance. The cost lands
+entirely on the first message after an idle gap — a ~20s cold start, and occasionally an error
+instead, because Cloud Run can refuse a request while the container is still starting. Export
+`MIN_INSTANCES=1` before a live presentation to remove both. Offer it with its price: one
+8 GiB / 2 vCPU instance is then billed continuously for as long as the demo exists, not just
+during the presentation, so `0` stays the right default for a demo that is deployed now and
+shown later.
 
 The rest of the shape is not negotiable:
 
@@ -312,7 +316,7 @@ before the first deploy.
 | `DASH_BUCKET` | `${PROJECT_ID}-${DOMAIN_SLUG}-${SUFFIX}-dash` | setup | Deliverables bucket, created unconditionally and passed as `DASHBOARDS_BUCKET`. `publish_dashboard` and the autonomous agent's skill mount both read it. |
 | `WORKER_QUEUE` | `${SERVICE_NAME}-worker` | setup | Cloud Tasks queue for background runs. |
 | `WORKER_QUEUE_LOCATION` | `us-central1` | setup | Pinned independently of `REGION` so a demo in a region without Cloud Tasks still gets durable background work. |
-| `MIN_INSTANCES` | `0` | setup | Set to `1` before a live presentation to avoid the ~20s cold start on the first message. |
+| `MIN_INSTANCES` | `0` | setup | Set to `1` before a live presentation to avoid the ~20s cold start (and the occasional cold-start error) on the first message. Bills one 8 GiB / 2 vCPU instance continuously until the demo is deleted. |
 | `GCS_BUCKET_NAME` | `${PROJECT_ID}-${DOMAIN_SLUG}-${SUFFIX}-docs` | both | Created and populated with `external_files/` in **both** modes (Job 3.2b, outside the `RAG_MODE` branch) — in `mcp` mode nothing indexes those documents, but the bucket is still the only copy that outlives the machine running the skill, and the completion banner links to it. In `rag` mode it is additionally the unstructured half of the index. Deleted recursively by cleanup in both modes. |
 | `DATA_SCALE` | unset | setup | Row count to amplify the fact tables to before `bq load`, via `scripts/amplify_data.py` in Job 1.4. Unset loads the CSVs exactly as generated. `data/data_scale_spec.json`, when present, gives per-table targets and overrides this number. The step is deterministic and idempotent — the hero rows are stashed as `data/<table>.hero.csv` on the first run and every later run amplifies from the stash, never from already-amplified output — so it is safe whether or not the data phase already ran it. |
 

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/scripts/verify_and_heal.py
@@ -24,7 +24,7 @@
 
 
 # =============================================================================
-# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.14.5)
+# Autonomous Post-Deployment Verification & Self-Healing Engine (v2.15.0)
 # Automatically audits 8 infrastructure layers and heals discrepancies in real time:
 #   1. BigQuery Dataset & Tables (Row counts, _id column for DataStores, schema metadata)
 #   2. Firestore Collection & Seeding (Task queue documents >= 3)

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/setup_and_deploy.sh
@@ -1842,6 +1842,10 @@ echo ""
 if [ ! -z "$GE_DIRECT_CHAT_URL" ]; then
   echo "💬 Start Chatting with Your Agent (Direct):"
   echo "   👉 ${GE_DIRECT_CHAT_URL}"
+  echo "   ⚠️  The FIRST message right after a deploy can come back as an error."
+  echo "      Gemini Enterprise takes up to ~90 seconds to start routing to a brand"
+  echo "      new agent, and a cold Cloud Run instance can refuse one request while"
+  echo "      it starts. Both are transient - send the message again."
   echo ""
 fi
 echo "💻 Gemini Enterprise Console (Overview):"


### PR DESCRIPTION
Port of internal commit `83b8bd7` (cloud-gtm/ge-demo-generator#199).

A freshly deployed demo errored on its first message and answered normally on the third. Two unrelated transients were behind it, and they get different answers on purpose.

## 1. Gemini Enterprise registration propagation — a warning, not a wait

`CreateAgent` returns in ~4s with `state=ENABLED` in the create response itself, and the agent stays ENABLED throughout. There is no readiness field to poll. Yet a chat opened +20s after creation failed every turn, with the GE session recording `state: FAILED`, 0 replies, and the Cloud Run access log showing zero requests with `userAgent="Google"` — GE never dialled the service, while a warm instance sat idle. +66s also failed; +76s was served.

What ships instead of artificial sleep is the chat link printed immediately, with the warning next to it:

```
💬 Start Chatting with Your Agent:
   👉 https://vertexaisearch.cloud.google.com/home/cid/.../session/-
   ⚠️  The FIRST message right after a deploy can come back as an error.
      Gemini Enterprise takes up to ~90 seconds to start routing to a brand
      new agent, and a cold Cloud Run instance can refuse one request while
      it starts. Both are transient - send the message again.
```

Same text in `Code.gs`, the skill's `setup_and_deploy.sh`, and the SKILL.md hand-off summary. It names both transients, so whichever one you hit, the printout explains it.

## 2. Cloud Run cold-start abort — an opt-in toggle

`500` with `0s` latency and `The request was aborted because there was no available instance.` in the container log — stochastic across demos during cold starts.

It is now **"Keep one instance warm"** in Advanced Settings, and something the skill proposes during its Step 2.1 requirements interview and states in brief section 6. Not default-on, and the price is quoted wherever it is offered: one 8 GiB / 2 vCPU instance billed continuously for as long as the demo exists — not just during the presentation.

The toggle **raises the default** rather than rewriting the deploy line:

```bash
# Advanced Settings asked for a warm instance: ...
if [ -z "$MIN_INSTANCES" ]; then
  MIN_INSTANCES=1
fi

# Scale-to-zero unless the operator asked for a warm instance
MIN_INSTANCES="${MIN_INSTANCES:-0}"
```

so the environment keeps the last word in **both** directions. `MIN_INSTANCES=0` puts a demo built while the toggle was on back on scale-to-zero without regenerating it, and the pre-toggle `MIN_INSTANCES=1` recipe still works on demos built with it off.

## Verification

- `npm run port:gates` — all 7 active gates passed (ShellCheck, shfmt, Hadolint, forbidden-pattern scan, spelling candidates, version parity, and Code.gs parity).
- Versions: `APP_VERSION` v12.4-public → v12.9-public; skill 2.14.5 → 2.15.0 across all sites.
