### PR TITLE
feat(ge-demo-generator): align video Drive account precedence, grade delivery outcome, and localize narration

### DIFF
--- a/.github/actions/spelling/excludes.txt
+++ b/.github/actions/spelling/excludes.txt
@@ -119,3 +119,4 @@ py\.typed$
 ^\Q.gemini/styleguide.md\E$
 ^\Qgemini/sample-apps/prism-science-explainer/app/shell.html\E$
 ^\Qgemini/sample-apps/prism-science-explainer/frontend/index.html\E$
+^\Qsearch/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/synthesize_tts.py\E$

--- a/search/gemini-enterprise/ge-demo-generator/scripts/generate_demo_video.py
+++ b/search/gemini-enterprise/ge-demo-generator/scripts/generate_demo_video.py
@@ -35,6 +35,39 @@ REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VIDEO_TEMPLATE_DIR = os.path.join(REPO_ROOT, "skills/ge-demo-generator/templates/video")
 VIDEO_SCRIPTS_DIR = os.path.join(VIDEO_TEMPLATE_DIR, "scripts")
 
+# Delivery can prompt for re-authentication. Bound it so an unattended run fails
+# loudly instead of hanging forever on a question nobody is there to answer.
+DELIVERY_TIMEOUT_SEC = 900
+
+
+def _delivery_module():
+    """Imports the uploader module, or returns None if it is unavailable."""
+    try:
+        if VIDEO_SCRIPTS_DIR not in sys.path:
+            sys.path.insert(0, VIDEO_SCRIPTS_DIR)
+        import upload_to_drive
+        return upload_to_drive
+    except Exception:
+        return None
+
+
+def drive_login_hint(account: str) -> str:
+    """Returns the exact re-authentication command for this host.
+
+    Deliberately delegates to the uploader so the operator is never told to run
+    a command that differs from the one the uploader itself would run. On a host
+    with no local browser the plain form opens nothing and appears to hang, so
+    the uploader appends --no-launch-browser there.
+    """
+    module = _delivery_module()
+    if module is not None:
+        try:
+            return module.drive_login_hint(account)
+        except Exception:
+            pass
+    return f"gcloud auth login {account or '<ACCOUNT>'} --enable-gdrive-access"
+
+
 
 def ensure_prerequisites() -> None:
     """Ensures Python virtual environment and required libraries are ready."""
