### PR TITLE
fix(ge-demo-generator): guard optional tools and ensure Cloud Run deploy logs print on failure (v12.10-public)

### DIFF
--- a/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/agent_template/adk_agent/app/agent.py
@@ -1379,19 +1379,21 @@ _all_tools.append(tools.run_scheduled_task_now)
 # the agent obtain a live-view link BEFORE the (blocking) inline browse call.
 _all_tools.append(tools.start_browser_session)
 _all_tools.append(tools.computer_use_browse)
-# Managed Autonomous Agent (Antigravity) delegation. Background workers are
-# blocked by a structural guard in tools.py; deep_analysis_agent is ALLOWED
-# to delegate (v11.2) so a mis-routed web/file/Workspace task has an escape
-# hatch instead of a dead end - the tool always returns within the sync
-# window, so the F1 hang pattern does not apply.
-_all_tools.append(tools.delegate_autonomous_task)
-_all_tools.append(tools.get_autonomous_task_status)
-# Recurring autonomous schedules (v11.33): Cloud Scheduler fires
-# /execute_task, which delegates to the sandbox headlessly.
-_all_tools.append(tools.register_scheduled_autonomous_task)
-# Drive handoff needs BOTH the user's Workspace OAuth (drive.file) and the
-# Managed Agent deliverables in GCS.
-_all_tools.append(tools.save_deliverables_to_drive)
+# Managed Autonomous Agent (Antigravity) delegation & Workspace Drive handoff.
+# Background workers are blocked by a structural guard in tools.py; deep_analysis_agent
+# is ALLOWED to delegate (v11.2) so a mis-routed web/file/Workspace task has an escape
+# hatch instead of a dead end - the tool always returns within the sync window, so the
+# F1 hang pattern does not apply.
+for _tool_name in (
+    "delegate_autonomous_task",
+    "get_autonomous_task_status",
+    "register_scheduled_autonomous_task",
+    "save_deliverables_to_drive",
+):
+    _tool = getattr(tools, _tool_name, None)
+    if _tool is not None:
+        _all_tools.append(_tool)
+
 
 
 # --- Agent Sandbox Code Executor (always enabled) ---

--- a/search/gemini-enterprise/ge-demo-generator/app/Code.gs
+++ b/search/gemini-enterprise/ge-demo-generator/app/Code.gs
@@ -101,7 +101,7 @@ const CONFIG = {
   GITHUB_TOKEN: SCRIPT_PROPS.getProperty('GITHUB_TOKEN'),
   MAX_RETRIES: 3,
   RETRY_DELAY_MS: 1000,
-  APP_VERSION: 'v12.9-public',
+  APP_VERSION: 'v12.10-public',
   // Agent-template source: the generated setup script fetches the static
   // Python/JSON template files (agent_template/ in the repo) at run time.
   // TEMPLATE_REF may be a branch name (default 'main'): it is resolved to a
@@ -5963,9 +5963,7 @@ ${ (params.importedMcpList || []).some(m => m.type === 'remote' && (m.auth_type 
     sleep 5
   done
   echo ""
-  wait $DEPLOY_PID
-  DEPLOY_EXIT=$?
-  if [ $DEPLOY_EXIT -ne 0 ]; then
+  if ! wait "$DEPLOY_PID"; then
     echo "   ❌ Cloud Run deployment failed. Build log:"
     echo "---------------------------------------------------------"
     cat "$DEPLOY_LOG"

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/agent.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/agent.py
@@ -1387,17 +1387,21 @@ _all_tools.append(tools.start_browser_session)
 _all_tools.append(tools.computer_use_browse)
 # Managed Autonomous Agent (Antigravity) delegation. Background workers are
 # blocked by a structural guard in tools.py; deep_analysis_agent is ALLOWED
-# to delegate (v11.2) so a mis-routed web/file/Workspace task has an escape
-# hatch instead of a dead end - the tool always returns within the sync
-# window, so the F1 hang pattern does not apply.
-_all_tools.append(tools.delegate_autonomous_task)
-_all_tools.append(tools.get_autonomous_task_status)
-# Recurring autonomous schedules (v11.33): Cloud Scheduler fires
-# /execute_task, which delegates to the sandbox headlessly.
-_all_tools.append(tools.register_scheduled_autonomous_task)
-# Drive handoff needs BOTH the user's Workspace OAuth (drive.file) and the
-# Managed Agent deliverables in GCS.
-_all_tools.append(tools.save_deliverables_to_drive)
+# Managed Autonomous Agent (Antigravity) delegation & Workspace Drive handoff.
+# Background workers are blocked by a structural guard in tools.py; deep_analysis_agent
+# is ALLOWED to delegate (v11.2) so a mis-routed web/file/Workspace task has an escape
+# hatch instead of a dead end - the tool always returns within the sync window, so the
+# F1 hang pattern does not apply.
+for _tool_name in (
+    "delegate_autonomous_task",
+    "get_autonomous_task_status",
+    "register_scheduled_autonomous_task",
+    "save_deliverables_to_drive",
+):
+    _tool = getattr(tools, _tool_name, None)
+    if _tool is not None:
+        _all_tools.append(_tool)
+
 
 
 # --- Agent Sandbox Code Executor (always enabled) ---


### PR DESCRIPTION
## Summary
Fixes two production issues encountered during demo deployment:

1. **AttributeError on container startup when optional tools are disabled**:
   - In `agent.py`, `save_deliverables_to_drive`, `delegate_autonomous_task`, `get_autonomous_task_status`, and `register_scheduled_autonomous_task` are gated in `tools.py` behind feature flags (`ENABLE_WORKSPACE_MCP` / `ENABLE_MANAGED_AGENT`).
   - If Workspace MCP or Managed Autonomous Agent is disabled (`ENABLE_WORKSPACE_MCP=0` or `ENABLE_MANAGED_AGENT=0`), appending these tools directly causes `AttributeError: module 'tools' has no attribute 'save_deliverables_to_drive'`, which crashes Uvicorn on startup and causes Cloud Run health checks on port 8080 to fail.
   - Guarded all 4 optional tools defensively using `getattr(tools, _tool_name, None)`.

2. **Cloud Run deploy logs silently lost on deployment failure in setup script**:
   - Under `set -e`, if Cloud Run deployment fails, `wait $DEPLOY_PID` returns non-zero.
   - Bash terminates immediately on `wait $DEPLOY_PID`, bypassing `DEPLOY_EXIT=$?` and `cat "$DEPLOY_LOG"`.
   - The exit trap (`trap "rm -f $DEPLOY_LOG" EXIT`) then runs and silently deletes the deploy log.
   - Replaced with `if ! wait "$DEPLOY_PID"; then` which is POSIX/bash `set -e` safe and guarantees the error log is printed to the terminal before exiting.

Carries forward `v12.10-public` and passes all public gate checks.