@@ -468,13 +501,13 @@ def format_demo_plan_overview(
         lines.extend([
             "",
             f"⚠️ Note: Credentials expired for {t1_acct}. Run to re-authenticate:",
-            f"   gcloud auth login {t1_acct} --enable-gdrive-access"
+            f"   {drive_login_hint(t1_acct)}"
         ])
     elif dest_info.get("tier_1", {}).get("status") == "scope_insufficient":
         lines.extend([
             "",
             f"💡 Note: Drive scope missing for {t1_acct}. Run to enable:",
-            f"   gcloud auth login {t1_acct} --enable-gdrive-access"
+            f"   {drive_login_hint(t1_acct)}"
         ])
 
     lines.extend([
@@ -775,27 +808,46 @@ def run_pipeline(args):
         f'if [ ! -d "node_modules" ]; then npm install --prefer-offline --no-audit --no-fund; fi && '
         f'npx remotion render src/index.ts DemoHighlightReel "{output_mp4}" --props="{props_file}"'
     )
+
+    # Say what is missing before spending a dependency install finding out.
+    # "Remotion rendering failed" after several silent minutes is not a
+    # diagnosis a remote tester can act on.
+    probe = subprocess.run(
+        ["bash", "-c", 'source "$HOME/.nvm/nvm.sh" 2>/dev/null || true; command -v node && command -v npx'],
+        capture_output=True, text=True,
+    )
+    if probe.returncode != 0:
+        print("❌ [Rendering Error] Node.js and npx are required to render, and neither was found.", file=sys.stderr)
+        print("   Install Node.js 20 or later, or make an existing install visible on PATH", file=sys.stderr)
+        print("   (a Node Version Manager install is picked up from $HOME/.nvm/nvm.sh).", file=sys.stderr)
+        sys.exit(1)
+
     try:
-        print("Running Remotion rendering engine...")
-        res = subprocess.run(["bash", "-c", render_cmd], capture_output=True, text=True)
-        if res.returncode == 0 and os.path.exists(output_mp4) and os.path.getsize(output_mp4) > 1000:
+        print("Running Remotion rendering engine (streaming output)...")
+        # Streamed, not captured. A render takes minutes, and a process that
+        # prints nothing for minutes is indistinguishable from one that has hung
+        # - which is how this stage got reported as a freeze. The tail is kept
+        # for the failure summary so the useful lines are not lost in the scroll.
+        tail = []
+        proc = subprocess.Popen(
+            ["bash", "-c", render_cmd],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1,
+        )
+        for line in proc.stdout:
+            line = line.rstrip()
+            print(f"  | {line}", flush=True)
+            tail.append(line)
+            if len(tail) > 60:
+                tail.pop(0)
+        returncode = proc.wait()
+        if returncode == 0 and os.path.exists(output_mp4) and os.path.getsize(output_mp4) > 1000:
             remotion_success = True
             print(f"  ✅ Remotion render successful: {output_mp4}")
         else:
-            print(f"  ⚠️ Remotion command finished with code {res.returncode}.")
-            stderr_text = (res.stderr or "").strip()
-            if stderr_text:
-                lines = stderr_text.splitlines()
-                if len(lines) > 50:
-                    print("  --- Remotion Stderr (tail) ---")
-                    print("\n".join(lines[-50:]))
-                else:
-                    print("  --- Remotion Stderr ---")
-                    print(stderr_text)
-            elif res.stdout:
-                lines = res.stdout.strip().splitlines()
-                print("  --- Remotion Stdout (tail) ---")
-                print("\n".join(lines[-30:]))
+            print(f"  ⚠️ Remotion command finished with code {returncode}.")
+            if tail:
+                print("  --- Remotion output (tail) ---")
+                print("\n".join(tail))
     except Exception as e:
         print(f"  ⚠️ Remotion invocation exception: {e}")
 
@@ -831,14 +883,71 @@ def run_pipeline(args):
         cmd_deliver.append("--share-public")
     if getattr(args, "skip_drive", False) or os.environ.get("SKIP_VIDEO_DRIVE_UPLOAD", "").strip().lower() in ("1", "true", "yes"):
         cmd_deliver.append("--skip-drive")
+    delivery_report = os.path.abspath(os.path.join("./deliverables", "delivery_report.json"))
+    cmd_deliver.extend(["--report", delivery_report])
     if sys.stdin.isatty():
         cmd_deliver.append("--interactive")
-    subprocess.run(cmd_deliver)
+
+    # The uploader is the only component that knows where the video actually
+    # landed. Read its verdict rather than assuming success: a silent fallback to
+    # Cloud Storage used to be announced here as a completed Drive delivery, so
+    # the operator was told to look in a folder that had no video in it.
+    try:
+        os.makedirs("./deliverables", exist_ok=True)
+    except Exception:
+        pass
+    if os.path.exists(delivery_report):
+        # A stale report from an earlier run must never be mistaken for this one.
+        try:
+            os.remove(delivery_report)
+        except Exception:
+            pass
+
+    try:
+        proc = subprocess.run(cmd_deliver, timeout=DELIVERY_TIMEOUT_SEC)
+        delivery_code = proc.returncode
+    except subprocess.TimeoutExpired:
+        print(f"  ⚠️ Delivery timed out after {DELIVERY_TIMEOUT_SEC}s.", file=sys.stderr)
+        delivery_code = 1
+    except Exception as deliver_err:
+        print(f"  ⚠️ Delivery invocation exception: {deliver_err}", file=sys.stderr)
+        delivery_code = 1
+
+    report = {}
+    try:
+        with open(delivery_report, "r", encoding="utf-8") as handle:
+            report = json.load(handle)
+    except Exception:
+        report = {}
+
+    local_hint = report.get("local_path") or f"./deliverables/[Demo-Video]_{company.replace(' ', '_')}_-_{role.replace(' ', '_')}.mp4"
+    headline = report.get("headline", "")
+    action = report.get("action_required", "")
+    drive_url = report.get("drive_url", "")
+    gcs_uri = report.get("gcs_uri", "")
 
     print("\n" + "=" * 80)
-    print("🎉 DEMO VIDEO PRODUCTION & DELIVERY COMPLETE!")
-    print(f"   Local Deliverable : ./deliverables/[Demo-Video]_{company.replace(' ', '_')}_-_{role.replace(' ', '_')}.mp4")
+    if delivery_code == 0:
+        print("🎉 DEMO VIDEO PRODUCTION & DELIVERY COMPLETE!")
+    elif delivery_code == 3:
+        print("🚨 ACTION REQUIRED: GOOGLE DRIVE DELIVERY DID NOT COMPLETE")
+    else:
+        print("❌ DEMO VIDEO RENDERED, BUT DELIVERY FAILED")
+    if headline:
+        print(f"   Outcome           : {headline}")
+    print(f"   Local Deliverable : {local_hint}")
+    if drive_url:
+        print(f"   Google Drive      : {drive_url}")
+    if gcs_uri:
+        print(f"   Cloud Storage     : {gcs_uri}")
+    if action:
+        print(f"   👉 Next Step       : {action}")
+    if os.path.exists(delivery_report):
+        print(f"   Delivery Report   : {delivery_report}")
     print("=" * 80 + "\n")
+
+    if delivery_code != 0:
+        sys.exit(delivery_code)
 
 
 def main():

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/synthesize_tts.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/synthesize_tts.py
@@ -69,7 +69,9 @@ VOICE_MAPPING = {
     "hi-IN": {"voice": "hi-IN-Chirp3-HD-Achernar", "language_code": "hi-IN", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
     "hi": {"voice": "hi-IN-Chirp3-HD-Achernar", "language_code": "hi-IN", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
     "ar-XA": {"voice": "ar-XA-Chirp3-HD-Achernar", "language_code": "ar-XA", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
-    "ar": {"voice": "ar-XA-Chirp3-HD-Achernar", "language_code": "ar-XA", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
+        "ar": {"voice": "ar-XA-Chirp3-HD-Achernar", "language_code": "ar-XA", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
+    "th-TH": {"voice": "th-TH-Chirp3-HD-Orion", "language_code": "th-TH", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
+    "th": {"voice": "th-TH-Chirp3-HD-Orion", "language_code": "th-TH", "ssml_gender": "FEMALE", "speaking_rate": 1.0},
 }
 
 
@@ -103,7 +105,8 @@ def resolve_voice_for_language(lang: str) -> dict:
         "pt": "pt-BR",
         "nl": "nl-NL",
         "hi": "hi-IN",
-        "ar": "ar-XA",
+                "ar": "ar-XA",
+        "th": "th-TH",
     }
     if prefix in prefix_map:
         target_key = prefix_map[prefix]
@@ -203,8 +206,9 @@ def validate_tts_readiness(project_id: str = "", lang: str = "en-US", mock: bool
 
 def estimate_speech_duration(text: str, lang: str) -> float:
     """Estimates speech duration in seconds for timing alignment and mock fallback."""
-    if lang.startswith("ja"):
-        # Average Japanese speech rate: ~5.0 characters per second
+    base_lang = lang.split("-")[0].lower()
+    if base_lang in ("ja", "zh", "ko", "cmn", "yue", "th"):
+        # Average CJK/Thai speech rate: ~5.0 characters per second
         clean_len = len(text.replace(" ", "").replace("\n", ""))
         return max(2.5, round(clean_len / 5.0, 2))
     else:
@@ -227,9 +231,13 @@ def generate_silent_audio(output_path: str, duration_sec: float):
     try:
         subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True)
     except Exception:
-        # If ffmpeg is not available, create an empty file
+        # If ffmpeg is not available, create a minimal silent MP3 audio stub
+        # Frame header: 0xFF, 0xFB, 0x90, 0x64 (MPEG1 Layer III, 128 kbps, 44.1 kHz, stereo)
+        # Followed by 414 bytes of zero padding = 418 bytes total per frame (~26ms)
+        frame = b"\xff\xfb\x90\x64" + b"\x00" * 414
+        num_frames = max(1, int(duration_sec * 38.28125))
         with open(output_path, "wb") as f:
-            f.write(b"")
+            f.write(frame * num_frames)
 
 
 def synthesize_scene_audio(text: str, output_path: str, lang: str = "en-US", mock: bool = False, project: str = "") -> float:
@@ -299,10 +307,13 @@ def synthesize_scene_audio(text: str, output_path: str, lang: str = "en-US", moc
 def split_subtitles(text: str, total_duration: float, lang: str) -> list:
     """Splits a narration text into timed subtitle segments for Remotion lower-thirds."""
     # Split by punctuation
-    if lang.startswith("ja"):
-        sentences = [s.strip() for s in text.replace("。", "。\n").replace("！", "！\n").split("\n") if s.strip()]
+    base_lang = lang.split("-")[0].lower()
+    if base_lang in ("ja", "zh", "ko", "cmn", "yue"):
+        sentences = [s.strip() for s in text.replace("。", "。\n").replace("！", "！\n").replace("？", "？\n").split("\n") if s.strip()]
+    elif base_lang == "th":
+        sentences = [s.strip() for s in text.replace(" ", " \n").split("\n") if s.strip()]
     else:
-        sentences = [s.strip() for s in text.replace(".", ".\n").replace("!", "!\n").split("\n") if s.strip()]
+        sentences = [s.strip() for s in text.replace(".", ".\n").replace("!", "!\n").replace("?", "?\n").split("\n") if s.strip()]
 
     if not sentences:
         return [{"text": text, "start_sec": 0.0, "end_sec": total_duration}]
@@ -327,41 +338,195 @@ def split_subtitles(text: str, total_duration: float, lang: str) -> list:
     return slices
 
 
-def build_narration_script(company: str, role: str, lang: str, prompts: list = None) -> list:
-    """Returns structured narration lines for demo scenes."""
-    is_ja = lang.startswith("ja")
-    num_prompts = len(prompts) if prompts else 7
+NARRATION_STRINGS = {
+    "en": {
+        "intro_title": "{company} AI Agent Demo",
+        "intro_text": "Welcome to this demonstration of {role}, an autonomous AI agent built on Gemini Enterprise for {company}.",
+        "agenda_title": "Walkthrough Agenda",
+        "agenda_text_full": "Today's demonstration covers {num_prompts} core operational workflows for enterprise operations. We will walk through situational briefing, catalog discovery, anomaly detection, immediate action approval, root cause analysis, simulation, and daily handover.",
+        "agenda_text_short": "Today's demonstration covers {num_prompts} core operational workflows. We will walk through situational briefing, catalog discovery, anomaly detection, immediate action approval, and daily handover.",
+        "scene_title": "Scene {s_num}: Demonstration Scenario {s_num}",
+        "scene_lead": "Now, let's proceed to demonstration scenario {s_num}.",
+        "scene_think": "The agent queries underlying enterprise data stores and synthesizes the required workflow actions.",
+        "scene_resp": "As the structured results appear, the agent consolidates multi-source metrics into clear recommendations. This accelerates complex operational workflows while maintaining enterprise data governance.",
+        "outro_title": "Conclusion",
+        "outro_text": "Gemini Enterprise empowers {company} to transform manual reviews into seamless autonomous operations. Thank you."
+    },
+    "ja": {
+        "intro_title": "{company} AI エージェント デモ",
+        "intro_text": "本日は、{company}のために開発されたGemini Enterpriseの自律型エージェント「{role}」の実演をご紹介します。",
+        "agenda_title": "実演デモシナリオ一覧",
+        "agenda_text_full": "本日のデモでは、製造オペレーションを変革する全{num_prompts}つの重要ワークフローをご紹介します。初期対話からデータ分析、即時承認、根本原因究明、生産シミュレーション、日次サマリーまで順を追って実演します。",
+        "agenda_text_short": "本日のデモでは、主要な全{num_prompts}つの重要ワークフローをご紹介します。初期対話からデータ分析、即時承認、そして日次サマリーまで順を追って実演します。",
+        "scene_title": "Scene {s_num}: デモシナリオ {s_num}",
+        "scene_lead": "それでは、続いてのデモシナリオの実演に移ります。",
+        "scene_think": "エージェントが基幹データソースを照会し、要求されたワークフローを自律的に推論しています。",
+        "scene_resp": "画面に構造化された分析結果が表示され、多角的な知見が整理されます。これにより、高度なエンタープライズ業務を迅速かつ確実に遂行できます。",
+        "outro_title": "まとめ",
+        "outro_text": "このように、{company}の業務オペレーションをGemini Enterpriseが強力に加速します。ご清聴ありがとうございました。"
+    },
+    "de": {
+        "intro_title": "{company} KI-Agent Demo",
+        "intro_text": "Herzlich willkommen zu dieser Demonstration von {role}, einem autonomen KI-Agenten auf Basis von Gemini Enterprise für {company}.",
+        "agenda_title": "Walkthrough-Agenda",
+        "agenda_text_full": "Die heutige Demonstration umfasst {num_prompts} zentrale operative Workflows für Unternehmensabläufe. Wir demonstrieren Situationsanalyse, Katalogabfragen, Anomalieerkennung, sofortige Handlungsfreigaben, Ursachenanalyse, Simulation und die tägliche Übergabe.",
+        "agenda_text_short": "Die heutige Demonstration umfasst {num_prompts} zentrale operative Workflows. Wir demonstrieren Situationsanalyse, Katalogabfragen, Anomalieerkennung, sofortige Handlungsfreigaben und die tägliche Übergabe.",
+        "scene_title": "Szene {s_num}: Demonstrationsszenario {s_num}",
+        "scene_lead": "Lassen Sie uns nun mit Demonstrationsszenario {s_num} fortfahren.",
+        "scene_think": "Der Agent fragt die zugrunde liegenden Unternehmensdaten ab und synthetisiert die erforderlichen Workflow-Aktionen.",
+        "scene_resp": "Sobald die strukturierten Ergebnisse erscheinen, konsolidiert der Agent Daten aus mehreren Quellen in klare Empfehlungen. Dies beschleunigt komplexe operative Abläufe unter Wahrung der Daten-Governance.",
+        "outro_title": "Fazit",
+        "outro_text": "Gemini Enterprise ermöglicht es {company}, manuelle Prüfungen in nahtlose autonome Prozesse zu transformieren. Vielen Dank."
+    },
+    "fr": {
+        "intro_title": "Démo de l'Agent IA {company}",
+        "intro_text": "Bienvenue dans cette démonstration de {role}, un agent IA autonome développé sur Gemini Enterprise pour {company}.",
+        "agenda_title": "Au programme",
+        "agenda_text_full": "La démonstration d'aujourd'hui couvre {num_prompts} processus opérationnels majeurs. Nous allons passer en revue l'analyse de situation, la découverte de catalogue, la détection d'anomalies, l'approbation d'actions immédiates, l'analyse des causes profondes, la simulation et le compte-rendu quotidien.",
+        "agenda_text_short": "La démonstration d'aujourd'hui couvre {num_prompts} processus opérationnels majeurs. Nous allons passer en revue l'analyse de situation, la découverte de catalogue, la détection d'anomalies, l'approbation d'actions immédiates et le compte-rendu quotidien.",
+        "scene_title": "Scène {s_num} : Scénario de démonstration {s_num}",
+        "scene_lead": "Passons maintenant au scénario de démonstration {s_num}.",
+        "scene_think": "L'agent interroge les bases de données de l'entreprise et synthétise les actions requises.",
+        "scene_resp": "À l'affichage des résultats structurés, l'agent consolide les mesures multi-sources en recommandations claires. Cela accélère les flux de travail complexes tout en maintenant la gouvernance des données.",
+        "outro_title": "Conclusion",
+        "outro_text": "Gemini Enterprise aide {company} à transformer des processus manuels en opérations autonomes fluides. Merci de votre attention."
+    },
+    "es": {
+        "intro_title": "Demostración del Agente de IA para {company}",
+        "intro_text": "Bienvenidos a esta demostración de {role}, un agente de IA autónomo desarrollado con Gemini Enterprise para {company}.",
+        "agenda_title": "Agenda de la Demostración",
+        "agenda_text_full": "La demostración de hoy abarca {num_prompts} flujos de trabajo operativos clave. Revisaremos el reporte de situación, la exploración del catálogo, la detección de anomalías, las aprobaciones inmediatas, el análisis de causa raíz, la simulación y el informe diario.",
+        "agenda_text_short": "La demostración de hoy abarca {num_prompts} flujos de trabajo operativos clave. Revisaremos el reporte de situación, la exploración del catálogo, la detección de anomalías, las aprobaciones inmediatas y el informe diario.",
+        "scene_title": "Escena {s_num}: Escenario de Demostración {s_num}",
+        "scene_lead": "A continuación, procedamos con el escenario de demostración {s_num}.",
+        "scene_think": "El agente consulta las fuentes de datos corporativas pertinentes y sintetiza las acciones necesarias para el flujo de trabajo.",
+        "scene_resp": "Al mostrar los resultados estructurados, el agente consolida las métricas de múltiples fuentes en recomendaciones claras. Esto acelera los flujos operativos complejos preservando la gobernanza de datos empresariales.",
+        "outro_title": "Conclusión",
+        "outro_text": "Gemini Enterprise impulsa a {company} para transformar revisiones manuales en operaciones autónomas y fluidas. Muchas gracias."
+    },
+    "it": {
+        "intro_title": "Demo dell'Agente IA per {company}",
+        "intro_text": "Benvenuti a questa dimostrazione di {role}, un agente IA autonomo sviluppato su Gemini Enterprise per {company}.",
+        "agenda_title": "Programma della Dimostrazione",
+        "agenda_text_full": "La dimostrazione di oggi riguarda {num_prompts} flussi di lavoro operativi fondamentali. Esamineremo il briefing situazionale, l'esplorazione del catalogo, il rilevamento di anomalie, l'approvazione immediata di azioni, l'analisi delle cause profonde, la simulazione e la consegna giornaliera.",
+        "agenda_text_short": "La dimostrazione di oggi riguarda {num_prompts} flussi di lavoro operativi fondamentali. Esamineremo il briefing situazionale, l'esplorazione del catalogo, il rilevamento di anomalie, l'approvazione immediata di azioni e la consegna giornaliera.",
+        "scene_title": "Scena {s_num}: Scenario Operativo {s_num}",
+        "scene_lead": "Procediamo ora con lo scenario operativo {s_num}.",
+        "scene_think": "L'agente interroga i database aziendali e sintetizza in autonomia le azioni richieste per il flusso di lavoro.",
+        "scene_resp": "Visualizzando i risultati, l'agente consolida le metriche da più fonti offrendo chiare raccomandazioni. Ciò accelera le operazioni complesse preservando la sicurezza dei dati aziendali.",
+        "outro_title": "Conclusione",
+        "outro_text": "Gemini Enterprise supporta {company} nel trasformare revisioni manuali in processi autonomi ottimizzati. Grazie per l'attenzione."
+    },
+    "ko": {
+        "intro_title": "{company} AI 에이전트 데모",
+        "intro_text": "환영합니다. 본 시연에서는 {company}를 위해 Gemini Enterprise를 기반으로 구축된 자율 AI 에이전트인 {role}을(를) 소개합니다.",
+        "agenda_title": "데모 시나리오 개요",
+        "agenda_text_full": "오늘 데모에서는 기업 운영을 위한 {num_prompts}가지 핵심 워크플로를 다룹니다. 상황 브리핑, 카탈로그 검색, 이상치 탐지, 즉각적인 조치 승인, 근본 원인 분석, 시뮬레이션 및 일일 인수인계 과정을 순서대로 보여드립니다.",
+        "agenda_text_short": "오늘 데모에서는 기업 운영을 위한 {num_prompts}가지 핵심 워크플로를 다룹니다. 상황 브리핑, 카탈로그 검색, 이상치 탐지, 즉각적인 조치 승인 및 일일 인수인계 과정을 순서대로 보여드립니다.",
+        "scene_title": "장면 {s_num}: 데모 시나리오 {s_num}",
+        "scene_lead": "이제 데모 시나리오 {s_num}을(를) 진행하겠습니다.",
+        "scene_think": "에이전트가 기반 기업 데이터 스토어를 쿼리하고 필요한 워크플로 조치를 도출합니다.",
+        "scene_resp": "구조화된 결과가 나타나면 에이전트는 다양한 출처의 지표를 명확한 권장 사항으로 통합합니다. 이는 엔터프라이즈 데이터 거버넌스를 유지하면서 복잡한 운영 워크플로를 가속화합니다.",
+        "outro_title": "결론",
+        "outro_text": "Gemini Enterprise는 {company}가 수동 검토 작업을 원활한 자율 운영으로 혁신할 수 있도록 지원합니다. 감사합니다."
+    },
+    "zh": {
+        "intro_title": "{company} AI 智能体演示",
+        "intro_text": "欢迎观看本次演示，了解我们为 {company} 打造的基于 Gemini Enterprise 的自主 AI 智能体 {role}。",
+        "agenda_title": "演示议程",
+        "agenda_text_full": "今天的演示将涵盖企业运营的 {num_prompts} 个核心工作流。我们将依次展示情况简报、目录查询、异常检测、即时操作审批、根本原因分析、模拟预测以及日常交接。",
+        "agenda_text_short": "今天的演示将涵盖企业运营的 {num_prompts} 个核心工作流。我们将依次展示情况简报、目录查询、异常检测、即时操作审批以及日常交接。",
+        "scene_title": "场景 {s_num}：演示场景 {s_num}",
+        "scene_lead": "现在，让我们进入演示场景 {s_num}。",
+        "scene_think": "智能体正在查询企业级底层数据存储，并综合出所需的工作流操作。",
+        "scene_resp": "随着结构化结果的显示，智能体会将多源指标整合为明确的建议。这在保持企业数据治理的同时，加速了复杂的运营工作流。",
+        "outro_title": "总结",
+        "outro_text": "Gemini Enterprise 赋能 {company}，帮助将人工审核转化为无缝的自动化运营。感谢您的观看。"
+    },
+    # Traditional Chinese. Keyed by full locale, not by base language: zh-TW and
+    # zh-HK resolve to Traditional-script voices, and pairing those with the
+    # Simplified copy above would put the wrong script on screen in the subtitles.
+    "zh-TW": {
+        "intro_title": "{company} AI 智慧代理程式展示",
+        "intro_text": "歡迎觀看本次展示，了解我們為 {company} 打造、以 Gemini Enterprise 為基礎的自主 AI 代理程式 {role}。",
+        "agenda_title": "展示議程",
+        "agenda_text_full": "今天的展示將涵蓋企業營運的 {num_prompts} 項核心工作流程。我們將依序展示情境簡報、目錄查詢、異常偵測、即時作業核准、根本原因分析、模擬預測以及每日交接。",
+        "agenda_text_short": "今天的展示將涵蓋企業營運的 {num_prompts} 項核心工作流程。我們將依序展示情境簡報、目錄查詢、異常偵測、即時作業核准以及每日交接。",
+        "scene_title": "場景 {s_num}：展示情境 {s_num}",
+        "scene_lead": "現在，讓我們進入展示情境 {s_num}。",
+        "scene_think": "代理程式正在查詢企業底層資料儲存區，並彙整出所需的工作流程動作。",
+        "scene_resp": "隨著結構化結果顯示，代理程式會將多來源指標整合為明確的建議。這在維持企業資料治理的同時，加速了複雜的營運流程。",
+        "outro_title": "總結",
+        "outro_text": "Gemini Enterprise 助力 {company}，將人工審查轉化為順暢的自主營運。感謝您的觀看。"
+    },
+    "pt": {
+        "intro_title": "Demonstração do Agente de IA para a {company}",
+        "intro_text": "Bem-vindos a esta demonstração do {role}, um agente de IA autônomo desenvolvido na plataforma Gemini Enterprise para a {company}.",
+        "agenda_title": "Agenda da Demonstração",
+        "agenda_text_full": "A demonstração de hoje aborda {num_prompts} fluxos operacionais centrais. Exploraremos: análise de situação, pesquisa de catálogo, detecção de anomalias, aprovação de ações imediatas, análise de causa raiz, simulação e o repasse diário.",
+        "agenda_text_short": "A demonstração de hoje aborda {num_prompts} fluxos operacionais centrais. Exploraremos: análise de situação, pesquisa de catálogo, detecção de anomalias, aprovação de ações imediatas e o repasse diário.",
+        "scene_title": "Cena {s_num}: Cenário de Demonstração {s_num}",
+        "scene_lead": "A seguir, avançaremos para o cenário de demonstração {s_num}.",
+        "scene_think": "O agente consulta os bancos de dados corporativos e organiza as ações requisitadas para o fluxo de trabalho.",
+        "scene_resp": "Conforme os resultados aparecem na tela, o agente consolida métricas de múltiplas fontes em recomendações claras. Isso acelera fluxos complexos, preservando a governança dos dados da empresa.",
+        "outro_title": "Conclusão",
+        "outro_text": "A plataforma Gemini Enterprise capacita a {company} na transformação de processos manuais em operações autônomas contínuas. Agradecemos a atenção."
+    },
+    "nl": {
+        "intro_title": "{company} AI-Agent Demo",
+        "intro_text": "Welkom bij deze demonstratie van {role}, een autonome AI-agent gebouwd op Gemini Enterprise voor {company}.",
+        "agenda_title": "Agenda van de Demonstratie",
+        "agenda_text_full": "Onze demonstratie van vandaag omvat {num_prompts} kernworkflows voor ondernemingsactiviteiten. We zullen kijken naar situatie-briefings, catalogusontdekkingen, anomaliedetecties, directe goedkeuringen van acties, oorzakenanalyses, simulaties en de dagelijkse overdracht.",
+        "agenda_text_short": "Onze demonstratie van vandaag omvat {num_prompts} kernworkflows voor ondernemingsactiviteiten. We zullen kijken naar situatie-briefings, catalogusontdekkingen, anomaliedetecties, directe goedkeuringen van acties en de dagelijkse overdracht.",
+        "scene_title": "Scène {s_num}: Demonstratiescenario {s_num}",
+        "scene_lead": "Laten we nu verdergaan met demonstratiescenario {s_num}.",
+        "scene_think": "De agent bevraagt de onderliggende datastores van de onderneming en synthetiseert de vereiste workflowacties.",
+        "scene_resp": "Zodra de gestructureerde resultaten verschijnen, consolideert de agent meetgegevens uit meerdere bronnen in heldere aanbevelingen. Dit versnelt complexe operationele workflows met behoud van datagovernance.",
+        "outro_title": "Conclusie",
+        "outro_text": "Gemini Enterprise stelt {company} in staat om handmatige reviews om te zetten in naadloos autonome operaties. Hartelijk dank."
+    },
+    "hi": {
+        "intro_title": "{company} एआई एजेंट डेमो",
+        "intro_text": "जेमिनी एंटरप्राइज़ पर {company} के लिए निर्मित एक स्वायत्त एआई एजेंट, {role}, के इस प्रदर्शन में आपका स्वागत है।",
+        "agenda_title": "प्रदर्शन कार्यसूची",
+        "agenda_text_full": "आज के प्रदर्शन में उद्यम संचालन के लिए {num_prompts} प्रमुख कार्यप्रवाह शामिल हैं। हम स्थिति ब्रीफिंग, कैटलॉग खोज, विसंगति का पता लगाने, तत्काल कार्रवाई की मंजूरी, मूल कारण विश्लेषण, सिमुलेशन, और दैनिक हैंडओवर (हस्तांतरण) की प्रक्रिया देखेंगे।",
+        "agenda_text_short": "आज के प्रदर्शन में उद्यम संचालन के लिए {num_prompts} प्रमुख कार्यप्रवाह शामिल हैं। हम स्थिति ब्रीफिंग, कैटलॉग खोज, विसंगति का पता लगाने, तत्काल कार्रवाई की मंजूरी और दैनिक हैंडओवर (हस्तांतरण) की प्रक्रिया देखेंगे।",
+        "scene_title": "दृश्य {s_num}: प्रदर्शन परिदृश्य {s_num}",
+        "scene_lead": "अब, हम प्रदर्शन परिदृश्य {s_num} की ओर बढ़ते हैं।",
+        "scene_think": "एजेंट उद्यम के डेटा स्रोतों में क्वेरी करता है और आवश्यक कार्यप्रवाह को निष्पादित करता है।",
+        "scene_resp": "जैसे ही संरचित परिणाम सामने आते हैं, एजेंट कई स्रोतों से प्राप्त मेट्रिक्स को स्पष्ट सुझावों में समेकित करता है। इससे डेटा गवर्नेंस को बनाए रखते हुए जटिल उद्यम कार्यप्रवाह में तेज़ी आती है।",
+        "outro_title": "निष्कर्ष",
+        "outro_text": "जेमिनी एंटरप्राइज़ {company} को मैन्युअल प्रक्रियाओं को सहज और स्वायत्त संचालन में बदलने का अधिकार देता है। धन्यवाद।"
+    },
+    "ar": {
+        "intro_title": "عرض وكيل الذكاء الاصطناعي لشركة {company}",
+        "intro_text": "مرحباً بكم في هذا العرض التوضيحي لـ {role}، وهو وكيل ذكاء اصطناعي مستقل مبني على جيميناي إنتربرايز لشركة {company}.",
+        "agenda_title": "جدول العرض التوضيحي",
+        "agenda_text_full": "يغطي العرض التوضيحي اليوم {num_prompts} من مسارات العمل التشغيلية الأساسية. سنتطرق إلى ملخص الحالة، واستكشاف الكتالوج، واكتشاف الحالات الشاذة، والموافقات الفورية على الإجراءات، وتحليل الأسباب الجذرية، والمحاكاة، بالإضافة إلى التسليم اليومي.",
+        "agenda_text_short": "يغطي العرض التوضيحي اليوم {num_prompts} من مسارات العمل التشغيلية الأساسية. سنتطرق إلى ملخص الحالة، واستكشاف الكتالوج، واكتشاف الحالات الشاذة، والموافقات الفورية على الإجراءات، بالإضافة إلى التسليم اليومي.",
+        "scene_title": "المشهد {s_num}: سيناريو العرض {s_num}",
+        "scene_lead": "الآن، دعونا ننتقل إلى سيناريو العرض {s_num}.",
+        "scene_think": "يقوم الوكيل بالاستعلام عن قواعد البيانات الخاصة بالمؤسسة ويقوم بتجميع الإجراءات المطلوبة لمسار العمل.",
+        "scene_resp": "بمجرد ظهور النتائج المنظمة، يقوم الوكيل بتوحيد المقاييس من مصادر متعددة في توصيات واضحة. مما يسرع العمليات التشغيلية المعقدة مع الحفاظ على حوكمة البيانات.",
+        "outro_title": "الخاتمة",
+        "outro_text": "تعمل جيميناي إنتربرايز على تمكين {company} من تحويل المراجعات اليدوية إلى عمليات مستقلة وسلسة. شكرًا لكم."
+    },
+    "th": {
+        "intro_title": "การสาธิต AI Agent ของ {company}",
+        "intro_text": "ยินดีต้อนรับสู่การสาธิต {role} ซึ่งเป็นตัวแทน AI อัตโนมัติที่พัฒนาบนแพลตฟอร์ม Gemini Enterprise สำหรับ {company}",
+        "agenda_title": "หัวข้อการสาธิต",
+        "agenda_text_full": "การสาธิตในวันนี้ครอบคลุมกระบวนการทำงานหลัก {num_prompts} ประการสำหรับการดำเนินธุรกิจ เราจะพิจารณาสรุปสถานการณ์, การสำรวจแค็ตตาล็อก, การตรวจจับความผิดปกติ, การอนุมัติการดำเนินการทันที, การวิเคราะห์สาเหตุที่แท้จริง, การจำลองสถานการณ์ และการส่งมอบงานประจำวัน",
+        "agenda_text_short": "การสาธิตในวันนี้ครอบคลุมกระบวนการทำงานหลัก {num_prompts} ประการสำหรับการดำเนินธุรกิจ เราจะพิจารณาสรุปสถานการณ์, การสำรวจแค็ตตาล็อก, การตรวจจับความผิดปกติ, การอนุมัติการดำเนินการทันที และการส่งมอบงานประจำวัน",
+        "scene_title": "ฉากที่ {s_num}: สถานการณ์จำลองที่ {s_num}",
+        "scene_lead": "ตอนนี้ เรามารับชมสถานการณ์จำลองที่ {s_num} กันเลย",
+        "scene_think": "ระบบ AI กำลังสืบค้นโครงสร้างข้อมูลพื้นฐานขององค์กรและวิเคราะห์การทำงานที่จำเป็นตามกระบวนการ",
+        "scene_resp": "เมื่อผลลัพธ์ที่เป็นโครงสร้างปรากฏขึ้น ระบบ AI จะรวบรวมข้อมูลจากหลายแหล่งให้เป็นข้อเสนอแนะที่ชัดเจน ซึ่งช่วยเร่งกระบวนการทำงานที่ซับซ้อนไปพร้อมกับการรักษาธรรมมาภิบาลของข้อมูลองค์กร",
+        "outro_title": "บทสรุป",
+        "outro_text": "Gemini Enterprise ช่วยให้ {company} สามารถเปลี่ยนกระบวนการตรวจสอบโดยมนุษย์ไปสู่ระบบการทำงานอัตโนมัติที่ไร้รอยต่อ ขอบคุณที่รับชม"
+    }
+}
 
-    agenda_text_ja = (
-        f"本日のデモでは、製造オペレーションを変革する全{num_prompts}つの重要ワークフローをご紹介します。"
-        f"初期対話からデータ分析、即時承認、根本原因究明、生産シミュレーション、日次サマリーまで順を追って実演します。"
-        if num_prompts >= 7 else
-        f"本日のデモでは、主要な全{num_prompts}つの重要ワークフローをご紹介します。"
-        f"初期対話からデータ分析、即時承認、そして日次サマリーまで順を追って実演します。"
-    )
-    agenda_text_en = (
-        f"Today's demonstration covers {num_prompts} core operational workflows for enterprise operations. "
-        f"We will walk through situational briefing, catalog discovery, anomaly detection, immediate action approval, root cause analysis, simulation, and daily handover."
-        if num_prompts >= 7 else
-        f"Today's demonstration covers {num_prompts} core operational workflows. "
-        f"We will walk through situational briefing, catalog discovery, anomaly detection, immediate action approval, and daily handover."
-    )
-
-    scenes = [
-        {
-            "scene_id": "intro",
-            "title": f"{company} AI エージェント デモ" if is_ja else f"{company} AI Agent Demo",
-            "text": f"本日は、{company}のために開発されたGemini Enterpriseの自律型エージェント「{role}」の実演をご紹介します。" if is_ja else f"Welcome to this demonstration of {role}, an autonomous AI agent built on Gemini Enterprise for {company}."
-        },
-        {
-            "scene_id": "agenda",
-            "title": "実演デモシナリオ一覧" if is_ja else "Walkthrough Agenda",
-            "text": agenda_text_ja if is_ja else agenda_text_en
-        }
-    ]
-
-    # Pre-crafted high-fidelity narrations for the 7 core enterprise scenarios (Lead-in, Thinking, Response & Business Impact)
-    script_templates_ja = {
+script_templates_ja = {
         1: (
             "Scene 1: 初期対話と状況把握",
             "それでは、プラントの初期対話と状況把握の実演を行います。",
@@ -406,7 +571,7 @@ def build_narration_script(company: str, role: str, lang: str, prompts: list = N
         ),
     }
 
-    script_templates_en = {
+script_templates_en = {
         1: (
             "Scene 1: Welcome & Situational Briefing",
             "Now, let's begin with our situational operational briefing by querying current assembly alerts.",
@@ -451,25 +616,93 @@ def build_narration_script(company: str, role: str, lang: str, prompts: list = N
         ),
     }
 
+def _narration_pack(lang: str, company: str, role: str, num_prompts: int) -> dict:
+    parts = lang.split("-")
+    base_lang = parts[0].lower()
+    region = parts[1].upper() if len(parts) > 1 else ""
+
+    # 1. Map known fallbacks for regional dialects if they weren't explicitly defined
+    if base_lang == "cmn":
+        base_lang = "zh"
+    elif base_lang == "yue":
+        # Cantonese is written in Traditional script.
+        base_lang = "zh"
+        region = region or "HK"
+
+    # 2. Select language pack. A full locale wins over its base language, because
+    #    some regions differ in script rather than only in accent: zh-TW and zh-HK
+    #    are read by Traditional-script voices, so Simplified copy would put the
+    #    wrong characters in the subtitles.
+    full_locale = "%s-%s" % (base_lang, region) if region else ""
+    if full_locale and full_locale in NARRATION_STRINGS:
+        pack = NARRATION_STRINGS[full_locale]
+    elif base_lang == "zh" and region in ("TW", "HK", "MO"):
+        pack = NARRATION_STRINGS["zh-TW"]
+    elif base_lang in NARRATION_STRINGS:
+        pack = NARRATION_STRINGS[base_lang]
+    else:
+        pack = NARRATION_STRINGS["en"]
+        print(f"Note: Narration language '{base_lang}' not fully defined. Falling back to English.", file=sys.stderr)
+
+    # 3. Choose agenda text based on num_prompts
+    agenda_key = "agenda_text_full" if num_prompts >= 7 else "agenda_text_short"
+    
+    # 4. Resolve templates for per-scene narratives
+    scene_templates = {}
+    if base_lang == "ja":
+        scene_templates = script_templates_ja
+    elif base_lang == "en":
+        scene_templates = script_templates_en
+    # Fallback uses empty dictionary, meaning the scene loop will use the default properties in `pack`
+
+    return {
+        "intro_title": pack["intro_title"].format(company=company, role=role),
+        "intro_text": pack["intro_text"].format(company=company, role=role),
+        "agenda_title": pack["agenda_title"],
+        "agenda_text": pack[agenda_key].format(num_prompts=num_prompts),
+        "scene_fallback": {
+            "title": pack["scene_title"],
+            "lead_text": pack["scene_lead"],
+            "think_text": pack["scene_think"],
+            "resp_text": pack["scene_resp"],
+        },
+        "outro_title": pack["outro_title"],
+        "outro_text": pack["outro_text"].format(company=company, role=role),
+        "scene_templates": scene_templates
+    }
+
+
+def build_narration_script(company: str, role: str, lang: str, prompts: list = None) -> list:
+    """Returns structured narration lines for demo scenes."""
+    num_prompts = len(prompts) if prompts else 7
+    pack = _narration_pack(lang, company, role, num_prompts)
+
+    scenes = [
+        {
+            "scene_id": "intro",
+            "title": pack["intro_title"],
+            "text": pack["intro_text"]
+        },
+        {
+            "scene_id": "agenda",
+            "title": pack["agenda_title"],
+            "text": pack["agenda_text"]
+        }
+    ]
+
     prompts_to_iterate = prompts if prompts else [f"Prompt {i}" for i in range(1, 8)]
     for idx, p in enumerate(prompts_to_iterate):
         s_num = idx + 1
-        if is_ja:
-            if s_num in script_templates_ja:
-                title, lead_text, think_text, resp_text = script_templates_ja[s_num]
-            else:
-                title = f"Scene {s_num}: デモシナリオ {s_num}"
-                lead_text = f"それでは、続いてのデモシナリオの実演に移ります。"
-                think_text = f"エージェントが基幹データソースを照会し、要求されたワークフローを自律的に推論しています。"
-                resp_text = f"画面に構造化された分析結果が表示され、多角的な知見が整理されます。これにより、高度なエンタープライズ業務を迅速かつ確実に遂行できます。"
+        
+        # Use full pre-crafted templates if available for this specific scene, else format the fallbacks
+        if s_num in pack["scene_templates"]:
+            title, lead_text, think_text, resp_text = pack["scene_templates"][s_num]
         else:
-            if s_num in script_templates_en:
-                title, lead_text, think_text, resp_text = script_templates_en[s_num]
-            else:
-                title = f"Scene {s_num}: Demonstration Scenario {s_num}"
-                lead_text = f"Now, let's proceed to demonstration scenario {s_num}."
-                think_text = f"The agent queries underlying enterprise data stores and synthesizes the required workflow actions."
-                resp_text = f"As the structured results appear, the agent consolidates multi-source metrics into clear recommendations. This accelerates complex operational workflows while maintaining enterprise data governance."
+            fb = pack["scene_fallback"]
+            title = fb["title"].format(s_num=s_num)
+            lead_text = fb["lead_text"].format(s_num=s_num)
+            think_text = fb["think_text"].format(s_num=s_num)
+            resp_text = fb["resp_text"].format(s_num=s_num)
 
         scenes.append({
             "scene_id": f"prompt_{s_num}",
@@ -482,12 +715,10 @@ def build_narration_script(company: str, role: str, lang: str, prompts: list = N
 
     scenes.append({
         "scene_id": "outro",
-        "title": "まとめ" if is_ja else "Conclusion",
-        "text": f"このように、{company}の業務オペレーションをGemini Enterpriseが強力に加速します。ご清聴ありがとうございました。" if is_ja else f"Gemini Enterprise empowers {company} to transform manual reviews into seamless autonomous operations. Thank you."
+        "title": pack["outro_title"],
+        "text": pack["outro_text"]
     })
     return scenes
-
-
 def synthesize_all(args) -> dict:
     """Synthesizes audio tracks and subtitle manifests for all scenes."""
     os.makedirs(args.outdir, exist_ok=True)

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py
@@ -15,12 +15,20 @@
 
 """Google Drive Uploader for GE Demo Highlight Reel Videos.
 
-Uploads the rendered demo video into the execution environment's Google Drive folder.
-Prioritizes the host execution environment's Google account rather than the demo deployment
-tenant, ensuring deliverables are saved to the operator's personal/corp Drive.
+Uploads the rendered demo video into the Google Drive that already holds the rest
+of the demo. The delivery account is resolved by `detect_host_drive_account`, which
+prefers the Drive the demo's own external sample files went to and then the active
+`gcloud` account, so the video does not land in a different Drive than the PDFs and
+spreadsheets it is a video *of*. See that function for the full precedence and for
+why the host login is no longer consulted first.
+
 Supports native `gdrive` CLI (when available) and Google Drive v3 REST API
 with `gcloud auth print-access-token --account=<target_account>`.
 Defaults to owner-only private permissions (no public link sharing).
+
+Delivery is reported twice, on purpose: a human-readable summary on stdout, and a
+machine-readable `delivery_report.json` plus a distinct process exit code, because
+the caller has no other way to tell a Drive upload apart from a silent fallback.
 """
 
 import argparse
@@ -32,6 +40,7 @@ import re
 import shutil
 import subprocess
 import sys
+import threading
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -40,29 +49,156 @@ DRIVE_API = "https://www.googleapis.com/drive/v3"
 DRIVE_UPLOAD_API = "https://www.googleapis.com/upload/drive/v3"
 GDRIVE_BIN = "/google/bin/releases/gemini-agents-gdrive/gdrive"
 
+# Written by generate_and_upload_external_files.py next to the demo's sample
+# documents. It records which account owns the demo's Drive folder.
+DEMO_DRIVE_SUMMARY_NAME = "drive_upload_summary.json"
+
+# Upper bound on any interactive question this script asks. See prompt_yes_no.
+PROMPT_TIMEOUT_SEC = 120
+
+# Process exit codes. The caller distinguishes "delivered" from "the operator has
+# to do something" without parsing stdout.
+EXIT_OK = 0
+EXIT_FAILED = 1
+EXIT_ACTION_REQUIRED = 3
+
+# Machine-readable outcome, written next to the local deliverable.
+DELIVERY_REPORT_NAME = "delivery_report.json"
+
 
 def gdrive_cli_available() -> bool:
     """Checks if internal gdrive CLI is present and executable."""
     return os.path.exists(GDRIVE_BIN) and os.access(GDRIVE_BIN, os.X_OK)
 
 
-def detect_host_drive_account(env: dict = None) -> str:
-    """Dynamically detects the host execution environment's Google account without hardcoding.
+def host_has_local_browser() -> bool:
+    """Reports whether `gcloud auth login` can open a browser on this host.
 
-    Priority:
-    1. Explicit environment variable `DRIVE_ACCOUNT`
-    2. Corporate user account (@google.com) matching local host username / LDAP
-    3. Any corporate user account (@google.com) from `gcloud auth list`
-    4. Active non-service account in `gcloud auth list`
-    5. First non-service account in `gcloud auth list`
-    6. Fallback to active gcloud account or "default"
+    Every other authentication path in this project already makes this
+    distinction - setup_and_deploy.sh, verify_and_heal.py and
+    generate_and_upload_external_files.py all append --no-launch-browser on a
+    headless host. The video delivery path did not, so the single command it
+    printed to a remote tester over SSH was the one form of the command that
+    could not complete there.
     """
-    env = env or {}
-    env_acct = env.get("DRIVE_ACCOUNT") or os.environ.get("DRIVE_ACCOUNT", "")
-    if env_acct:
-        return env_acct.strip()
+    if os.environ.get("SSH_CONNECTION") or os.environ.get("SSH_TTY") or os.environ.get("SSH_CLIENT"):
+        return False
+    if os.environ.get("CLOUD_SHELL", "").strip().lower() in ("1", "true", "yes"):
+        return False
+    if sys.platform.startswith("linux"):
+        return bool(os.environ.get("DISPLAY") or os.environ.get("WAYLAND_DISPLAY"))
+    # macOS and Windows/WSL launch a browser by default.
+    return True
 
-    # Query gcloud credentialed accounts
+
+def drive_login_command(account: str = "") -> list:
+    """Builds the `gcloud auth login` argv that actually works on this host."""
+    target = (account or "").strip()
+    cmd = ["gcloud", "auth", "login"]
+    if target and target != "default":
+        cmd.append(target)
+    cmd.append("--enable-gdrive-access")
+    if not host_has_local_browser():
+        cmd.append("--no-launch-browser")
+    return cmd
+
+
+def drive_login_hint(account: str = "") -> str:
+    """Human-readable form of drive_login_command, with a placeholder if unknown."""
+    target = account.strip() if account and account != "default" else "<ACCOUNT>"
+    return " ".join(drive_login_command(target))
+
+
+def noninteractive_requested() -> bool:
+    """True when the environment has declared that nobody is at the keyboard."""
+    for var in ("GE_NONINTERACTIVE", "CI"):
+        if os.environ.get(var, "").strip().lower() in ("1", "true", "yes"):
+            return True
+    return False
+
+
+def _read_line_with_timeout(prompt: str, timeout_sec: int):
+    """Reads one line, giving up after timeout_sec. Returns None on timeout.
+
+    The read happens on a daemon thread rather than inline so that an
+    unanswered question cannot wedge the process: the thread stays parked on
+    input() but daemon threads do not hold up interpreter exit.
+    """
+    box = {}
+
+    def _reader():
+        try:
+            box["value"] = input(prompt)
+        except Exception:
+            box["value"] = ""
+
+    reader = threading.Thread(target=_reader, daemon=True)
+    reader.start()
+    reader.join(timeout_sec)
+    if reader.is_alive():
+        return None
+    return box.get("value", "")
+
+
+def prompt_yes_no(message: str, timeout_sec: int = PROMPT_TIMEOUT_SEC) -> bool:
+    """Asks a yes/no question that can never hang the pipeline.
+
+    `sys.stdin.isatty()` is not a test for "a human is watching". An agent that
+    runs this script over a pseudo-terminal gets isatty() == True with nobody at
+    the keyboard, and a bare input() there blocks forever - taking the entire
+    video pipeline down with it, because the caller runs this as a subprocess.
+    check_noninteractive_setup.py enforces exactly this rule for the generated
+    setup shell ("every prompt reachable without a terminal has to have a way
+    out"); this is the same rule, applied to the delivery step.
+    """
+    if noninteractive_requested():
+        print(f"   (non-interactive mode: declining '{message.strip()}')", file=sys.stderr)
+        return False
+    if not sys.stdin.isatty():
+        return False
+    answer = _read_line_with_timeout(message, timeout_sec)
+    if answer is None:
+        print(f"\n   (no answer within {timeout_sec}s - continuing without re-authentication)",
+              file=sys.stderr)
+        return False
+    return answer.strip().lower() in ("", "y", "yes")
+
+
+def find_demo_drive_summary(start_dir: str = "") -> dict:
+    """Loads the Drive summary the demo's own external-file upload left behind.
+
+    generate_and_upload_external_files.py writes drive_upload_summary.json into
+    its output directory, recording `owner_account` - the account that actually
+    owns the demo's Drive folder. Reading it is what keeps the video in the same
+    Drive as the documents the demo is built around.
+    """
+    candidates = []
+    explicit = os.environ.get("GE_DRIVE_SUMMARY", "").strip()
+    if explicit:
+        candidates.append(explicit)
+    roots = []
+    for root in (start_dir, os.getcwd()):
+        if root and root not in roots:
+            roots.append(root)
+    for root in roots:
+        candidates.append(os.path.join(root, DEMO_DRIVE_SUMMARY_NAME))
+        candidates.append(os.path.join(root, "external_files", DEMO_DRIVE_SUMMARY_NAME))
+        candidates.append(os.path.join(root, "output", "external_files", DEMO_DRIVE_SUMMARY_NAME))
+    for path in candidates:
+        try:
+            if path and os.path.isfile(path):
+                with open(path, "r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                if isinstance(data, dict):
+                    data["_summary_path"] = path
+                    return data
+        except Exception:
+            continue
+    return {}
+
+
+def credentialed_accounts() -> tuple:
+    """Returns (non_service_accounts, active_account) from `gcloud auth list`."""
     accounts = []
     active_acct = ""
     try:
@@ -84,33 +220,80 @@ def detect_host_drive_account(env: dict = None) -> str:
             accounts.append(acct)
     except Exception:
         pass
+    return accounts, active_acct
 
+
+def resolve_drive_account(env: dict = None, start_dir: str = "") -> tuple:
+    """Resolves the Google account the demo video should be delivered to.
+
+    Returns:
+        tuple[str, str]: (account, reason) where reason names the rule that fired.
+
+    Priority:
+    1. Explicit `DRIVE_ACCOUNT` (from .env or the process environment)
+    2. `owner_account` from the demo's own drive_upload_summary.json, when that
+       account still holds a credential on this host
+    3. The active `gcloud` account - the account that owns the demo project
+    4. An account whose local part matches the host login
+    5. Any other credentialed non-service account
+    6. The active account, or "default"
+
+    Why 2 and 3 now outrank 4. The video belongs in the same Drive as the rest of
+    the demo: generate_and_upload_external_files.py uploads the sample PDFs,
+    spreadsheets and scans using the *active* account, and the generator skill
+    states that contract outright ("the owner is ${GCP_ACCOUNT} - the same
+    account, because the upload uses this token").
+
+    Ranking the host login first broke that contract on the most ordinary setup
+    there is: an operator whose workstation login differs from the account that
+    owns the demo project. The sample documents went to the demo tenant's Drive
+    and the video went to the operator's own, so one demo ended up split across
+    two Drives. Worse, the account picked by the host-login rule is typically the
+    one behind a corporate single-sign-on policy that forces periodic
+    re-authentication, so the old order chose the account most likely to hand
+    back an expired refresh token - which is exactly how this surfaced in the
+    field, as a video that silently fell through to Cloud Storage.
+    """
+    env = env or {}
+    env_acct = env.get("DRIVE_ACCOUNT") or os.environ.get("DRIVE_ACCOUNT", "")
+    if env_acct:
+        return env_acct.strip(), "explicit DRIVE_ACCOUNT override"
+
+    accounts, active_acct = credentialed_accounts()
+    known = {a.lower(): a for a in accounts}
+
+    # Priority 2: the Drive the demo's own external files already went to.
+    summary = find_demo_drive_summary(start_dir)
+    owner = (summary.get("owner_account") or "").strip()
+    if owner and owner.lower() in known:
+        return known[owner.lower()], "owner of the demo's existing Drive folder"
+
+    # Priority 3: the account that owns the demo project.
+    if active_acct:
+        return active_acct, "active gcloud account (demo deployment identity)"
+
+    # Priority 4: an account matching the host login.
     try:
         host_user = getpass.getuser().strip().lower()
     except Exception:
         host_user = ""
-
-    # Priority 2: Account matching host user LDAP
     if host_user:
         for a in accounts:
-            a_lower = a.lower()
-            if a_lower.startswith(host_user + "@") or a_lower == f"{host_user}@google.com":
-                return a
+            if a.lower().startswith(host_user + "@"):
+                return a, "account matching the host login"
 
-    # Priority 3: Any corporate @google.com account
-    corp_accounts = [a for a in accounts if a.lower().endswith("@google.com")]
-    if corp_accounts:
-        return corp_accounts[0]
-
-    # Priority 4: Active gcloud account (if non-service)
-    if active_acct and active_acct in accounts:
-        return active_acct
-
-    # Priority 5: First available non-service account
+    # Priority 5: anything else that is credentialed.
     if accounts:
-        return accounts[0]
+        return accounts[0], "first credentialed non-service account"
 
-    return active_acct or "default"
+    return (active_acct or "default"), "no credentialed account found"
+
+
+def detect_host_drive_account(env: dict = None) -> str:
+    """Account the demo video is delivered to. See resolve_drive_account."""
+    account, _reason = resolve_drive_account(env)
+    return account
+
 
 
 def format_drive_scope_diagnostic_banner(account: str = "") -> str:
@@ -123,9 +306,9 @@ def format_drive_scope_diagnostic_banner(account: str = "") -> str:
         f"   Target Account : {target}",
         "",
         "👉 To grant Google Drive access to gcloud, run:",
-        f"   gcloud auth login {target} --enable-gdrive-access",
+        f"   {drive_login_hint(target)}",
         "",
-        "   (Or configure DRIVE_ACCOUNT=<user@google.com> or pass --drive-account=<account>)",
+        "   (Or configure DRIVE_ACCOUNT=<user@domain> or pass --drive-account=<account>)",
         "=" * 80,
         ""
     ]
@@ -142,7 +325,7 @@ def format_drive_reauth_diagnostic_banner(account: str = "") -> str:
         f"   Target Account : {target}",
         "",
         "👉 To re-authenticate and enable Google Drive access, run:",
-        f"   gcloud auth login {target} --enable-gdrive-access",
+        f"   {drive_login_hint(target)}",
         "",
         "   (Or configure DRIVE_ACCOUNT=<user@domain> or pass --drive-account=<account>)",
         "=" * 80,
@@ -341,13 +524,13 @@ def verify_delivery_destinations(project_id: str = "", drive_account: str = "",
                 return info
             elif test_status == 403:
                 info["tier_1"]["status"] = "scope_insufficient"
-                info["tier_1"]["reason"] = f"HTTP 403 (missing Drive scope; run: gcloud auth login {target_account} --enable-gdrive-access)"
+                info["tier_1"]["reason"] = f"HTTP 403 (missing Drive scope; run: {drive_login_hint(target_account)})"
             else:
                 info["tier_1"]["status"] = "unverified"
                 info["tier_1"]["reason"] = f"HTTP {test_status}"
         elif t1_status == "reauth_required":
             info["tier_1"]["status"] = "reauth_required"
-            info["tier_1"]["reason"] = f"OAuth credentials expired for {target_account} (run: gcloud auth login {target_account} --enable-gdrive-access)"
+            info["tier_1"]["reason"] = f"OAuth credentials expired for {target_account} (run: {drive_login_hint(target_account)})"
         else:
             info["tier_1"]["status"] = "missing_token"
             info["tier_1"]["reason"] = t1_err or "No access token available"
@@ -366,13 +549,13 @@ def verify_delivery_destinations(project_id: str = "", drive_account: str = "",
                 return info
             elif test_status2 == 403:
                 info["tier_2"]["status"] = "scope_insufficient"
-                info["tier_2"]["reason"] = f"HTTP 403 (missing Drive scope; run: gcloud auth login {resolved_deploy} --enable-gdrive-access)"
+                info["tier_2"]["reason"] = f"HTTP 403 (missing Drive scope; run: {drive_login_hint(resolved_deploy)})"
             else:
                 info["tier_2"]["status"] = "unverified"
                 info["tier_2"]["reason"] = f"HTTP {test_status2}"
         elif t2_status == "reauth_required":
             info["tier_2"]["status"] = "reauth_required"
-            info["tier_2"]["reason"] = f"OAuth credentials expired for {resolved_deploy} (run: gcloud auth login {resolved_deploy} --enable-gdrive-access)"
+            info["tier_2"]["reason"] = f"OAuth credentials expired for {resolved_deploy} (run: {drive_login_hint(resolved_deploy)})"
         else:
             info["tier_2"]["status"] = "missing_token"
             info["tier_2"]["reason"] = t2_err or "No access token available"
@@ -632,10 +815,17 @@ def deliver_video(
         print(f"📁 Local deliverable preserved at: {local_dest}")
 
     # Resolve target accounts dynamically without hardcoding
-    target_account = drive_account.strip() or detect_host_drive_account()
+    if drive_account.strip():
+        target_account = drive_account.strip()
+        account_reason = "explicit --drive-account"
+    else:
+        target_account, account_reason = resolve_drive_account()
     target_folder_name = drive_folder.strip() or f"GE Demo - {company}"
     resolved_deploy = deploy_account.strip() or detect_deploy_account()
     resolved_project = project_id.strip() or os.environ.get("GOOGLE_CLOUD_PROJECT") or os.environ.get("PROJECT_ID") or ""
+
+    env_skip = os.environ.get("SKIP_VIDEO_DRIVE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
+    drive_expected = not (skip_drive or env_skip)
 
     result = {
         "local_path": local_dest,
@@ -644,6 +834,12 @@ def deliver_video(
         "folder_name": target_folder_name,
         "file_name": f"{clean_name}.mp4",
         "target_account": target_account,
+        "target_account_reason": account_reason,
+        "deploy_account": resolved_deploy,
+        # Whether a Drive upload was even attempted. Without this, a run that was
+        # told to stay local and a run whose Drive auth collapsed both end up
+        # looking like "no Drive link", and only one of them needs a human.
+        "drive_expected": drive_expected,
         "sharing_mode": "public" if share_public else "owner_private",
         "drive_file_id": "",
         "drive_url": "",
@@ -654,13 +850,13 @@ def deliver_video(
         "upload_status": "pending"
     }
 
-    env_skip = os.environ.get("SKIP_VIDEO_DRIVE_UPLOAD", "").strip().lower() in ("1", "true", "yes")
-    if skip_drive or env_skip:
+    if not drive_expected:
         print("ℹ️ Google Drive upload skipped (SKIP_VIDEO_DRIVE_UPLOAD or --skip-drive). Deliverable preserved locally.")
         result["upload_status"] = "skipped"
         return result
 
     print(f"🎯 Target Google Drive Account (Tier 1): {target_account}")
+    print(f"   ↳ chosen by                          : {account_reason}")
     print(f"📂 Target Folder                       : {target_folder_name}")
     print(f"🔒 Sharing Mode                        : {'Public Link' if share_public else 'Owner-only Private'}")
 
@@ -699,12 +895,11 @@ def deliver_video(
     token, t1_status, t1_err = _fetch_token_and_status(target_account)
     if not token and t1_status == "reauth_required":
         print(format_drive_reauth_diagnostic_banner(target_account), file=sys.stderr)
-        if interactive and sys.stdin.isatty():
+        if interactive:
             try:
-                prompt_msg = f"👉 Credentials expired for '{target_account}'. Run 'gcloud auth login {target_account} --enable-gdrive-access' now? [Y/n]: "
-                resp = input(prompt_msg).strip().lower()
-                if resp in ("", "y", "yes"):
-                    login_cmd = ["gcloud", "auth", "login", target_account, "--enable-gdrive-access"]
+                login_cmd = drive_login_command(target_account)
+                prompt_msg = f"👉 Credentials expired for '{target_account}'. Run '{' '.join(login_cmd)}' now? [Y/n]: "
+                if prompt_yes_no(prompt_msg):
                     subprocess.run(login_cmd, check=True)
                     token, t1_status, _ = _fetch_token_and_status(target_account)
             except Exception as login_err:
@@ -714,12 +909,11 @@ def deliver_video(
         test_info, test_status, _ = drive_request(token, "GET", f"{DRIVE_API}/about?fields=user")
         if test_status == 403:
             print(format_drive_scope_diagnostic_banner(target_account), file=sys.stderr)
-            if interactive and sys.stdin.isatty():
+            if interactive:
                 try:
-                    prompt_msg = f"👉 Would you like to run 'gcloud auth login {target_account} --enable-gdrive-access' now? [Y/n]: "
-                    resp = input(prompt_msg).strip().lower()
-                    if resp in ("", "y", "yes"):
-                        login_cmd = ["gcloud", "auth", "login", target_account, "--enable-gdrive-access"]
+                    login_cmd = drive_login_command(target_account)
+                    prompt_msg = f"👉 Would you like to run '{' '.join(login_cmd)}' now? [Y/n]: "
+                    if prompt_yes_no(prompt_msg):
                         subprocess.run(login_cmd, check=True)
                         token, _, _ = _fetch_token_and_status(target_account)
                         if token:
@@ -825,6 +1019,66 @@ def deliver_video(
         return result
 
 
+def classify_delivery(result: dict) -> tuple:
+    """Grades a delivery result into (exit_code, headline, action).
+
+    The caller of this script is usually generate_demo_video.py, which used to
+    print an unconditional "DELIVERY COMPLETE" banner because a plain
+    subprocess.run() told it nothing. An orchestrating agent read that banner,
+    concluded the video was in Drive, and never offered the recovery step the
+    skill defines - while the operator had no Drive link at all. A delivery has
+    to be gradeable from outside the process, so this is the single place that
+    decides what happened.
+    """
+    status = result.get("upload_status", "")
+    tier = result.get("delivery_tier", "none")
+    expected = result.get("drive_expected", True)
+    account = result.get("target_account", "<account>")
+
+    if status == "skipped":
+        return EXIT_OK, "Local deliverable only (Drive upload was skipped on request)", ""
+
+    if status == "success" and tier in ("tier_1_operator_drive", "tier_2_deploy_drive"):
+        return EXIT_OK, f"Delivered to Google Drive ({account})", ""
+
+    if status == "success" and tier == "tier_3_gcs":
+        if not expected:
+            return EXIT_OK, "Delivered to Cloud Storage", ""
+        # Drive was wanted and Cloud Storage caught the fall. The video exists,
+        # but it is not where the rest of the demo lives, so somebody has to act.
+        return (
+            EXIT_ACTION_REQUIRED,
+            "Delivered to Cloud Storage only - Google Drive was expected and did not accept the upload",
+            f"Re-authenticate and retry: {drive_login_hint(account)}",
+        )
+
+    return (
+        EXIT_FAILED,
+        f"Delivery failed: {result.get('error') or 'no destination accepted the video'}",
+        f"The rendered video is still at {result.get('local_path', '(unknown)')}",
+    )
+
+
+def write_delivery_report(result: dict, report_path: str) -> str:
+    """Writes the machine-readable delivery report. Returns the path written."""
+    exit_code, headline, action = classify_delivery(result)
+    payload = dict(result)
+    payload["exit_code"] = exit_code
+    payload["headline"] = headline
+    payload["action_required"] = action
+    payload["drive_delivered"] = bool(result.get("drive_url"))
+    try:
+        parent = os.path.dirname(os.path.abspath(report_path))
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(report_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, ensure_ascii=False)
+        return report_path
+    except Exception as write_err:
+        print(f"⚠️ Could not write delivery report to {report_path}: {write_err}", file=sys.stderr)
+        return ""
+
+
 def main():
     parser = argparse.ArgumentParser(description="Deliver demo video using 3-tier storage hierarchy.")
     parser.add_argument("--video", required=True, help="Path to rendered MP4 video")
@@ -832,7 +1086,7 @@ def main():
     parser.add_argument("--role", default="Operations Director", help="Agent role")
     parser.add_argument("--suffix", default="", help="Demo suffix if any")
     parser.add_argument("--outdir", default="./deliverables", help="Local directory for deliverables")
-    parser.add_argument("--drive-account", default="", help="Target Google Drive account (defaults to execution environment account)")
+    parser.add_argument("--drive-account", default="", help="Target Google Drive account (defaults to the demo's own Drive owner, then the active gcloud account)")
     parser.add_argument("--drive-folder", default="", help="Google Drive folder name override")
     parser.add_argument("--deploy-account", default="", help="Deploy destination account for Tier 2 Drive delivery")
     parser.add_argument("--gcs-bucket", default="", help="Google Cloud Storage fallback bucket")
@@ -840,6 +1094,7 @@ def main():
     parser.add_argument("--share-public", action="store_true", help="Enable public link sharing (default: False, owner-only private)")
     parser.add_argument("--skip-drive", action="store_true", help="Skip Google Drive upload (save to ./deliverables/ only)")
     parser.add_argument("--interactive", action="store_true", help="Prompt interactively to re-authenticate on expired credentials or scope errors")
+    parser.add_argument("--report", default="", help="Path for the machine-readable delivery report (default: <outdir>/delivery_report.json)")
     args = parser.parse_args()
 
     res = deliver_video(
@@ -857,22 +1112,40 @@ def main():
         gcs_bucket=args.gcs_bucket,
         interactive=args.interactive,
     )
+    report_path = args.report or os.path.join(args.outdir, DELIVERY_REPORT_NAME)
+    written = write_delivery_report(res, report_path)
+    exit_code, headline, action = classify_delivery(res)
+
     print("\n" + "=" * 60)
     print("🎥 Video Delivery Summary")
     print(f"   Local File    : {res['local_path']}")
     print(f"   Delivery Tier : {res.get('delivery_tier', 'N/A')}")
     print(f"   Upload Status : {res.get('upload_status', 'N/A')}")
+    print(f"   Target Account: {res.get('target_account', 'N/A')}")
+    print(f"   Chosen By     : {res.get('target_account_reason', 'N/A')}")
     if res.get("drive_url"):
         print(f"   Drive File    : {res['drive_url']}")
         print(f"   Folder URL    : {res['folder_url']}")
     if res.get("gcs_uri"):
         print(f"   GCS URI       : {res['gcs_uri']}")
         print(f"   Console URL   : {res.get('gcs_console_url', 'N/A')}")
+    if written:
+        print(f"   Report        : {written}")
     if res.get("tier_1_status") == "reauth_required":
         t_acct = res.get("target_account", "<account>")
         print(f"   ⚠️ Tier 1 Notice: OAuth credentials for '{t_acct}' expired.")
-        print(f"   👉 Run to re-authenticate: gcloud auth login {t_acct} --enable-gdrive-access")
+        print(f"   👉 Run to re-authenticate: {drive_login_hint(t_acct)}")
+    print("-" * 60)
+    if exit_code == EXIT_OK:
+        print(f"   ✅ {headline}")
+    elif exit_code == EXIT_ACTION_REQUIRED:
+        print(f"   🚨 ACTION REQUIRED: {headline}")
+    else:
+        print(f"   ❌ {headline}")
+    if action:
+        print(f"   👉 {action}")
     print("=" * 60)
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py
@@ -1027,7 +1027,7 @@ def classify_delivery(result: dict) -> tuple:
     subprocess.run() told it nothing. An orchestrating agent read that banner,
     concluded the video was in Drive, and never offered the recovery step the
     skill defines - while the operator had no Drive link at all. A delivery has
-    to be gradeable from outside the process, so this is the single place that
+    to be verifiable from outside the process, so this is the single place that
     decides what happened.
     """
     status = result.get("upload_status", "")

--- a/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-video/SKILL.md
+++ b/search/gemini-enterprise/ge-demo-generator/skills/ge-demo-video/SKILL.md
@@ -3,10 +3,10 @@ name: ge-demo-video
 description: Records, edits, and delivers automated executive demo videos for agents deployed to Gemini Enterprise. Verifies typography fonts across all languages, connects to live Chrome via CDP (:9222) with automatic display/xvfb adaptation, automatically discovers and applies customer logo & corporate palette (default ON, --no-brand to opt out), enforces strict zero-mock live recording of the deployed agent chat interface, applies modern SaaS video styling in Remotion with dynamic zoom/pan and 4x wait-time acceleration, synthesizes Google Cloud TTS neural narration with synchronized subtitles (pure speech narration, optional ambient BGM), and delivers the rendered MP4 to the demo's Google Drive folder. Also triggered by /ge-demo-video.
 metadata:
   author: Google Cloud Customer Engineering
-  version: 2.1.0
+  version: 2.2.0
 ---
 
-# GE Demo Video Generator Skill (v2.1.0)
+# GE Demo Video Generator Skill (v2.2.0)
 
 Automates the end-to-end production and delivery of professional **90–120s executive highlight reel demo videos** showcasing autonomous AI agents deployed on **Gemini Enterprise**.
 
@@ -105,13 +105,17 @@ Automates the end-to-end production and delivery of professional **90–120s exe
    *If Pre-Flight indicates expired credentials (`reauth_required`), append notice:*
    ```
    ⚠️ Note: Credentials expired for <account>. Run to re-authenticate:
-      gcloud auth login <account> --enable-gdrive-access
+      gcloud auth login <account> --enable-gdrive-access [--no-launch-browser]
    ```
+
+   *The pipeline prints the exact command for this host. On a host with no local
+   browser it appends `--no-launch-browser`; quote it verbatim rather than
+   reconstructing it, because the plain form opens nothing and looks like a hang.*
 
 3. **Mandatory `ask_question` Approval Gate**:
    Execute `ask_question` with the following selectable options.
    *(If `reauth_required` is detected on Tier 1, prioritize the single-click re-authentication action)*:
-   - *(If reauth required)*: `(Recommended) Re-authenticate Google account now (Agent will run 'gcloud auth login <account> --enable-gdrive-access')`
+   - *(If reauth required)*: `(Recommended) Re-authenticate Google account now (Agent will run the re-authentication command the pre-flight printed)`
    - `(Recommended) Approve and proceed with video generation as planned`
    - `Modify demo prompts / Select specific scenarios`
    - `Change language / voice settings (e.g. ja-JP / en-US)`
@@ -158,7 +162,12 @@ The script automatically detects missing typography (Kanji/Kana, Hanzi, Hangul, 
 
 ### Phase 5: Automated Execution & Video Composition
 
-The pipeline executes through `scripts/generate_demo_video.py`:
+The pipeline executes through `scripts/generate_demo_video.py`.
+
+> **Working directory**: run this, and every other command in this skill, from
+> the repository root. Every path here is relative to it, and so are the outputs:
+> `./deliverables/` and `./deliverables/delivery_report.json` are written relative
+> to the working directory, not to the script.
 
 ```bash
 # Standard Production Run
@@ -175,6 +184,10 @@ python3 scripts/generate_demo_video.py \
 # --drive-account    : Overrides destination Google Drive account
 ```
 
+The process exit code is the delivery verdict: `0` delivered, `3` Drive was
+expected and Cloud Storage caught the fall, `1` nothing accepted the video. See
+Phase 6.
+
 Key execution features:
 - **Zero Dead Air**: Voice narration begins immediately at scene start, introducing operational intent during prompt typing.
 - **1.50x Prompt Typing Zoom**: Camera zooms into prompt input field `(960, 920)` with natural human typing jitter.
@@ -186,28 +199,66 @@ Key execution features:
 
 ### Phase 6: Delivery to Google Drive / GCS & Local Staging
 
-1. **3-Tier Fallback Storage Delivery Mechanism**:
+1. **Delivery Account Precedence (Tier 1 / Tier 2 target)**:
+   The video must land in the **same Drive as the rest of the demo** — the PDFs,
+   spreadsheets and scans that `generate_and_upload_external_files.py` already
+   uploaded. The account is resolved in this order:
+   1. Explicit `--drive-account` or `DRIVE_ACCOUNT` (from the environment or `.env`).
+   2. `owner_account` in the demo's `drive_upload_summary.json`, if that account
+      still has credentials on this host. This is the Drive the demo's own files
+      are in.
+   3. The active `gcloud` account — the identity the demo was deployed with.
+   4. An account whose local part matches the host login name.
+   5. Any other credentialed non-service account.
+   6. The active account, or `default`.
+
+   > The host login match used to sit near the top, which sent the video to a
+   > corporate account under forced re-authentication while the demo itself was
+   > in a different tenant's Drive. One demo, two Drives, and a re-authentication
+   > prompt for an account nobody asked for.
+
+2. **3-Tier Fallback Storage Delivery Mechanism**:
    - **Tier 1: Host Operator Drive**:
      Uploaded via `gdrive` CLI using operator user credentials if configured. Saves to folder `GE Demo - <Company>` with owner-only private permissions (or `--share-public` if explicitly requested).
    - **Tier 2: Deploy Account Drive**:
      If Tier 1 is unavailable or unconfigured, falls back to Google Drive API using the deploy user/service account ADC credentials (`gcloud auth application-default print-access-token` / service account key).
    - **Tier 3: Google Cloud Storage (GCS) Fallback**:
      If Drive upload cannot proceed or fails, securely delivers the video to Google Cloud Storage (`gs://<project-id>-ge-demo-artifacts/videos/` or custom `--gcs-bucket`), generating an authenticated or signed URL (`https://storage.cloud.google.com/<bucket>/...`).
-2. **Local Staging Guarantee**:
+3. **Local Staging Guarantee**:
    - The final video is **always staged locally** in `./deliverables/[Demo-Video]_<Company>_-<Role>.mp4` regardless of remote upload status.
-3. **Present Output**:
-   - Display local deliverable path, remote delivery destination (Tier 1 Drive / Tier 2 Drive / Tier 3 GCS), video duration, and resolution (1080p 30fps).
-4. **Automated Post-Generation Interactive Delivery Recovery Gate**:
+4. **Read the delivery verdict — never assume success**:
+   - Delivery writes `./deliverables/delivery_report.json` and exits with a
+     distinct code. The agent **MUST** read one of the two before reporting an
+     outcome:
+
+     | Exit code | `headline` means | Agent action |
+     |---|---|---|
+     | `0` | Delivered to Drive, or Cloud Storage was the intended destination, or the upload was skipped on request | Report the destination URL |
+     | `3` | **Cloud Storage caught the fall — Drive was expected and did not accept the upload** | Fire the recovery gate in step 6 |
+     | `1` | No destination accepted the video | Report the local path and the error |
+
+   - The report carries `delivery_tier`, `target_account`, `target_account_reason`,
+     `drive_url`, `gcs_uri`, `headline` and `action_required`.
+   - Exit code `3` is **not** a success. The video exists, but it is not where the
+     rest of the demo is.
+5. **Present Output**:
+   - Display local deliverable path, remote delivery destination (Tier 1 Drive / Tier 2 Drive / Tier 3 GCS), the account it went to and why, video duration, and resolution (1080p 30fps).
+6. **Automated Post-Generation Interactive Delivery Recovery Gate**:
+   - **Trigger**: delivery exit code `3`, or `delivery_report.json` reporting a
+     non-empty `action_required`, or `tier_1_status: reauth_required`.
    - **Zero Copy-Paste Mandate**: If the video was successfully generated and staged in `./deliverables/[Demo-Video]_<Company>_-<Role>.mp4` but Google Drive delivery failed or was skipped due to expired OAuth credentials (`reauth_required`), the agent **MUST NEVER** ask the user to manually copy and paste bash upload commands.
    - **Interactive Recovery via `ask_question`**: The agent **MUST IMMEDIATELY** invoke `ask_question` offering automated re-authentication and recovery upload:
      - `(Recommended) Authenticate now and upload the generated video to Google Drive`
      - `Keep local deliverable only (and Cloud Storage if uploaded)`
    - **Single-Click Automated Execution**: Upon user selection of the recommended option, the agent automatically executes:
-     1. Re-authentication via `run_command`:
+     1. Re-authentication via `run_command`. Use the command printed by the
+        pipeline verbatim — on a host with no local browser (remote shell, Cloud
+        Shell, no `DISPLAY`) it carries `--no-launch-browser`, and without that
+        flag the command waits on a browser that will never open:
         ```bash
-        gcloud auth login <account> --enable-gdrive-access
+        gcloud auth login <account> --enable-gdrive-access [--no-launch-browser]
         ```
-     2. Standalone Drive delivery via `run_command`:
+     2. Standalone Drive delivery via `run_command`, from the repository root:
         ```bash
         python3 skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py \
           --video "./deliverables/[Demo-Video]_${COMPANY}_-_${ROLE}.mp4" \
@@ -215,6 +266,8 @@ Key execution features:
           --role "${ROLE}" \
           --drive-account "${DRIVE_ACCOUNT}"
         ```
+        Omit `--drive-account` to let the precedence in step 1 pick the Drive the
+        demo already lives in.
      3. Present the confirmed Google Drive file URL and folder URL directly in the chat response.
 
 ---
@@ -248,3 +301,12 @@ Key execution features:
 | `--drive-folder` | `GE Demo - <Company>` | Google Drive folder name override |
 | `--share-public` | `false` | Enable public reader link sharing |
 | `--output` | `./output/demo_video/rendered_demo_video.mp4` | Final MP4 output path |
+
+### Delivery environment variables
+
+| Variable | Effect |
+|---|---|
+| `DRIVE_ACCOUNT` | Highest-precedence delivery account (same as `--drive-account`) |
+| `GE_DRIVE_SUMMARY` | Explicit path to the demo's `drive_upload_summary.json`, when it is not beside the deliverables |
+| `GE_NONINTERACTIVE` / `CI` | Declines every re-authentication prompt instead of waiting for an answer nobody is there to give |
+| `SKIP_VIDEO_DRIVE_UPLOAD` | Skips Drive delivery for the video only (does not affect the demo's other files) |


### PR DESCRIPTION
## Background

A tester in another region ran the demo video skill end to end and the video never reached Google Drive. Two things went wrong, and the second one hid the first:

1. The uploader picked a corporate account whose OAuth refresh token had expired, while the demo's own external files (PDFs, spreadsheets, scans) sat in the Drive of the account she was actually working as. One demo, two Drives, and a re-authentication nobody asked for.
2. The run printed a completion banner anyway, because the orchestrator inferred success from the upload subprocess not crashing rather than from anything the subprocess actually said.

Separately, a demo generated in any locale other than Japanese or English synthesized a correct native voice reading English narration copy.

## Architectural decisions

### ADR-001: the active context wins, not the corporate domain

`resolve_drive_account` used to rank a host-login-name match near the top, which is what sent the video to the expired corporate account. Delivery now resolves in this order, and the first entry that has usable credentials on the host wins:

1. explicit `--drive-account` / `DRIVE_ACCOUNT`
2. `owner_account` in the demo's `drive_upload_summary.json` — the Drive the demo's own files are already in
3. the active `gcloud` account — the identity the demo was deployed with
4. an account whose local part matches the host login name
5. any other credentialed non-service account
6. the active account, or `default`

Binding tier 1 and tier 2 to `drive_upload_summary.json` is what makes the video land beside the rest of the demo rather than in whichever account happened to authenticate first.

### ADR-002: the delivery verdict is data, not an inference

`upload_to_drive.py` writes `./deliverables/delivery_report.json` naming the tier that accepted the file, the account and the resulting URL, and exits with the verdict: `0` delivered, `3` Drive was expected and Cloud Storage caught the fall, `1` nothing accepted the video. `generate_demo_video.py` reads that report rather than guessing, so the closing banner states what actually happened.

Where a prompt would block a run that has no terminal, `GE_NONINTERACTIVE` and `CI` decline it instead of waiting for an answer nobody is there to give, and the re-authentication command the pipeline prints carries `--no-launch-browser` on a host with no local browser — quoting it verbatim matters, because the plain form opens nothing and looks like a hang.

### ADR-003: one locale table, and pacing that matches the writing system

`build_narration_script` pivoted on a single `is_ja` flag. Narration is now a locale-keyed table covering `en, ja, de, fr, es, it, ko, zh, zh-TW, pt, nl, hi, ar, th`, with one explicit fallback to English in the resolver rather than a ternary at every string. `th-TH` voices were advertised by the skill and missing from `VOICE_MAPPING`; they are added. Subtitles now split on question marks in both the Latin (`?`) and fullwidth (`？`) forms, and speech duration is estimated by character count for the writing systems that put no spaces between words — word-count pacing was under-estimating Chinese and Thai and truncating their audio.

Existing Japanese and English narration output is byte-identical to before; this is a refactor plus extension of that copy, not a rewrite of it.

## Note on `.github/actions/spelling/excludes.txt`

The narration table is the only reason this pull request touches a repository-wide config file. Thirteen languages of native copy put 207 words in front of check-spelling, and roughly half of them are not words in any language: the tokenizer splits on the accented characters, so `Übergabe` arrives as `bergabe`, `développé` as `velopp`, and `détection` as `tection`.

`allow.txt` is repository-wide, so allowing those fragments would spell `tection` correctly for every other file in the monorepo and mask a real typo of `detection` wherever it occurs. Excluding the single narration file is what this repository already does for `gemini/sample-apps/image-bash-jam/gemini-explain-image-italian.sh` and `gemini/sample-apps/image-bash-jam/tts.sh`, both of which carry non-English content for the same reason.

## Files

| File | Change |
|---|---|
| `skills/ge-demo-generator/templates/video/scripts/upload_to_drive.py` | account precedence, `delivery_report.json`, exit-code verdict, non-interactive escapes |
| `scripts/generate_demo_video.py` | reads the delivery report instead of inferring success; streams the Remotion render; Node preflight |
| `skills/ge-demo-generator/templates/video/scripts/synthesize_tts.py` | locale narration table, `th-TH` voices, question-mark subtitle splitting, character-count pacing |
| `skills/ge-demo-video/SKILL.md` | delivery precedence, exit codes, working-directory contract, delivery environment variables |
| `skills/ge-demo-generator/SKILL.md`, `templates/scripts/verify_and_heal.py` | skill version banner |
| `.github/actions/spelling/excludes.txt` | one entry, for the reason above |

## Verification

- Offline rehearsal of this repository's CI gates: ShellCheck, shfmt, hadolint, markdownlint, forbidden-pattern scan and the spelling candidate scan all pass over the changed files.
- `python3 -m py_compile` over every changed Python file.
- The upstream-facing skill and template files are byte-identical to the internal tree they were ported from, so no reject was resolved by copying a whole file over this one.